### PR TITLE
removing compile since already being done at model build

### DIFF
--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -238,7 +238,6 @@ class Tuner(object):
                 hp = hp.copy()
 
             model = self._build_model(hp)
-            self._compile_model(model)
 
             # Start execution
             execution = execution_module.Execution(


### PR DESCRIPTION
I believe _build_model fn already carries out model compilation as the last step https://github.com/keras-team/keras-tuner/blob/master/kerastuner/engine/tuner.py#L612, no need to explicitly model compile in run_trial https://github.com/keras-team/keras-tuner/blob/master/kerastuner/engine/tuner.py#L241