### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ These are ready-to-use hypermodels for computer vision.
 They come pre-compiled with `loss="categorical_crossentropy"` and `metrics=["accuracy"]`.
 
 ```python
-from kerastuner.applications import HyperResnet
+from kerastuner.applications import HyperResNet
 from kerastuner.tuners import Hyperband
 
-hypermodel = HyperResnet(input_shape=(128, 128, 3), num_classes=10)
+hypermodel = HyperResNet(input_shape=(128, 128, 3), num_classes=10)
 
 tuner = Hyperband(
     hypermodel,


### PR DESCRIPTION
This is just changes `HyperResnet` to `HyperResNet` in the readme.