### PR TITLE
Fix for multi-execution Tuner: ensure callbacks are run each execution

### DIFF
--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -79,13 +79,13 @@ class MultiExecutionTuner(tuner_module.Tuner):
             mode=self.oracle.objective.direction,
             save_best_only=True,
             save_weights_only=True)
+        original_callbacks = fit_kwargs.pop('callbacks', [])
 
         # Run the training process multiple times.
         metrics = collections.defaultdict(list)
         for execution in range(self.executions_per_trial):
             fit_kwargs = copy.copy(fit_kwargs)
-            callbacks = fit_kwargs.pop('callbacks', [])
-            callbacks = self._deepcopy_callbacks(callbacks)
+            callbacks = self._deepcopy_callbacks(original_callbacks)
             self._configure_tensorboard_dir(callbacks, trial.trial_id, execution)
             callbacks.append(tuner_utils.TunerCallback(self, trial))
             # Only checkpoint the best epoch across all executions.

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -146,14 +146,15 @@ class Tuner(base_tuner.BaseTuner):
                 trial_id, epoch - self._save_n_checkpoints)
 
     def load_model(self, trial):
-        model = self.hypermodel.build(trial.hyperparameters)
-        # Reload best checkpoint. The Oracle scores the Trial and also
-        # indicates at what epoch the best value of the objective was
-        # obtained.
-        best_epoch = trial.best_step
-        model.load_weights(self._get_checkpoint_fname(
-            trial.trial_id, best_epoch))
-        return model
+        with hm_module.maybe_distribute(self.distribution_strategy):
+            model = self.hypermodel.build(trial.hyperparameters)
+            # Reload best checkpoint. The Oracle scores the Trial and also
+            # indicates at what epoch the best value of the objective was
+            # obtained.
+            best_epoch = trial.best_step
+            model.load_weights(self._get_checkpoint_fname(
+                trial.trial_id, best_epoch))
+            return model
 
     def on_epoch_begin(self, trial, model, epoch, logs=None):
         """A hook called at the start of every epoch.

--- a/tests/kerastuner/engine/base_tuner_test.py
+++ b/tests/kerastuner/engine/base_tuner_test.py
@@ -101,9 +101,8 @@ def test_simple_sklearn_tuner(tmp_dir):
                 return pickle.load(f)
 
     def sklearn_build_fn(hp):
-        penalty = hp.Choice('penalty', ['l1', 'l2'])
         c = hp.Float('c', 1e-4, 10)
-        return linear_model.LogisticRegression(penalty=penalty, C=c)
+        return linear_model.LogisticRegression(C=c)
 
     tuner = SimpleSklearnTuner(
         oracle=kerastuner.tuners.randomsearch.RandomSearchOracle(

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -250,3 +250,25 @@ def test_error_on_unknown_objective_direction(tmp_dir):
             objective='custom_metric',
             max_trials=2,
             directory=tmp_dir)
+
+
+def test_callbacks_run_each_execution(tmp_dir):
+    callback_instances = set()
+
+    class LoggingCallback(keras.callbacks.Callback):
+
+        def on_train_begin(self, logs):
+            callback_instances.add(id(self))
+
+    logging_callback = LoggingCallback()
+    tuner = kerastuner.tuners.RandomSearch(
+        hypermodel=build_model,
+        objective='val_accuracy',
+        max_trials=2,
+        executions_per_trial=3,
+        directory=tmp_dir)
+    tuner.search(TRAIN_INPUTS, TRAIN_TARGETS,
+                 validation_data=(VAL_INPUTS, VAL_TARGETS),
+                 callbacks=[logging_callback])
+
+    assert len(callback_instances) == 6


### PR DESCRIPTION
Previously the callbacks were only running for the first execution because they were popped from the `fit_kwargs` each execution