### PR TITLE
Add ability to merge HP objects

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -621,7 +621,7 @@ class HyperParameters(object):
         return HyperParameters.from_config(self.get_config())
 
     def merge(self, hps, overwrite=True):
-        """Merges `hps` into this object.
+        """Merges hyperparameters into this object.
 
         Arguments:
           hps: A `HyperParameters` object of list of `HyperParameter`

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -626,7 +626,6 @@ class HyperParameters(object):
           overwrite: bool. Whether existing `HyperParameter`s should
             be overridden by those in `hps` with the same name.
         """
-        self._frozen = not overwrite
         if isinstance(hps, HyperParameters):
             hps = hps.space
         for hp in hps:

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -334,3 +334,30 @@ def test_Fixed():
     fixed = hp_module.Fixed.from_config(fixed.get_config())
     assert fixed.default == 'value'
     assert fixed.random_sample() == 'value'
+
+
+def test_merge():
+    hp = hp_module.HyperParameters()
+    hp.Int('a', 0, 100)
+    hp.Fixed('b', 2)
+
+    hp2 = hp_module.HyperParameters()
+    hp2.Fixed('a', 3)
+    hp.Int('c', 10, 100, default=30)
+
+    hp.merge(hp2)
+
+    assert hp.get('a') == 3
+    assert hp.get('b') == 2
+    assert hp.get('c') == 30
+
+    hp3 = hp_module.HyperParameters()
+    hp3.Fixed('a', 5)
+    hp3.Choice('d', [1, 2, 3], default=1)
+
+    hp.merge(hp3, overwrite=False)
+
+    assert hp.get('a') == 3
+    assert hp.get('b') == 2
+    assert hp.get('c') == 30
+    assert hp.get('d') == 1


### PR DESCRIPTION
@fchollet 

From discussion with @sagipe 

This PR adds the ability to `merge` two HP objects, with an option (default `True`) to let values of the same name be overridden

Also, not included in this PR but Sagi pointed out that internal users will mostly define HPs outside of the model code and therefore want to be able to override HPs at any time, i.e.

```python
hp = HyperParameters()
hp.Int('a', 0, 10)
hp.Fixed('a', 3) . # Internal users will think this is respected
```

We could support this by having public `freeze()` and `unfreeze()` methods on the `HyperParameters` object, where `unfreeze()` would allow existing values to be overridden (like the private `self._frozen` in this PR). We could then `freeze()` in the `Tuner` before calling `build_model`.

One thing that might be confusing is, even when frozen in `build_model`, we will want to allow adding *new* HPs, so we may have to think of a different name for this concept.

Also if we decide to make HPs unfrozen (mutable) by default, we will have to think through if there are any unwanted implications for users, including those writing new `Tuner`s and `Oracle`s. For instance, if we freeze in the `Tuner` before `build_model`, then other `Tuner`s will have to do this too
