### PR TITLE
Making the pypi page nicer.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,20 @@ from __future__ import absolute_import
 
 from setuptools import find_packages
 from setuptools import setup
+from pathlib import Path
 
+this_file = Path(__file__).resolve()
+readme = this_file.parent / 'README.md'
 version = '1.0.0'
 
 setup(
     name='keras-tuner',
     version=version,
     description='Hypertuner for Keras',
+    package_data={'': ['README.md']},
+    long_description=readme.read_text(encoding='utf-8'),
+    long_description_content_type='text/markdown',
+    url='https://github.com/keras-team/keras-tuner',
     author='The Keras Tuner authors',
     author_email='kerastuner@google.com',
     license='Apache License 2.0',
@@ -46,5 +53,15 @@ setup(
                   'pytest-xdist',
                   'pytest-cov'],
     },
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',
+        'Operating System :: Unix',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: MacOS',
+        'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Software Development'
+    ],
     packages=find_packages(exclude=('tests',))
 )


### PR DESCRIPTION
Currently the page https://pypi.org/project/keras-tuner/ is a bit empty. This PR will fill it with the readme and tags once the next release is uploaded.