### PR TITLE
Add __repr__() method to HyperParameter classes

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -75,7 +75,8 @@ class Choice(HyperParameter):
                 'You passed: values=%s, default=%s' % (values, default))
 
     def __repr__(self):
-        return f"Choice(name: {self.name!r}, values: {self.values}"
+        return (f'Choice(name: {self.name!r}, values: {self.values},'
+                f' default: {self.default})')
 
     @property
     def default(self):
@@ -116,8 +117,9 @@ class Range(HyperParameter):
         self._values = list(range(min_value, max_value, step))
 
     def __repr__(self):
-        return (f"Range(name: {self.name!r}, min_value: {self.min_value}," +
-                f" max_value: {self.max_value}, step: {self.step})")
+        return (f'Range(name: {self.name!r}, min_value: {self.min_value},'
+                f' max_value: {self.max_value}, step: {self.step},'
+                f' default: {self.default})')
 
     def random_sample(self, seed=None):
         random_state = random.Random(seed)
@@ -158,9 +160,9 @@ class Linear(HyperParameter):
         self.resolution = float(resolution)
 
     def __repr__(self):
-        return (f"Linear(name: {self.name!r}, min_value: {self.min_value}," +
-                f" max_value: {self.max_value}," +
-                f" resolution: {self.resolution})")
+        return (f'Linear(name: {self.name!r}, min_value: {self.min_value},'
+                f' max_value: {self.max_value}, resolution: {self.resolution},'
+                f' default: {self.default})')
 
     @property
     def default(self):
@@ -197,7 +199,7 @@ class Fixed(HyperParameter):
         self.value = value
 
     def __repr__(self):
-        return f"Fixed(name: {self.name!r}, value: {self.value}"
+        return f'Fixed(name: {self.name!r}, value: {self.value})'
 
     def random_sample(self, seed=None):
         return self.value

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -74,6 +74,9 @@ class Choice(HyperParameter):
                 'The default value should be one of the choices. '
                 'You passed: values=%s, default=%s' % (values, default))
 
+    def __repr__(self):
+        return f"Choice(name: {self.name!r}, values: {self.values}"
+
     @property
     def default(self):
         if self._default is None:
@@ -111,6 +114,10 @@ class Range(HyperParameter):
         self.min_value = int(min_value)
         self.step = int(step)
         self._values = list(range(min_value, max_value, step))
+
+    def __repr__(self):
+        return (f"Range(name: {self.name!r}, min_value: {self.min_value}, "
+                + f"max_value: {self.max_value}, step: {self.step})")
 
     def random_sample(self, seed=None):
         random_state = random.Random(seed)
@@ -150,6 +157,11 @@ class Linear(HyperParameter):
         self.min_value = float(min_value)
         self.resolution = float(resolution)
 
+    def __repr__(self):
+        return (f"Linear(name: {self.name!r}, min_value: {self.min_value}, "
+                + f"max_value: {self.max_value}, "
+                + f"resolution: {self.resolution})")
+
     @property
     def default(self):
         if self._default is not None:
@@ -183,6 +195,9 @@ class Fixed(HyperParameter):
     def __init__(self, name, value):
         self.name = name
         self.value = value
+
+    def __repr__(self):
+        return f"Fixed(name: {self.name!r}, value: {self.value}"
 
     def random_sample(self, seed=None):
         return self.value

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -116,8 +116,8 @@ class Range(HyperParameter):
         self._values = list(range(min_value, max_value, step))
 
     def __repr__(self):
-        return (f"Range(name: {self.name!r}, min_value: {self.min_value}, "
-                + f"max_value: {self.max_value}, step: {self.step})")
+        return (f"Range(name: {self.name!r}, min_value: {self.min_value}," +
+                f" max_value: {self.max_value}, step: {self.step})")
 
     def random_sample(self, seed=None):
         random_state = random.Random(seed)
@@ -158,9 +158,9 @@ class Linear(HyperParameter):
         self.resolution = float(resolution)
 
     def __repr__(self):
-        return (f"Linear(name: {self.name!r}, min_value: {self.min_value}, "
-                + f"max_value: {self.max_value}, "
-                + f"resolution: {self.resolution})")
+        return (f"Linear(name: {self.name!r}, min_value: {self.min_value}," +
+                f" max_value: {self.max_value}," +
+                f" resolution: {self.resolution})")
 
     @property
     def default(self):


### PR DESCRIPTION
This PR overwrites the (pointless) default implementation of `__repr__()` for all child classes of `HyperParameter` (namely `Choice`, `Range`, `Linear`, and `Fixed`), mainly to make debugging more comfortable. I've ignored `default` values for brevity but can add those too if desired.