### PR TITLE
Add test framework for mocking tuning distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ install:
     # install pydot for visualization tests
   - travis_retry conda install -q $MKL pydot graphviz $PIL
 
+    # install portpicker for mock distribution framework.
+  - travis_retry conda install portpicker
+
   - pip install -e .[tests] --progress-bar off
 
 # command to run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 attrs
 cprint
 numpy
-portpicker
 tabulate
 termcolor
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 attrs
 cprint
 numpy
+portpicker
 tabulate
 termcolor
 tqdm

--- a/tests/kerastuner/__init__.py
+++ b/tests/kerastuner/__init__.py
@@ -1,0 +1,1 @@
+"""KerasTuner tests."""

--- a/tests/kerastuner/mock_distribute.py
+++ b/tests/kerastuner/mock_distribute.py
@@ -1,0 +1,53 @@
+# Copyright 2019 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Mock running KerasTuner in a distributed tuning setting."""
+
+import multiprocessing
+import os
+import portpicker
+
+
+def mock_distribute(fn, num_workers=2):
+    """Runs `fn` in multiple processes, setting appropriate env vars."""
+    port = str(portpicker.pick_unused_port())
+
+    def chief_fn():
+        # The port for the chief and workers to communicate on.
+        os.environ['KERASTUNER_PORT'] = port
+        # Run in distributed mode when present. Cloud oracle does not
+        # run in this mode because the Cloud API coordinates workers.
+        os.environ['KERASTUNER_DISTRIBUTED'] = 'True'
+        # The ID of this process. 'chief' should run a server.   
+        os.environ['KERASTUNER_TUNER_ID'] = 'chief'
+        fn()
+    chief_process = multiprocessing.Process(target=chief_fn)
+    chief_process.start()
+
+    worker_processes = []
+    for i in range(num_workers):
+
+        def worker_fn():
+            os.environ['KERASTUNER_PORT'] = port
+            os.environ['KERASTUNER_DISTRIBUTED'] = 'True'
+            # Workers that are part of the same multi-worker
+            # DistributionStrategy should have the smae TUNER_ID.
+            os.environ['KERASTUNER_TUNER_ID'] = 'worker{}'.format(i)
+            fn()
+        worker_process = multiprocessing.Process(target=worker_fn)
+        worker_process.start()
+        worker_processes.append(worker_process)
+
+    for worker_process in worker_processes:
+        worker_process.join()
+    chief_process.terminate()

--- a/tests/kerastuner/mock_distribute_test.py
+++ b/tests/kerastuner/mock_distribute_test.py
@@ -1,0 +1,45 @@
+# Copyright 2019 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test mock running KerasTuner in a distributed tuning setting."""
+
+import os
+import pytest
+import tensorflow as tf
+import time
+from .mock_distribute import mock_distribute
+
+
+@pytest.fixture(scope='module')
+def tmp_dir(tmpdir_factory):
+    return tmpdir_factory.mktemp('integration_test')
+
+
+def test_mock_distribute(tmp_dir):
+    def process_fn():
+        tuner_id = os.environ['KERASTUNER_TUNER_ID']
+        if 'worker' in tuner_id:
+            # Give the chief process time to write its value,
+            # as we do not join on the chief since it will run
+            # a server.
+            time.sleep(2)
+        fname = os.path.join(tmp_dir, tuner_id)
+        with tf.io.gfile.GFile(fname, 'w') as f:
+            f.write(tuner_id)
+
+    mock_distribute(process_fn, num_workers=3)
+
+    for tuner_id in {'chief', 'worker0', 'worker1', 'worker2'}:
+        fname = os.path.join(tmp_dir, tuner_id)
+        with tf.io.gfile.GFile(fname, 'r') as f:
+            assert f.read() == tuner_id


### PR DESCRIPTION
The distribution will rely on 3 environment variables being set:

`KERASTUNER_DISTRIBUTED` -> controls if a service and client are started
`KERASTUNER_TUNER_ID` -> {chief, worker0, worker1, ...}
`KERASTUNER_PORT` -> the port the workers and chief use to communicate

This framework mocks setting those env vars and running the code in different processes