### PR TITLE
Remove conditional HPs from HyperResnet

### DIFF
--- a/kerastuner/applications/resnet.py
+++ b/kerastuner/applications/resnet.py
@@ -47,17 +47,8 @@ class HyperResNet(hypermodel.HyperModel):
 
     def build(self, hp):
         version = hp.Choice('version', ['v1', 'v2', 'next'], default='v2')
-
-        # Version-conditional hyperparameters.
-        with hp.name_scope(version):
-            conv3_depth = hp.Choice(
-                'conv3_depth',
-                [4] if version == 'next' else [4, 8],
-                default=4)
-            conv4_depth = hp.Choice(
-                'conv4_depth',
-                [6, 23] if version == 'next' else [6, 23, 36],
-                default=6)
+        conv3_depth = hp.Choice('conv3_depth', [4, 8])
+        conv4_depth = hp.Choice('conv4_depth', [6, 23, 36])
 
         # Version-conditional fixed parameters
         preact = True if version == 'v2' else False

--- a/tests/kerastuner/applications/resnet_test.py
+++ b/tests/kerastuner/applications/resnet_test.py
@@ -43,8 +43,8 @@ def test_hyperparameter_existence_and_defaults():
     hypermodel = resnet.HyperResNet(input_shape=(256, 256, 3), classes=10)
     hypermodel.build(hp)
     assert hp.get('version') == 'v2'
-    assert hp.get('v2/conv3_depth') == 4
-    assert hp.get('v2/conv4_depth') == 6
+    assert hp.get('conv3_depth') == 4
+    assert hp.get('conv4_depth') == 6
     assert hp.get('learning_rate') == 0.01
     assert hp.get('pooling') == 'avg'
 
@@ -61,11 +61,12 @@ def test_include_top_false():
 def test_hyperparameter_override():
     hp = hp_module.HyperParameters()
     hp.Choice('version', ['v1'])
+    hp.Fixed('conv3_depth', 10)
     hypermodel = resnet.HyperResNet(input_shape=(256, 256, 3), classes=10)
     hypermodel.build(hp)
     assert hp.get('version') == 'v1'
-    assert hp.get('v1/conv3_depth') == 4
-    assert hp.get('v1/conv4_depth') == 6
+    assert hp.get('conv3_depth') == 10
+    assert hp.get('conv4_depth') == 6
 
 
 def test_input_tensor():


### PR DESCRIPTION
Looking at this again the different values of the conv sizes for "next" doesn't seem to be a big enough distinction to warrant the additional complexity of having conditional parameters here