### PR TITLE
Fix for running in notebook model: display was not defined

### DIFF
--- a/kerastuner/abstractions/display.py
+++ b/kerastuner/abstractions/display.py
@@ -43,6 +43,7 @@ except NameError:
 if IS_NOTEBOOK:
     from tqdm import tqdm_notebook as tqdm
     from IPython.display import HTML
+    display = HTML
 else:
     from tqdm import tqdm
     display = print
@@ -285,8 +286,9 @@ def cprint(text, color, bg_color=None, brightness='normal'):
 
     # HTMLify if needed
     if IS_NOTEBOOK and isinstance(text, str):
-        text = HTML(text)
-    display(text)
+        HTML(text)
+    else:
+        display(text)
 
 
 def colorize_row(row, color, bg_color=None, brightness='normal'):


### PR DESCRIPTION
When running in notebook mode, I got the NameError below, since display wasn't defined.
It's only defined to be: display = print, for IS_NOTEBOOK=False.

kerastuner/engine/tuner.py in _build_model(self, hp)
    554         self._stats.num_invalid_models += 1
    555         display.warning('Invalid model %s/%s' %
--> 556                         (self._stats.num_invalid_models, self._max_fail_streak))
    557 
    558         if self._stats.num_invalid_models >= self._max_fail_streak:

kerastuner/abstractions/display.py in warning(text, render)
    114   write_log(s)
    115   if render:
--> 116     cprint(s, color)
    117   else:
    118     return colorize(s + '\n', color)

kerastuner/abstractions/display.py in cprint(text, color, bg_color, brightness)
    300   if IS_NOTEBOOK and isinstance(text, str):
    301     text = HTML(text)
--> 302   display(text)
    303 
    304 

NameError: name 'display' is not defined