### PR TITLE
Fix Bayesian Choice boundary

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -841,6 +841,9 @@ def cumulative_prob_to_value(prob, hp):
     elif isinstance(hp, Choice):
         ele_prob = 1 / len(hp.values)
         index = math.floor(prob / ele_prob)
+        # Can happen when `prob` is very close to 1.
+        if index == len(hp.values):
+            index = index - 1
         return hp.values[index]
     elif isinstance(hp, (Int, Float)):
         sampling = hp.sampling or 'linear'

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -478,3 +478,13 @@ def test_dict_methods():
     assert 'b' in hps
     assert 'c' in hps
     assert 'd' not in hps
+
+
+def test_prob_one_choice():
+    hp = hp_module.Choice('a', [0, 1, 2])
+    # Check that boundaries are valid.
+    value = hp_module.cumulative_prob_to_value(1, hp)
+    assert value == 2
+
+    value = hp_module.cumulative_prob_to_value(0, hp)
+    assert value == 0


### PR DESCRIPTION
When the `BayesianOptimization` oracle was hitting the `1` cumulative probabilty bound for `Choice`, `math.floor` was not properly rounding down resulting in an out of index error