### PR TITLE
Fix bugs for updating from tf 2.0b0 to rc0

### DIFF
--- a/kerastuner/utils.py
+++ b/kerastuner/utils.py
@@ -20,7 +20,7 @@ from tensorflow.python.keras import backend as K
 
 def compute_model_size(model):
     "comput the size of a given model"
-    params = [K.count_params(p) for p in set(model.trainable_weights)]
+    params = [K.count_params(p) for p in model.trainable_weights]
     return int(np.sum(params))
 
 


### PR DESCRIPTION
Updating the dependency of tensorflow from 2.0.0b1 to 2.0.0rc0 is causing crashes in keras-tuner.
Not sure the "set" operation is really useful, but it is causing the crash because it tries to hash a tensor with equality enabled.

```
../../.virtualenvs/ak/lib/python3.6/site-packages/kerastuner/utils.py:23: in compute_model_size
    params = [K.count_params(p) for p in set(model.trainable_weights)]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <tf.Variable 'dense/kernel:0' shape=(32, 32) dtype=float32, numpy=
array([[ 0.03147817, -0.30117437, -0.08552131, ...,...],
       [ 0.23273078, -0.10847142,  0.0151484 , ...,  0.16468436,
        -0.21210298, -0.1087181 ]], dtype=float32)>

    def __hash__(self):
      if ops.Tensor._USE_EQUALITY and ops.executing_eagerly_outside_functions():  # pylint: disable=protected-access
>       raise TypeError("Variable is unhashable if Tensor equality is enabled. "
                        "Instead, use tensor.experimental_ref() as the key.")
E       TypeError: Variable is unhashable if Tensor equality is enabled. Instead, use tensor.experimental_ref() as the key.

../../.virtualenvs/ak/lib/python3.6/site-packages/tensorflow_core/python/ops/variables.py:1085: TypeError
```