### PR TITLE
Bumped keras autodoc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - travis_retry conda install portpicker
 
   # install tools for building the docs
-  - pip install mkdocs git+https://github.com/keras-team/keras-autodoc.git@v0.3.0
+  - pip install mkdocs keras-autodoc==0.4.0
 
   - pip install -e .[tests] --progress-bar off
 


### PR DESCRIPTION
Two new goodies coming with this release:

When the function/class/method signature is too long, it does a nice line break automatically:

```python
kerastuner.oracles.BayesianOptimization(objective, max_trials, num_initial_points=None, alpha=0.0001, beta=2.6, seed=None, hyperparameters=None, allow_new_entries=True, tune_new_entries=True)
```

becomes:

```python
kerastuner.oracles.BayesianOptimization(
    objective,
    max_trials,
    num_initial_points=None,
    alpha=0.0001,
    beta=2.6,
    seed=None,
    hyperparameters=None,
    allow_new_entries=True,
    tune_new_entries=True,
)
```

Also, the `[Source]` link was displayed before only next to classes. Now it is also displayed next to methods and functions.