### PR TITLE
Improve BayesianOptimization Oracle

### DIFF
--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -28,8 +28,10 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
             Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has been
             exhausted.
-        num_initial_points: Int. The number of randomly generated samples as initial
-            training data for Bayesian optimization.
+        num_initial_points: (Optional) Int. The number of randomly generated samples
+            as initial training data for Bayesian optimization. If not specified,
+            a value of 3 times the dimensionality of the hyperparameter space is
+            used.
         alpha: Float. Value added to the diagonal of the kernel matrix
             during fitting. It represents the expected amount of noise
             in the observed performances in Bayesian optimization.

--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -262,15 +262,6 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         bounds = []
         for hp in self._nonfixed_space():
             bounds.append([0, 1])
-            continue
-
-            if isinstance(hp, hp_module.Boolean):
-                bound = [0, 1]
-            elif isinstance(hp, hp_module.Choice):
-                bound = [0, len(hp.values) - 1]
-            else:
-                bound = [hp.min_value, hp.max_value]
-            bounds.append(bound)
         return np.array(bounds)
 
 

--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -2,7 +2,9 @@ import random
 
 import numpy as np
 from scipy import optimize as scipy_optimize
+from sklearn import exceptions
 from sklearn import gaussian_process
+from sklearn import preprocessing
 
 from ..engine import hyperparameters as hp_module
 from ..engine import multi_execution_tuner
@@ -52,7 +54,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     def __init__(self,
                  objective,
                  max_trials,
-                 num_initial_points=2,
+                 num_initial_points=None,
                  alpha=1e-4,
                  beta=2.6,
                  seed=None,
@@ -73,20 +75,34 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         self._tried_so_far = set()
         self._max_collisions = 20
         self.gpr = gaussian_process.GaussianProcessRegressor(
+            kernel=gaussian_process.kernels.Matern(),
+            n_restarts_optimizer=20,
+            normalize_y=True,
             alpha=self.alpha)
 
     def _populate_space(self, trial_id):
         # Generate enough samples before training Gaussian process.
         completed_trials = [t for t in self.trials.values()
                             if t.status == 'COMPLETED']
-        if len(self.trials) < self.num_initial_points or len(completed_trials) < 2:
+
+        # Use 3 times the dimensionality of the space as the default number of
+        # random points.
+        dimensions = len(self.hyperparameters.space)
+        num_initial_points = self.num_initial_points or 3 * dimensions
+        if len(completed_trials) < num_initial_points:
             values = self._random_trial()
             return {'status': trial_lib.TrialStatus.RUNNING,
                     'values': values}
 
         # Fit a GPR to the completed trials and return the predicted optimum values.
         x, y = self._vectorize_trials()
-        self.gpr.fit(x, y)
+        try:
+            self.gpr.fit(x, y)
+        except exceptions.ConvergenceWarning:
+            # If convergence of the GPR fails, create a random trial.
+            values = self._random_trial()
+            return {'status': trial_lib.TrialStatus.RUNNING,
+                    'values': values}
 
         def _upper_confidence_bound(x):
             x = x.reshape(1, -1)
@@ -95,7 +111,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
         optimal_val = float('inf')
         optimal_x = None
-        num_restarts = 25
+        num_restarts = 50
         bounds = self._get_hp_bounds()
         for _ in range(num_restarts):
             x0 = np.random.uniform(bounds[:, 0], bounds[:, 1])
@@ -169,18 +185,10 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     def _vectorize_trials(self):
         x = []
         y = []
+        ongoing_trials = {t for t in self.ongoing_trials.values()}
         for trial in self.trials.values():
-            if trial.status != "COMPLETED":
-                continue
-
+            # Create a vector representation of each Trial's hyperparameters.
             trial_values = trial.hyperparameters.values
-            score = trial.score
-
-            # Always frame the optimization as a minimization for scipy.minimize.
-            if self.objective.direction == 'max':
-                score = -1*score
-
-            # Create a vector representation for each Trial's hyperparameters.
             vector = []
             for hp in self._nonfixed_space():
                 # Hyperparameters could have been added to the study since
@@ -199,13 +207,24 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                     val = trial_value
                 vector.append(val)
 
+            if trial in ongoing_trials:
+                # "Hallucinate" the results of ongoing trials. This ensures that
+                # repeat trials are not selected when running distributed.
+                x_h = np.array(vector).reshape((1, -1))
+                y_h_mean, y_h_std = self.gpr.predict(x_h, return_std=True)
+                # Give a pessimistic estimate of the ongoing trial.
+                score = y_h_mean[0] + y_h_std[0]
+            elif trial.status == 'COMPLETED':
+                score = trial.score
+                # Always frame the optimization as a minimization for scipy.minimize.
+                if self.objective.direction == 'max':
+                    score = -1*score
+
             x.append(vector)
             y.append(score)
 
         x = np.array(x)
-        max_score = np.max(np.abs(y))
-        if max_score > 0:
-            y = np.array(y) / max_score
+        y = np.array(y)
         return x, y
 
     def _vector_to_values(self, vector):

--- a/tests/kerastuner/tuners/bayesian_test.py
+++ b/tests/kerastuner/tuners/bayesian_test.py
@@ -39,6 +39,7 @@ def test_bayesian_oracle(tmp_dir):
     oracle = bo_module.BayesianOptimizationOracle(
         objective=kt.Objective('score', 'max'),
         max_trials=20,
+        num_initial_points=2,
         hyperparameters=hps)
     oracle._set_project_dir(tmp_dir, 'untitled')
     for i in range(5):
@@ -57,6 +58,7 @@ def test_bayesian_oracle_with_zero_y(tmp_dir):
     oracle = bo_module.BayesianOptimizationOracle(
         objective=kt.Objective('score', 'max'),
         max_trials=20,
+        num_initial_points=2,
         hyperparameters=hps)
     oracle._set_project_dir(tmp_dir, 'untitled')
     for i in range(5):
@@ -69,7 +71,7 @@ def test_bayesian_dynamic_space(tmp_dir):
     hps = hp_module.HyperParameters()
     hps.Choice('a', [1, 2], default=1)
     oracle = bo_module.BayesianOptimizationOracle(
-        objective='val_acc', max_trials=20)
+        objective='val_acc', max_trials=20, num_initial_points=10)
     oracle._set_project_dir(tmp_dir, 'untitled')
     oracle.hyperparameters = hps
     for i in range(10):


### PR DESCRIPTION
Spoke with @sagipe , based on his suggestions this PR:

* Sets the default for `num_initial_points` to 3 times the dimensionality of the space
* Runs 20 restarts of the optimization process for the `GaussianProcessRegressor`
* Uses the `Matern` kernel for the `GaussianProcessRegressor`
* Uses 50 restarts for `scipy.minimize`. Sagi recommended this be much higher (1000s), but increasing this really slowed down suggestions so just doubled from 25 to 50 for now. We can increase this or maybe make this configurable in the future
* Scaled and normalized data so that x-values are within [0, 1], and so that log and reverse-log sampling is respected (this leads to more accurate optimization for the learning-rate, for instance)
* For distributed mode: the results of ongoing trials are "hallucinated" based on the predicted values from the last iteration of the GPR. This discourages multiple workers from trying the same params 