### PR TITLE
Make random values collision detection aware of conditional params

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -841,6 +841,9 @@ def cumulative_prob_to_value(prob, hp):
     elif isinstance(hp, Choice):
         ele_prob = 1 / len(hp.values)
         index = math.floor(prob / ele_prob)
+        # Can happen when `prob` is very close to 1.
+        if index == len(hp.values):
+            index = index - 1
         return hp.values[index]
     elif isinstance(hp, (Int, Float)):
         sampling = hp.sampling or 'linear'

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -563,7 +563,8 @@ class HyperParameters(object):
         # that was defined in the current scope.
         full_cond_name = self._get_name(name)
         if full_cond_name in self.values:
-            if self._conditions_are_active():
+            scopes = self._get_name_parts(full_cond_name)[:-1]
+            if self._conditions_are_active(scopes):
                 return self.values[full_cond_name]
             elif error_on_inactive:
                 raise ValueError(

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -556,7 +556,7 @@ class HyperParameters(object):
 
     def get(self, name):
         """Returns the current value of this HyperParameter."""
-        self._get(name, error_on_inactive=True)
+        return self._get(name, error_on_inactive=True)
 
     def _get(self, name, error_on_inactive=True):
         # Fast path: check for a non-conditional param or for a conditional param

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -351,7 +351,8 @@ class Oracle(stateful.Stateful):
 
     def _compute_values_hash(self, hps):
         # Don't include conditional params that are not currently active.
-        values = {name: val for name, val in hps.values.items() if hps.is_active(name)}
+        values = {name: val for name, val in hps.values.items()
+                  if hps.is_active(name)}
         keys = sorted(values.keys())
         s = ''.join(str(k) + '=' + str(values[k]) for k in keys)
         return hashlib.sha256(s.encode('utf-8')).hexdigest()[:32]

--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -103,7 +103,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
         optimal_val = float('inf')
         optimal_x = None
-        num_restarts = 50
+        num_restarts = 150
         bounds = self._get_hp_bounds()
         for _ in range(num_restarts):
             x0 = np.random.uniform(bounds[:, 0], bounds[:, 1])

--- a/kerastuner/tuners/hyperband.py
+++ b/kerastuner/tuners/hyperband.py
@@ -126,13 +126,7 @@ class HyperbandOracle(oracle_module.Oracle):
 
             if len(rounds[0]) < self._get_size(bracket_num, round_num=0):
                 # Populate the initial random trials for this bracket.
-                # Allow collisions since a previous trial may have been stopped
-                # too early during an aggressive bracket.
-                result = self._random_populate_space(allow_collisions=True)
-                result['values'] = self._add_bracket_info(
-                    result['values'], bracket_num)
-                rounds[0].append({'past_id': None, 'id': trial_id})
-                return result
+                return self._random_trial(trial_id, bracket)
             else:
                 # Try to populate incomplete rounds for this bracket.
                 for round_num in range(1, len(rounds)):
@@ -202,6 +196,17 @@ class HyperbandOracle(oracle_module.Oracle):
                 return False
             return True
         self._brackets = list(filter(_bracket_is_incomplete, self._brackets))
+
+    def _random_trial(self, trial_id, bracket):
+        bracket_num = bracket['bracket_num']
+        rounds = bracket['rounds']
+        rounds[0].append({'past_id': None, 'id': trial_id})
+        # Allow collisions since a previous trial may have been stopped
+        # too early during an aggressive bracket.
+        result = self._random_populate_space(allow_collisions=True)
+        result['values'] = self._add_bracket_info(
+            result['values'], bracket_num)
+        return result
 
     def _add_bracket_info(self, values, bracket_num):
         values = values or {}

--- a/kerastuner/tuners/randomsearch.py
+++ b/kerastuner/tuners/randomsearch.py
@@ -20,9 +20,6 @@ from __future__ import print_function
 
 from ..engine import multi_execution_tuner
 from ..engine import oracle as oracle_module
-from ..engine import trial as trial_lib
-
-import random
 
 
 class RandomSearchOracle(oracle_module.Oracle):
@@ -63,63 +60,11 @@ class RandomSearchOracle(oracle_module.Oracle):
             max_trials=max_trials,
             hyperparameters=hyperparameters,
             tune_new_entries=tune_new_entries,
-            allow_new_entries=allow_new_entries)
-        self.seed = seed or random.randint(1, 1e4)
-        # Incremented at every call to `populate_space`.
-        self._seed_state = self.seed
-        # Hashes of values tried so far.
-        self._tried_so_far = set()
-        # Maximum number of identical values that can be generated
-        # before we consider the space to be exhausted.
-        self._max_collisions = 5
+            allow_new_entries=allow_new_entries,
+            seed=seed)
 
     def _populate_space(self, _):
-        """Fill the hyperparameter space with values.
-
-        Args:
-          `trial_id`: The id for this Trial.
-
-        Returns:
-            A dictionary with keys "values" and "status", where "values" is
-            a mapping of parameter names to suggested values, and "status"
-            is the TrialStatus that should be returned for this trial (one
-            of "RUNNING", "IDLE", or "STOPPED").
-        """
-        collisions = 0
-        while 1:
-            # Generate a set of random values.
-            values = {}
-            for p in self.hyperparameters.space:
-                values[p.name] = p.random_sample(self._seed_state)
-                self._seed_state += 1
-            # Keep trying until the set of values is unique,
-            # or until we exit due to too many collisions.
-            values_hash = self._compute_values_hash(values)
-            if values_hash in self._tried_so_far:
-                collisions += 1
-                if collisions > self._max_collisions:
-                    return {'status': trial_lib.TrialStatus.STOPPED,
-                            'values': None}
-                continue
-            self._tried_so_far.add(values_hash)
-            break
-        return {'status': trial_lib.TrialStatus.RUNNING,
-                'values': values}
-
-    def get_state(self):
-        state = super(RandomSearchOracle, self).get_state()
-        state.update({
-            'seed': self.seed,
-            'seed_state': self._seed_state,
-            'tried_so_far': list(self._tried_so_far),
-        })
-        return state
-
-    def set_state(self, state):
-        super(RandomSearchOracle, self).set_state(state)
-        self.seed = state['seed']
-        self._seed_state = state['seed_state']
-        self._tried_so_far = set(state['tried_so_far'])
+        return self._random_populate_space()
 
 
 class RandomSearch(multi_execution_tuner.MultiExecutionTuner):

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -488,3 +488,19 @@ def test_prob_one_choice():
 
     value = hp_module.cumulative_prob_to_value(0, hp)
     assert value == 0
+
+
+def test_is_active():
+    hp = hp_module.HyperParameters()
+    hp.Choice('a', [1, 2, 3], default=2)
+    assert hp.is_active('a')
+    with hp.conditional_scope('a', 2):
+        hp.Fixed('b', 4)
+        assert hp.is_active('b')
+    with hp.conditional_scope('a', 3):
+        hp.Fixed('b', 5)
+        assert not hp.is_active('b')
+
+    assert hp.is_active('b')
+    assert hp.is_active('a=2/b')
+    assert not hp.is_active('a=3/b')

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -478,3 +478,13 @@ def test_dict_methods():
     assert 'b' in hps
     assert 'c' in hps
     assert 'd' not in hps
+
+
+def test_prob_one_choice():
+    hp = hp_module.Choice('a', [0, 1, 2])
+    # Check that boundaries are valid.
+    value = hp_module.cumulative_prob_to_value(1, hp)
+    assert value == 2
+
+    value = hp_module.cumulative_prob_to_value(0, hp)
+    assert value == 0


### PR DESCRIPTION
* As part of this PR, factors random values generation into the base oracle
* Also increased the number of restarts in the `BayesianOptimization` oracle because the change to use a Matern kernel with nu=2.5 allows `scipy.minimize` to converge faster but seems to require more restarts to work well