### PR TITLE
Bayesian save before result bug fixed

### DIFF
--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -81,8 +81,8 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
             'num_trials': self._num_trials,
             'score': self._score,
             'values': self._values,
-            'x': self._x.tolist(),
-            'y': self._y.tolist(),
+            'x': self._x.tolist() if isinstance(self._x, np.ndarray) else self._x,
+            'y': self._y.tolist() if isinstance(self._y, np.ndarray) else self._y,
         }
         state_json = json.dumps(state)
         tf_utils.write_file(fname, state_json)

--- a/tests/kerastuner/tuners/bayesian_test.py
+++ b/tests/kerastuner/tuners/bayesian_test.py
@@ -96,3 +96,15 @@ def test_bayesian_optimization_tuner(tmp_dir):
         max_trials=15,
     )
     assert isinstance(tuner.oracle, bo_module.BayesianOptimizationOracle)
+
+
+def test_save_before_result(tmp_dir):
+    hp_list = [hp_module.Choice('a', [1, 2], default=1),
+               hp_module.Range('b', 3, 10, default=3),
+               hp_module.Linear('c', 0, 1, 0.1, default=0),
+               hp_module.Fixed('d', 7),
+               hp_module.Choice('e', [9, 0], default=9)]
+    oracle = bo_module.BayesianOptimizationOracle()
+    oracle.populate_space(str(1), hp_list)
+    oracle.save(os.path.join(tmp_dir, 'temp_oracle'))
+    oracle.result(str(1), 0)


### PR DESCRIPTION
This pull request resolves #44.

It added a unit test to fail for the bug.
Do not do .tolist() for self._x when _x is empty.
The same for self._y.