### PR TITLE
Fix unexpected keyword argument `input` in AutoKeras old_block.build()

### DIFF
--- a/kerastuner/engine/hypermodel.py
+++ b/kerastuner/engine/hypermodel.py
@@ -57,12 +57,12 @@ class HyperModel(object):
         """
         raise NotImplementedError
 
-    def _build_wrapper(self, hp):
+    def _build_wrapper(self, hp, *args, **kwargs):
         if not self.tunable:
             # Copy `HyperParameters` object so that new entries are not added
             # to the search space.
             hp = hp.copy()
-        return self._build(hp)
+        return self._build(hp, *args, **kwargs)
 
 
 class DefaultHyperModel(HyperModel):


### PR DESCRIPTION
In the AutoKeras of the current version, there will be an unexpected keyword argument `input` error thrown even when I run the mnist.py example. 

```
Traceback (most recent call last):
  File "mnist.py", line 38, in <module>
    task_api()
  File "mnist.py", line 9, in task_api
    clf.fit(x_train, y_train, validation_split=0.2)
  File "/usr/local/var/pyenv/versions/3.7.4/lib/python3.7/site-packages/autokeras/auto_model.py", line 123, in fit
    preprocess_graph, keras_graph = self.hyper_graph.build_graphs(hp)
  File "/usr/local/var/pyenv/versions/3.7.4/lib/python3.7/site-packages/autokeras/hypermodel/graph.py", line 434, in build_graphs
    plain_graph = self.hyper_build(hp)
  File "/usr/local/var/pyenv/versions/3.7.4/lib/python3.7/site-packages/autokeras/hypermodel/graph.py", line 454, in hyper_build
    outputs = old_block.build(hp, inputs=inputs)
TypeError: _build_wrapper() got an unexpected keyword argument 'inputs'
```

The pull request fixed the bug and the example will then run without errors.