### PR TITLE
Bugfix for search failing on windows machine with CD drive

### DIFF
--- a/kerastuner/abstractions/host.py
+++ b/kerastuner/abstractions/host.py
@@ -188,6 +188,8 @@ class Host():
         """Returns disk usage"""
         partitions = []
         for partition in self.partitions:
+            if partition.opts.upper() in ('CDROM', 'REMOVABLE'):
+              continue
             name = partition.mountpoint
             usage = psutil.disk_usage(name)
             info = {

--- a/kerastuner/abstractions/host.py
+++ b/kerastuner/abstractions/host.py
@@ -188,8 +188,10 @@ class Host():
         """Returns disk usage"""
         partitions = []
         for partition in self.partitions:
-            if partition.opts.upper() in ('CDROM', 'REMOVABLE'):
-              continue
+            if os.name == 'nt':
+                if 'cdrom' in partition.opts or partition.fstype == '':
+                    # skip cd-rom drives on windows machines (will throw error)s
+                    continue
             name = partition.mountpoint
             usage = psutil.disk_usage(name)
             info = {

--- a/kerastuner/abstractions/host.py
+++ b/kerastuner/abstractions/host.py
@@ -190,7 +190,7 @@ class Host():
         for partition in self.partitions:
             if os.name == 'nt':
                 if 'cdrom' in partition.opts or partition.fstype == '':
-                    # skip cd-rom drives on windows machines (will throw error)s
+                    # skip cd-rom drives on windows machines (will throw error)
                     continue
             name = partition.mountpoint
             usage = psutil.disk_usage(name)


### PR DESCRIPTION
See issue #36 

This fix implements the same method to skip cd drives on windows machines as in the psutil disk usage utility.