### PR TITLE
Add modular import for BayesianOptimization class

### DIFF
--- a/kerastuner/__init__.py
+++ b/kerastuner/__init__.py
@@ -23,7 +23,8 @@ from kerastuner.engine.hyperparameters import HyperParameter
 from kerastuner.engine.hypermodel import HyperModel
 from kerastuner.engine.tuner import Tuner
 from kerastuner.engine.oracle import Oracle
-from kerastuner.tuners import RandomSearch
+from kerastuner.tuners import BayesianOptimization
 from kerastuner.tuners import Hyperband
+from kerastuner.tuners import RandomSearch
 
 __version__ = '0.9.0'

--- a/kerastuner/tuners/__init__.py
+++ b/kerastuner/tuners/__init__.py
@@ -14,5 +14,6 @@
 
 from __future__ import absolute_import
 
-from .randomsearch import RandomSearch
+from .bayesian import BayesianOptimization
 from .hyperband import Hyperband
+from .randomsearch import RandomSearch


### PR DESCRIPTION
#15 apparently forgot to make the new `BayesianOptimization` class importable from both the `kerastuner` as well as the `kerastuner.tuners` modules. This PR simply adds the mentioned imports.