### PR TITLE
Added flake8 and removed some errors.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,32 @@
+[flake8]
+
+ignore =
+    # defaults flake8 ignores
+    E121,E123,E126,E226,E24,E704,W503,W504
+    # Function name should be lowercase
+    N802
+    # imported but unused
+    F401
+    # class name should use CapWords convention
+    N801
+    # lowercase ... imported as non lowercase
+    N812
+    # do not use bare 'except'
+    E722
+    # trailing whitespace
+    W291
+    # constant ... imported as non constant
+    N811
+    # local variable is assigned to but never used
+    F841
+    # redefinition of unused ...
+    F811
+    # variable ... in function should be lowercase
+    N806
+    # blank line at end of file
+    W391
+    # undefined name
+    F821
+
+
+max-line-length = 85

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ dist/
 bigquery/
 export/
 logs/
-Kerastuner.egg-info/
+Keras_Tuner.egg-info/
 results/
 tmp/
 .ipynb_checkpoints/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
         - python: 3.6
           env: TEST_MODE=INTEGRATION_TESTS
         - python: 3.6
-          env: TEST_MODE=PEP8
+          env: TEST_MODE=FLAKE8
         - python: 3.6
           env: TEST_MODE=TF2
 install:
@@ -38,8 +38,8 @@ install:
 script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
-    elif [[ "$TEST_MODE" == "PEP8" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test kerastuner/ --pep8;
+    elif [[ "$TEST_MODE" == "FLAKE8" ]]; then
+      flake8;
     else
       PYTHONPATH=$PWD:$PYTHONPATH py.test tests/kerastuner --cov-config .coveragerc --cov=kerastuner;
     fi

--- a/kerastuner/abstractions/display.py
+++ b/kerastuner/abstractions/display.py
@@ -24,7 +24,7 @@ from kerastuner import config
 from terminaltables import SingleTable, AsciiTable
 from tabulate import tabulate
 from colorama import init, Fore, Back, Style
-from tensorflow.python.lib.io import file_io  # nopep8 pylint: disable=no-name-in-module
+from tensorflow.python.lib.io import file_io
 
 init()  # colorama init
 

--- a/kerastuner/abstractions/host.py
+++ b/kerastuner/abstractions/host.py
@@ -128,9 +128,8 @@ class Host():
             display_setting('software', idx=1)
             display_settings(status['software'], indent_level=2)
 
-            # ram
-            s = "ram: %s/%s%s" % (status['ram']['used'], status['ram']['total'],  # nopep8
-                                  status['ram']['unit'])
+            ram = status['ram']
+            s = "ram: %s/%s%s" % (ram['used'], ram['total'], ram['unit'])
             display_setting(s, idx=2)
 
             # disk
@@ -243,7 +242,9 @@ class Host():
             # try to find it from system drive with default installation path
             nvidia_smi = spawn.find_executable('nvidia-smi')
             if nvidia_smi is None:
-                nvidia_smi = "%s\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe" % os.environ['systemdrive']  # nopep8
+                nvidia_smi = ("{}\\Program Files\\NVIDIA Corporation"
+                              "\\NVSMI\\nvidia-smi.exe")
+                nvidia_smi.format(os.environ['systemdrive'])
         else:
             nvidia_smi = "nvidia-smi"
         return nvidia_smi

--- a/kerastuner/engine/cloudservice.py
+++ b/kerastuner/engine/cloudservice.py
@@ -92,7 +92,8 @@ class CloudService():
     def __init__(self):
         self.enabled = False
         self.status = "disable"
-        self.base_url = 'https://us-central1-kerastuner-prod.cloudfunctions.net/api/'  # nopep8
+        self.base_url = (
+            'https://us-central1-kerastuner-prod.cloudfunctions.net/api/')
         self.api_key = None
         self.log_interval = 5
         self.last_update = -1

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -475,7 +475,6 @@ class Tuner(object):
             # Dynamic
             'best_metrics': self.best_metrics.get_config(),
             'trials': [t.save() for t in self.trials],
-            'start_time': self.start_time,
             # Extra
             'eta': self.eta,
             'remaining_trials': self.remaining_trials,

--- a/kerastuner/utils.py
+++ b/kerastuner/utils.py
@@ -14,8 +14,8 @@
 
 import gc
 import numpy as np
-from tensorflow.python import Session, ConfigProto  # nopep8 pylint: disable=no-name-in-module
-import tensorflow.keras.backend as K  # pylint: disable=import-error
+from tensorflow.python import Session, ConfigProto
+from tensorflow.python.keras import backend as K
 
 
 def compute_model_size(model):

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,9 +12,3 @@ addopts=-v
 
 # Do not run tests in the build folder
 norecursedirs= build
-
-# Enable line length testing with maximum line length of 85
-pep8maxlinelength = 85
-
-markers =
-    pep8

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     ],
     extras_require={
         'tests': ['pytest',
-                  'pytest-pep8',
+                  'flake8',
                   'pytest-xdist',
                   'pytest-cov'],
     },

--- a/tests/kerastuner/engine/metrics_tracking_test.py
+++ b/tests/kerastuner/engine/metrics_tracking_test.py
@@ -109,7 +109,7 @@ def test_get_last_value():
     tracker.register('new_metric', 'min')
     assert tracker.get_last_value('new_metric') is None
     tracker.set_history('new_metric', [1., 2., 3.])
-    assert tracker.get_last_value('new_metric') is 3.
+    assert tracker.get_last_value('new_metric') == 3.
 
 
 def test_serialization():


### PR DESCRIPTION
I propose that we use flake8 to detect some errors that the pep8 plugin of pytest doesn't detect.
For example, duplicated dictionary keys or the use of `is` instead of `==` to compare ints.

Based on the experience in the keras repo, quite some time was spent fixing simple mistakes. This should ensure that we don't make easily detectable mistakes.

To avoid having a lots of errors to fix at once, I ignored many rules. Some should be enabled again, but in separate PRs to be able to discuss if we really want the rule or not.