### PR TITLE
Make HyperParameters Proto more useable for generic use cases

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -164,33 +164,18 @@ class Choice(HyperParameter):
 
     @classmethod
     def from_proto(cls, proto):
-        values = getattr(proto, proto.WhichOneof('values')).values
-        default = getattr(proto, proto.WhichOneof('default'), None)
         return cls(
             name=proto.name,
-            values=values,
+            values=proto.values,
             ordered=proto.ordered,
-            default=default)
+            default=proto.default)
 
     def to_proto(self):
-        kwargs = {}
-        if self._type == str:
-            kwargs['string_values'] = kerastuner_pb2.Choice.StringValues(
-                values=self.values)
-            kwargs['string_default'] = self.default
-        elif self._type == int:
-            kwargs['int_values'] = kerastuner_pb2.Choice.IntValues(
-                values=self.values)
-            kwargs['int_default'] = self.default
-        else:
-            kwargs['float_values'] = kerastuner_pb2.Choice.FloatValues(
-                values=self.values)
-            kwargs['float_default'] = self.default
-
         return kerastuner_pb2.Choice(
             name=self.name,
+            values=self.values,
             ordered=self.ordered,
-            **kwargs)
+            default=self.default)
 
 
 class Int(HyperParameter):
@@ -718,13 +703,13 @@ class HyperParameters(object):
         hps = cls()
 
         space = []
-        for float_proto in proto.float_space:
+        for float_proto in proto.space.float_space:
             space.append(Float.from_proto(float_proto))
-        for int_proto in proto.int_space:
+        for int_proto in proto.space.int_space:
             space.append(Int.from_proto(int_proto))
-        for choice_proto in proto.choice_space:
+        for choice_proto in proto.space.choice_space:
             space.append(Choice.from_proto(choice_proto))
-        for boolean_proto in proto.boolean_space:
+        for boolean_proto in proto.space.boolean_space:
             space.append(Boolean.from_proto(boolean_proto))
 
         for hp in space:
@@ -732,14 +717,8 @@ class HyperParameters(object):
                          hp.__class__.__name__,
                          hp.get_config())
 
-        for name, float_val in proto.float_values.items():
-            hps.values[name] = float_val
-        for name, int_val in proto.int_values.items():
-            hps.values[name] = int_val
-        for name, string_val in proto.string_values.items():
-            hps.values[name] = string_val
-        for name, boolean_val in proto.boolean_values.items():
-            hps.values[name] = boolean_val
+        for name, val in proto.values.items():
+            hps.values[name] = val
 
         return hps
 
@@ -778,14 +757,12 @@ class HyperParameters(object):
                     'Unrecognized value type: {}'.format(value))
 
         return kerastuner_pb2.HyperParameters(
-            float_space=float_space,
-            int_space=int_space,
-            choice_space=choice_space,
-            boolean_space=boolean_space,
-            float_values=float_values,
-            int_values=int_values,
-            string_values=string_values,
-            boolean_values=boolean_values)
+            space=kerastuner_pb2.HyperParameters.Space(
+                float_space=float_space,
+                int_space=int_space,
+                choice_space=choice_space,
+                boolean_space=boolean_space),
+            values=self.values)
 
     def _get_name(self, name, scopes=None):
         """Returns a name qualified by `name_scopes`."""

--- a/kerastuner/protos/kerastuner.proto
+++ b/kerastuner/protos/kerastuner.proto
@@ -17,14 +17,21 @@ syntax = "proto3";
 
 package kerastuner;
 
-import "google/protobuf/struct.proto";
-
 
 enum Sampling {
     NONE = 0;
     LINEAR = 1;
     LOG = 2;
     REVERSE_LOG = 3;
+}
+
+message Value {
+    oneof kind {
+        sint64 int_value = 1;
+        double float_value = 2;
+        string string_value = 3;
+        bool boolean_value = 4;
+    }
 }
 
 message Float {
@@ -47,8 +54,8 @@ message Int {
 
 message Choice {
     string name = 1;
-    repeated google.protobuf.Value values = 2;
-    google.protobuf.Value default = 3;
+    repeated Value values = 2;
+    Value default = 3;
     bool ordered = 4;
 }
 
@@ -66,7 +73,7 @@ message HyperParameters {
     }
     Space space = 1;
 
-    map<string, google.protobuf.Value> values = 2;
+    map<string, Value> values = 2;
 }
 
 message MetricObservation {

--- a/kerastuner/protos/kerastuner.proto
+++ b/kerastuner/protos/kerastuner.proto
@@ -17,6 +17,8 @@ syntax = "proto3";
 
 package kerastuner;
 
+import "google/protobuf/struct.proto";
+
 
 enum Sampling {
     NONE = 0;
@@ -45,29 +47,9 @@ message Int {
 
 message Choice {
     string name = 1;
-
-    message FloatValues {
-        repeated double values = 1;
-    }
-    message IntValues {
-        repeated sint64 values = 1;
-    }
-    message StringValues {
-        repeated string values = 1;
-    }
-    oneof values {
-        FloatValues float_values = 2;
-        IntValues int_values = 3;
-        StringValues string_values = 4;
-    }
-
-    oneof default {
-        sint64 int_default = 5;
-        double float_default = 6;
-        string string_default = 7;
-    }
-
-    bool ordered = 8;
+    repeated google.protobuf.Value values = 2;
+    google.protobuf.Value default = 3;
+    bool ordered = 4;
 }
 
 message Boolean {
@@ -76,15 +58,15 @@ message Boolean {
 }
 
 message HyperParameters {
-    repeated Float float_space = 1;
-    repeated Int int_space = 2;
-    repeated Choice choice_space = 3;
-    repeated Boolean boolean_space = 4;
+    message Space {
+        repeated Float float_space = 1;
+        repeated Int int_space = 2;
+        repeated Choice choice_space = 3;
+        repeated Boolean boolean_space = 4;
+    }
+    Space space = 1;
 
-    map<string, double> float_values = 5;
-    map<string, sint64> int_values = 6;
-    map<string, string> string_values = 7;
-    map<string, bool> boolean_values = 8;
+    map<string, google.protobuf.Value> values = 2;
 }
 
 message MetricObservation {
@@ -121,5 +103,4 @@ message Trial {
         int64 step = 2;
     }
     Score score = 5;
-
 }

--- a/kerastuner/protos/kerastuner_pb2.py
+++ b/kerastuner/protos/kerastuner_pb2.py
@@ -14,7 +14,6 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -22,9 +21,8 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='kerastuner',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\x1a\x1cgoogle/protobuf/struct.proto\"\x82\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\"\x80\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\"x\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12&\n\x06values\x18\x02 \x03(\x0b\x32\x16.google.protobuf.Value\x12\'\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\"(\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\"\xef\x02\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x37\n\x06values\x18\x02 \x03(\x0b\x32\'.kerastuner.HyperParameters.ValuesEntry\x1a\xa9\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x1a\x45\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
-  ,
-  dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
+  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"l\n\x05Value\x12\x13\n\tint_value\x18\x01 \x01(\x12H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x03 \x01(\tH\x00\x12\x17\n\rboolean_value\x18\x04 \x01(\x08H\x00\x42\x06\n\x04kind\"\x82\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\"\x80\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\"n\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.Value\x12\"\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\"(\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\"\xea\x02\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x37\n\x06values\x18\x02 \x03(\x0b\x32\'.kerastuner.HyperParameters.ValuesEntry\x1a\xa9\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x1a@\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
+)
 
 _SAMPLING = _descriptor.EnumDescriptor(
   name='Sampling',
@@ -51,8 +49,8 @@ _SAMPLING = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1414,
-  serialized_end=1472,
+  serialized_start=1479,
+  serialized_end=1537,
 )
 _sym_db.RegisterEnumDescriptor(_SAMPLING)
 
@@ -90,8 +88,8 @@ _TRIALSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1474,
-  serialized_end=1564,
+  serialized_start=1539,
+  serialized_end=1629,
 )
 _sym_db.RegisterEnumDescriptor(_TRIALSTATUS)
 
@@ -107,6 +105,61 @@ INVALID = 3
 STOPPED = 4
 COMPLETED = 5
 
+
+
+_VALUE = _descriptor.Descriptor(
+  name='Value',
+  full_name='kerastuner.Value',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='int_value', full_name='kerastuner.Value.int_value', index=0,
+      number=1, type=18, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='float_value', full_name='kerastuner.Value.float_value', index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='string_value', full_name='kerastuner.Value.string_value', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='boolean_value', full_name='kerastuner.Value.boolean_value', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='kind', full_name='kerastuner.Value.kind',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=50,
+  serialized_end=158,
+)
 
 
 _FLOAT = _descriptor.Descriptor(
@@ -170,8 +223,8 @@ _FLOAT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=81,
-  serialized_end=211,
+  serialized_start=161,
+  serialized_end=291,
 )
 
 
@@ -236,8 +289,8 @@ _INT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=214,
-  serialized_end=342,
+  serialized_start=294,
+  serialized_end=422,
 )
 
 
@@ -288,8 +341,8 @@ _CHOICE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=344,
-  serialized_end=464,
+  serialized_start=424,
+  serialized_end=534,
 )
 
 
@@ -326,8 +379,8 @@ _BOOLEAN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=466,
-  serialized_end=506,
+  serialized_start=536,
+  serialized_end=576,
 )
 
 
@@ -378,8 +431,8 @@ _HYPERPARAMETERS_SPACE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=636,
-  serialized_end=805,
+  serialized_start=706,
+  serialized_end=875,
 )
 
 _HYPERPARAMETERS_VALUESENTRY = _descriptor.Descriptor(
@@ -415,8 +468,8 @@ _HYPERPARAMETERS_VALUESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=807,
-  serialized_end=876,
+  serialized_start=877,
+  serialized_end=941,
 )
 
 _HYPERPARAMETERS = _descriptor.Descriptor(
@@ -452,8 +505,8 @@ _HYPERPARAMETERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=509,
-  serialized_end=876,
+  serialized_start=579,
+  serialized_end=941,
 )
 
 
@@ -490,8 +543,8 @@ _METRICOBSERVATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=878,
-  serialized_end=926,
+  serialized_start=943,
+  serialized_end=991,
 )
 
 
@@ -528,8 +581,8 @@ _METRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=928,
-  serialized_end=1014,
+  serialized_start=993,
+  serialized_end=1079,
 )
 
 
@@ -566,8 +619,8 @@ _METRICSTRACKER_METRICSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1093,
-  serialized_end=1166,
+  serialized_start=1158,
+  serialized_end=1231,
 )
 
 _METRICSTRACKER = _descriptor.Descriptor(
@@ -596,8 +649,8 @@ _METRICSTRACKER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1017,
-  serialized_end=1166,
+  serialized_start=1082,
+  serialized_end=1231,
 )
 
 
@@ -634,8 +687,8 @@ _TRIAL_SCORE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1376,
-  serialized_end=1412,
+  serialized_start=1441,
+  serialized_end=1477,
 )
 
 _TRIAL = _descriptor.Descriptor(
@@ -692,20 +745,32 @@ _TRIAL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1169,
-  serialized_end=1412,
+  serialized_start=1234,
+  serialized_end=1477,
 )
 
+_VALUE.oneofs_by_name['kind'].fields.append(
+  _VALUE.fields_by_name['int_value'])
+_VALUE.fields_by_name['int_value'].containing_oneof = _VALUE.oneofs_by_name['kind']
+_VALUE.oneofs_by_name['kind'].fields.append(
+  _VALUE.fields_by_name['float_value'])
+_VALUE.fields_by_name['float_value'].containing_oneof = _VALUE.oneofs_by_name['kind']
+_VALUE.oneofs_by_name['kind'].fields.append(
+  _VALUE.fields_by_name['string_value'])
+_VALUE.fields_by_name['string_value'].containing_oneof = _VALUE.oneofs_by_name['kind']
+_VALUE.oneofs_by_name['kind'].fields.append(
+  _VALUE.fields_by_name['boolean_value'])
+_VALUE.fields_by_name['boolean_value'].containing_oneof = _VALUE.oneofs_by_name['kind']
 _FLOAT.fields_by_name['sampling'].enum_type = _SAMPLING
 _INT.fields_by_name['sampling'].enum_type = _SAMPLING
-_CHOICE.fields_by_name['values'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
-_CHOICE.fields_by_name['default'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
+_CHOICE.fields_by_name['values'].message_type = _VALUE
+_CHOICE.fields_by_name['default'].message_type = _VALUE
 _HYPERPARAMETERS_SPACE.fields_by_name['float_space'].message_type = _FLOAT
 _HYPERPARAMETERS_SPACE.fields_by_name['int_space'].message_type = _INT
 _HYPERPARAMETERS_SPACE.fields_by_name['choice_space'].message_type = _CHOICE
 _HYPERPARAMETERS_SPACE.fields_by_name['boolean_space'].message_type = _BOOLEAN
 _HYPERPARAMETERS_SPACE.containing_type = _HYPERPARAMETERS
-_HYPERPARAMETERS_VALUESENTRY.fields_by_name['value'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
+_HYPERPARAMETERS_VALUESENTRY.fields_by_name['value'].message_type = _VALUE
 _HYPERPARAMETERS_VALUESENTRY.containing_type = _HYPERPARAMETERS
 _HYPERPARAMETERS.fields_by_name['space'].message_type = _HYPERPARAMETERS_SPACE
 _HYPERPARAMETERS.fields_by_name['values'].message_type = _HYPERPARAMETERS_VALUESENTRY
@@ -718,6 +783,7 @@ _TRIAL.fields_by_name['hyperparameters'].message_type = _HYPERPARAMETERS
 _TRIAL.fields_by_name['status'].enum_type = _TRIALSTATUS
 _TRIAL.fields_by_name['metrics'].message_type = _METRICSTRACKER
 _TRIAL.fields_by_name['score'].message_type = _TRIAL_SCORE
+DESCRIPTOR.message_types_by_name['Value'] = _VALUE
 DESCRIPTOR.message_types_by_name['Float'] = _FLOAT
 DESCRIPTOR.message_types_by_name['Int'] = _INT
 DESCRIPTOR.message_types_by_name['Choice'] = _CHOICE
@@ -730,6 +796,13 @@ DESCRIPTOR.message_types_by_name['Trial'] = _TRIAL
 DESCRIPTOR.enum_types_by_name['Sampling'] = _SAMPLING
 DESCRIPTOR.enum_types_by_name['TrialStatus'] = _TRIALSTATUS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
+Value = _reflection.GeneratedProtocolMessageType('Value', (_message.Message,), {
+  'DESCRIPTOR' : _VALUE,
+  '__module__' : 'kerastuner.protos.kerastuner_pb2'
+  # @@protoc_insertion_point(class_scope:kerastuner.Value)
+  })
+_sym_db.RegisterMessage(Value)
 
 Float = _reflection.GeneratedProtocolMessageType('Float', (_message.Message,), {
   'DESCRIPTOR' : _FLOAT,

--- a/kerastuner/protos/kerastuner_pb2.py
+++ b/kerastuner/protos/kerastuner_pb2.py
@@ -14,6 +14,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
+from google.protobuf import struct_pb2 as google_dot_protobuf_dot_struct__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(
@@ -21,8 +22,9 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='kerastuner',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"\x82\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\"\x80\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\"\x88\x03\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x36\n\x0c\x66loat_values\x18\x02 \x01(\x0b\x32\x1e.kerastuner.Choice.FloatValuesH\x00\x12\x32\n\nint_values\x18\x03 \x01(\x0b\x32\x1c.kerastuner.Choice.IntValuesH\x00\x12\x38\n\rstring_values\x18\x04 \x01(\x0b\x32\x1f.kerastuner.Choice.StringValuesH\x00\x12\x15\n\x0bint_default\x18\x05 \x01(\x12H\x01\x12\x17\n\rfloat_default\x18\x06 \x01(\x01H\x01\x12\x18\n\x0estring_default\x18\x07 \x01(\tH\x01\x12\x0f\n\x07ordered\x18\x08 \x01(\x08\x1a\x1d\n\x0b\x46loatValues\x12\x0e\n\x06values\x18\x01 \x03(\x01\x1a\x1b\n\tIntValues\x12\x0e\n\x06values\x18\x01 \x03(\x12\x1a\x1e\n\x0cStringValues\x12\x0e\n\x06values\x18\x01 \x03(\tB\x08\n\x06valuesB\t\n\x07\x64\x65\x66\x61ult\"(\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\"\x96\x05\n\x0fHyperParameters\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x12\x42\n\x0c\x66loat_values\x18\x05 \x03(\x0b\x32,.kerastuner.HyperParameters.FloatValuesEntry\x12>\n\nint_values\x18\x06 \x03(\x0b\x32*.kerastuner.HyperParameters.IntValuesEntry\x12\x44\n\rstring_values\x18\x07 \x03(\x0b\x32-.kerastuner.HyperParameters.StringValuesEntry\x12\x46\n\x0e\x62oolean_values\x18\x08 \x03(\x0b\x32..kerastuner.HyperParameters.BooleanValuesEntry\x1a\x32\n\x10\x46loatValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01:\x02\x38\x01\x1a\x30\n\x0eIntValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x12:\x02\x38\x01\x1a\x33\n\x11StringValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x1a\x34\n\x12\x42ooleanValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x08:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
-)
+  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\x1a\x1cgoogle/protobuf/struct.proto\"\x82\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\"\x80\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\"x\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12&\n\x06values\x18\x02 \x03(\x0b\x32\x16.google.protobuf.Value\x12\'\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\"(\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\"\xef\x02\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x37\n\x06values\x18\x02 \x03(\x0b\x32\'.kerastuner.HyperParameters.ValuesEntry\x1a\xa9\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x1a\x45\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
+  ,
+  dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,])
 
 _SAMPLING = _descriptor.EnumDescriptor(
   name='Sampling',
@@ -49,8 +51,8 @@ _SAMPLING = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1952,
-  serialized_end=2010,
+  serialized_start=1414,
+  serialized_end=1472,
 )
 _sym_db.RegisterEnumDescriptor(_SAMPLING)
 
@@ -88,8 +90,8 @@ _TRIALSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2012,
-  serialized_end=2102,
+  serialized_start=1474,
+  serialized_end=1564,
 )
 _sym_db.RegisterEnumDescriptor(_TRIALSTATUS)
 
@@ -168,8 +170,8 @@ _FLOAT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=51,
-  serialized_end=181,
+  serialized_start=81,
+  serialized_end=211,
 )
 
 
@@ -234,100 +236,10 @@ _INT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=184,
-  serialized_end=312,
+  serialized_start=214,
+  serialized_end=342,
 )
 
-
-_CHOICE_FLOATVALUES = _descriptor.Descriptor(
-  name='FloatValues',
-  full_name='kerastuner.Choice.FloatValues',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='values', full_name='kerastuner.Choice.FloatValues.values', index=0,
-      number=1, type=1, cpp_type=5, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=596,
-  serialized_end=625,
-)
-
-_CHOICE_INTVALUES = _descriptor.Descriptor(
-  name='IntValues',
-  full_name='kerastuner.Choice.IntValues',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='values', full_name='kerastuner.Choice.IntValues.values', index=0,
-      number=1, type=18, cpp_type=2, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=627,
-  serialized_end=654,
-)
-
-_CHOICE_STRINGVALUES = _descriptor.Descriptor(
-  name='StringValues',
-  full_name='kerastuner.Choice.StringValues',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='values', full_name='kerastuner.Choice.StringValues.values', index=0,
-      number=1, type=9, cpp_type=9, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=656,
-  serialized_end=686,
-)
 
 _CHOICE = _descriptor.Descriptor(
   name='Choice',
@@ -344,50 +256,22 @@ _CHOICE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='float_values', full_name='kerastuner.Choice.float_values', index=1,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
+      name='values', full_name='kerastuner.Choice.values', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='int_values', full_name='kerastuner.Choice.int_values', index=2,
+      name='default', full_name='kerastuner.Choice.default', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='string_values', full_name='kerastuner.Choice.string_values', index=3,
-      number=4, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='int_default', full_name='kerastuner.Choice.int_default', index=4,
-      number=5, type=18, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='float_default', full_name='kerastuner.Choice.float_default', index=5,
-      number=6, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='string_default', full_name='kerastuner.Choice.string_default', index=6,
-      number=7, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='ordered', full_name='kerastuner.Choice.ordered', index=7,
-      number=8, type=8, cpp_type=7, label=1,
+      name='ordered', full_name='kerastuner.Choice.ordered', index=3,
+      number=4, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -395,7 +279,7 @@ _CHOICE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_CHOICE_FLOATVALUES, _CHOICE_INTVALUES, _CHOICE_STRINGVALUES, ],
+  nested_types=[],
   enum_types=[
   ],
   serialized_options=None,
@@ -403,15 +287,9 @@ _CHOICE = _descriptor.Descriptor(
   syntax='proto3',
   extension_ranges=[],
   oneofs=[
-    _descriptor.OneofDescriptor(
-      name='values', full_name='kerastuner.Choice.values',
-      index=0, containing_type=None, fields=[]),
-    _descriptor.OneofDescriptor(
-      name='default', full_name='kerastuner.Choice.default',
-      index=1, containing_type=None, fields=[]),
   ],
-  serialized_start=315,
-  serialized_end=707,
+  serialized_start=344,
+  serialized_end=464,
 )
 
 
@@ -448,29 +326,80 @@ _BOOLEAN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=709,
-  serialized_end=749,
+  serialized_start=466,
+  serialized_end=506,
 )
 
 
-_HYPERPARAMETERS_FLOATVALUESENTRY = _descriptor.Descriptor(
-  name='FloatValuesEntry',
-  full_name='kerastuner.HyperParameters.FloatValuesEntry',
+_HYPERPARAMETERS_SPACE = _descriptor.Descriptor(
+  name='Space',
+  full_name='kerastuner.HyperParameters.Space',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='kerastuner.HyperParameters.FloatValuesEntry.key', index=0,
+      name='float_space', full_name='kerastuner.HyperParameters.Space.float_space', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='int_space', full_name='kerastuner.HyperParameters.Space.int_space', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='choice_space', full_name='kerastuner.HyperParameters.Space.choice_space', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='boolean_space', full_name='kerastuner.HyperParameters.Space.boolean_space', index=3,
+      number=4, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=636,
+  serialized_end=805,
+)
+
+_HYPERPARAMETERS_VALUESENTRY = _descriptor.Descriptor(
+  name='ValuesEntry',
+  full_name='kerastuner.HyperParameters.ValuesEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='kerastuner.HyperParameters.ValuesEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='kerastuner.HyperParameters.FloatValuesEntry.value', index=1,
-      number=2, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
+      name='value', full_name='kerastuner.HyperParameters.ValuesEntry.value', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -486,119 +415,8 @@ _HYPERPARAMETERS_FLOATVALUESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1207,
-  serialized_end=1257,
-)
-
-_HYPERPARAMETERS_INTVALUESENTRY = _descriptor.Descriptor(
-  name='IntValuesEntry',
-  full_name='kerastuner.HyperParameters.IntValuesEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='kerastuner.HyperParameters.IntValuesEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='kerastuner.HyperParameters.IntValuesEntry.value', index=1,
-      number=2, type=18, cpp_type=2, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=_b('8\001'),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1259,
-  serialized_end=1307,
-)
-
-_HYPERPARAMETERS_STRINGVALUESENTRY = _descriptor.Descriptor(
-  name='StringValuesEntry',
-  full_name='kerastuner.HyperParameters.StringValuesEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='kerastuner.HyperParameters.StringValuesEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='kerastuner.HyperParameters.StringValuesEntry.value', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=_b('8\001'),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1309,
-  serialized_end=1360,
-)
-
-_HYPERPARAMETERS_BOOLEANVALUESENTRY = _descriptor.Descriptor(
-  name='BooleanValuesEntry',
-  full_name='kerastuner.HyperParameters.BooleanValuesEntry',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='key', full_name='kerastuner.HyperParameters.BooleanValuesEntry.key', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='value', full_name='kerastuner.HyperParameters.BooleanValuesEntry.value', index=1,
-      number=2, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=_b('8\001'),
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=1362,
-  serialized_end=1414,
+  serialized_start=807,
+  serialized_end=876,
 )
 
 _HYPERPARAMETERS = _descriptor.Descriptor(
@@ -609,57 +427,15 @@ _HYPERPARAMETERS = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='float_space', full_name='kerastuner.HyperParameters.float_space', index=0,
-      number=1, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
+      name='space', full_name='kerastuner.HyperParameters.space', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='int_space', full_name='kerastuner.HyperParameters.int_space', index=1,
+      name='values', full_name='kerastuner.HyperParameters.values', index=1,
       number=2, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='choice_space', full_name='kerastuner.HyperParameters.choice_space', index=2,
-      number=3, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='boolean_space', full_name='kerastuner.HyperParameters.boolean_space', index=3,
-      number=4, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='float_values', full_name='kerastuner.HyperParameters.float_values', index=4,
-      number=5, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='int_values', full_name='kerastuner.HyperParameters.int_values', index=5,
-      number=6, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='string_values', full_name='kerastuner.HyperParameters.string_values', index=6,
-      number=7, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='boolean_values', full_name='kerastuner.HyperParameters.boolean_values', index=7,
-      number=8, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -667,7 +443,7 @@ _HYPERPARAMETERS = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_HYPERPARAMETERS_FLOATVALUESENTRY, _HYPERPARAMETERS_INTVALUESENTRY, _HYPERPARAMETERS_STRINGVALUESENTRY, _HYPERPARAMETERS_BOOLEANVALUESENTRY, ],
+  nested_types=[_HYPERPARAMETERS_SPACE, _HYPERPARAMETERS_VALUESENTRY, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -676,8 +452,8 @@ _HYPERPARAMETERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=752,
-  serialized_end=1414,
+  serialized_start=509,
+  serialized_end=876,
 )
 
 
@@ -714,8 +490,8 @@ _METRICOBSERVATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1416,
-  serialized_end=1464,
+  serialized_start=878,
+  serialized_end=926,
 )
 
 
@@ -752,8 +528,8 @@ _METRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1466,
-  serialized_end=1552,
+  serialized_start=928,
+  serialized_end=1014,
 )
 
 
@@ -790,8 +566,8 @@ _METRICSTRACKER_METRICSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1631,
-  serialized_end=1704,
+  serialized_start=1093,
+  serialized_end=1166,
 )
 
 _METRICSTRACKER = _descriptor.Descriptor(
@@ -820,8 +596,8 @@ _METRICSTRACKER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1555,
-  serialized_end=1704,
+  serialized_start=1017,
+  serialized_end=1166,
 )
 
 
@@ -858,8 +634,8 @@ _TRIAL_SCORE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1914,
-  serialized_end=1950,
+  serialized_start=1376,
+  serialized_end=1412,
 )
 
 _TRIAL = _descriptor.Descriptor(
@@ -916,48 +692,23 @@ _TRIAL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1707,
-  serialized_end=1950,
+  serialized_start=1169,
+  serialized_end=1412,
 )
 
 _FLOAT.fields_by_name['sampling'].enum_type = _SAMPLING
 _INT.fields_by_name['sampling'].enum_type = _SAMPLING
-_CHOICE_FLOATVALUES.containing_type = _CHOICE
-_CHOICE_INTVALUES.containing_type = _CHOICE
-_CHOICE_STRINGVALUES.containing_type = _CHOICE
-_CHOICE.fields_by_name['float_values'].message_type = _CHOICE_FLOATVALUES
-_CHOICE.fields_by_name['int_values'].message_type = _CHOICE_INTVALUES
-_CHOICE.fields_by_name['string_values'].message_type = _CHOICE_STRINGVALUES
-_CHOICE.oneofs_by_name['values'].fields.append(
-  _CHOICE.fields_by_name['float_values'])
-_CHOICE.fields_by_name['float_values'].containing_oneof = _CHOICE.oneofs_by_name['values']
-_CHOICE.oneofs_by_name['values'].fields.append(
-  _CHOICE.fields_by_name['int_values'])
-_CHOICE.fields_by_name['int_values'].containing_oneof = _CHOICE.oneofs_by_name['values']
-_CHOICE.oneofs_by_name['values'].fields.append(
-  _CHOICE.fields_by_name['string_values'])
-_CHOICE.fields_by_name['string_values'].containing_oneof = _CHOICE.oneofs_by_name['values']
-_CHOICE.oneofs_by_name['default'].fields.append(
-  _CHOICE.fields_by_name['int_default'])
-_CHOICE.fields_by_name['int_default'].containing_oneof = _CHOICE.oneofs_by_name['default']
-_CHOICE.oneofs_by_name['default'].fields.append(
-  _CHOICE.fields_by_name['float_default'])
-_CHOICE.fields_by_name['float_default'].containing_oneof = _CHOICE.oneofs_by_name['default']
-_CHOICE.oneofs_by_name['default'].fields.append(
-  _CHOICE.fields_by_name['string_default'])
-_CHOICE.fields_by_name['string_default'].containing_oneof = _CHOICE.oneofs_by_name['default']
-_HYPERPARAMETERS_FLOATVALUESENTRY.containing_type = _HYPERPARAMETERS
-_HYPERPARAMETERS_INTVALUESENTRY.containing_type = _HYPERPARAMETERS
-_HYPERPARAMETERS_STRINGVALUESENTRY.containing_type = _HYPERPARAMETERS
-_HYPERPARAMETERS_BOOLEANVALUESENTRY.containing_type = _HYPERPARAMETERS
-_HYPERPARAMETERS.fields_by_name['float_space'].message_type = _FLOAT
-_HYPERPARAMETERS.fields_by_name['int_space'].message_type = _INT
-_HYPERPARAMETERS.fields_by_name['choice_space'].message_type = _CHOICE
-_HYPERPARAMETERS.fields_by_name['boolean_space'].message_type = _BOOLEAN
-_HYPERPARAMETERS.fields_by_name['float_values'].message_type = _HYPERPARAMETERS_FLOATVALUESENTRY
-_HYPERPARAMETERS.fields_by_name['int_values'].message_type = _HYPERPARAMETERS_INTVALUESENTRY
-_HYPERPARAMETERS.fields_by_name['string_values'].message_type = _HYPERPARAMETERS_STRINGVALUESENTRY
-_HYPERPARAMETERS.fields_by_name['boolean_values'].message_type = _HYPERPARAMETERS_BOOLEANVALUESENTRY
+_CHOICE.fields_by_name['values'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
+_CHOICE.fields_by_name['default'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
+_HYPERPARAMETERS_SPACE.fields_by_name['float_space'].message_type = _FLOAT
+_HYPERPARAMETERS_SPACE.fields_by_name['int_space'].message_type = _INT
+_HYPERPARAMETERS_SPACE.fields_by_name['choice_space'].message_type = _CHOICE
+_HYPERPARAMETERS_SPACE.fields_by_name['boolean_space'].message_type = _BOOLEAN
+_HYPERPARAMETERS_SPACE.containing_type = _HYPERPARAMETERS
+_HYPERPARAMETERS_VALUESENTRY.fields_by_name['value'].message_type = google_dot_protobuf_dot_struct__pb2._VALUE
+_HYPERPARAMETERS_VALUESENTRY.containing_type = _HYPERPARAMETERS
+_HYPERPARAMETERS.fields_by_name['space'].message_type = _HYPERPARAMETERS_SPACE
+_HYPERPARAMETERS.fields_by_name['values'].message_type = _HYPERPARAMETERS_VALUESENTRY
 _METRICHISTORY.fields_by_name['observations'].message_type = _METRICOBSERVATION
 _METRICSTRACKER_METRICSENTRY.fields_by_name['value'].message_type = _METRICHISTORY
 _METRICSTRACKER_METRICSENTRY.containing_type = _METRICSTRACKER
@@ -995,35 +746,11 @@ Int = _reflection.GeneratedProtocolMessageType('Int', (_message.Message,), {
 _sym_db.RegisterMessage(Int)
 
 Choice = _reflection.GeneratedProtocolMessageType('Choice', (_message.Message,), {
-
-  'FloatValues' : _reflection.GeneratedProtocolMessageType('FloatValues', (_message.Message,), {
-    'DESCRIPTOR' : _CHOICE_FLOATVALUES,
-    '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.Choice.FloatValues)
-    })
-  ,
-
-  'IntValues' : _reflection.GeneratedProtocolMessageType('IntValues', (_message.Message,), {
-    'DESCRIPTOR' : _CHOICE_INTVALUES,
-    '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.Choice.IntValues)
-    })
-  ,
-
-  'StringValues' : _reflection.GeneratedProtocolMessageType('StringValues', (_message.Message,), {
-    'DESCRIPTOR' : _CHOICE_STRINGVALUES,
-    '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.Choice.StringValues)
-    })
-  ,
   'DESCRIPTOR' : _CHOICE,
   '__module__' : 'kerastuner.protos.kerastuner_pb2'
   # @@protoc_insertion_point(class_scope:kerastuner.Choice)
   })
 _sym_db.RegisterMessage(Choice)
-_sym_db.RegisterMessage(Choice.FloatValues)
-_sym_db.RegisterMessage(Choice.IntValues)
-_sym_db.RegisterMessage(Choice.StringValues)
 
 Boolean = _reflection.GeneratedProtocolMessageType('Boolean', (_message.Message,), {
   'DESCRIPTOR' : _BOOLEAN,
@@ -1034,31 +761,17 @@ _sym_db.RegisterMessage(Boolean)
 
 HyperParameters = _reflection.GeneratedProtocolMessageType('HyperParameters', (_message.Message,), {
 
-  'FloatValuesEntry' : _reflection.GeneratedProtocolMessageType('FloatValuesEntry', (_message.Message,), {
-    'DESCRIPTOR' : _HYPERPARAMETERS_FLOATVALUESENTRY,
+  'Space' : _reflection.GeneratedProtocolMessageType('Space', (_message.Message,), {
+    'DESCRIPTOR' : _HYPERPARAMETERS_SPACE,
     '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.FloatValuesEntry)
+    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.Space)
     })
   ,
 
-  'IntValuesEntry' : _reflection.GeneratedProtocolMessageType('IntValuesEntry', (_message.Message,), {
-    'DESCRIPTOR' : _HYPERPARAMETERS_INTVALUESENTRY,
+  'ValuesEntry' : _reflection.GeneratedProtocolMessageType('ValuesEntry', (_message.Message,), {
+    'DESCRIPTOR' : _HYPERPARAMETERS_VALUESENTRY,
     '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.IntValuesEntry)
-    })
-  ,
-
-  'StringValuesEntry' : _reflection.GeneratedProtocolMessageType('StringValuesEntry', (_message.Message,), {
-    'DESCRIPTOR' : _HYPERPARAMETERS_STRINGVALUESENTRY,
-    '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.StringValuesEntry)
-    })
-  ,
-
-  'BooleanValuesEntry' : _reflection.GeneratedProtocolMessageType('BooleanValuesEntry', (_message.Message,), {
-    'DESCRIPTOR' : _HYPERPARAMETERS_BOOLEANVALUESENTRY,
-    '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.BooleanValuesEntry)
+    # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters.ValuesEntry)
     })
   ,
   'DESCRIPTOR' : _HYPERPARAMETERS,
@@ -1066,10 +779,8 @@ HyperParameters = _reflection.GeneratedProtocolMessageType('HyperParameters', (_
   # @@protoc_insertion_point(class_scope:kerastuner.HyperParameters)
   })
 _sym_db.RegisterMessage(HyperParameters)
-_sym_db.RegisterMessage(HyperParameters.FloatValuesEntry)
-_sym_db.RegisterMessage(HyperParameters.IntValuesEntry)
-_sym_db.RegisterMessage(HyperParameters.StringValuesEntry)
-_sym_db.RegisterMessage(HyperParameters.BooleanValuesEntry)
+_sym_db.RegisterMessage(HyperParameters.Space)
+_sym_db.RegisterMessage(HyperParameters.ValuesEntry)
 
 MetricObservation = _reflection.GeneratedProtocolMessageType('MetricObservation', (_message.Message,), {
   'DESCRIPTOR' : _METRICOBSERVATION,
@@ -1116,9 +827,6 @@ _sym_db.RegisterMessage(Trial)
 _sym_db.RegisterMessage(Trial.Score)
 
 
-_HYPERPARAMETERS_FLOATVALUESENTRY._options = None
-_HYPERPARAMETERS_INTVALUESENTRY._options = None
-_HYPERPARAMETERS_STRINGVALUESENTRY._options = None
-_HYPERPARAMETERS_BOOLEANVALUESENTRY._options = None
+_HYPERPARAMETERS_VALUESENTRY._options = None
 _METRICSTRACKER_METRICSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -402,9 +402,9 @@ def test_choice_proto():
     proto = hp.to_proto()
     assert proto.name == 'a'
     assert proto.ordered
-    assert np.allclose(proto.float_values.values, [2.3, 4.5, 6.3])
+    assert np.allclose([v.float_value for v in proto.values], [2.3, 4.5, 6.3])
     # Proto stores the implicit default.
-    assert np.isclose(proto.float_default, 2.3)
+    assert np.isclose(proto.default.float_value, 2.3)
 
     new_hp = hp_module.Choice.from_proto(proto)
     assert new_hp.name == 'a'

--- a/tests/kerastuner/engine/trial_test.py
+++ b/tests/kerastuner/engine/trial_test.py
@@ -26,8 +26,8 @@ def test_trial_proto():
     trial.metrics.update('score', 10, step=1)
 
     proto = trial.to_proto()
-    assert len(proto.hyperparameters.int_space) == 1
-    assert proto.hyperparameters.int_values['a'] == 3
+    assert len(proto.hyperparameters.space.int_space) == 1
+    assert proto.hyperparameters.values['a'].int_value == 3
     assert not proto.HasField('score')
 
     new_trial = trial_module.Trial.from_proto(proto)


### PR DESCRIPTION
@sagipe 

Spoke to Sagi, he suggested this restructuring for integration with TensorBoard, etc

Was planning to use `google.protobuf.Value`, but that doesn't make a distinction b/t int and double, so ended up creating a similar structure (called `Value`) in kerastuner.proto