### PR TITLE
Using docker to run the ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   # code below is taken from https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=3.6 .
+  - docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=$TRAVIS_PYTHON_VERSION .
 
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: trusty
 language: python
+services:
+  - docker
 python:
   - "2.7"
   - "3.6"
@@ -11,39 +13,14 @@ install:
   # code below is taken from https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  - travis_retry conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
-  - source activate test-environment
-
-  # set library path
-  - export LD_LIBRARY_PATH=$HOME/miniconda/envs/test-environment/lib/:$LD_LIBRARY_PATH
-
-    # install pydot for visualization tests
-  - travis_retry conda install -q $MKL pydot graphviz $PIL
-
-    # install portpicker for mock distribution framework.
-  - travis_retry conda install portpicker
-
-  - pip install -e .[tests] --progress-bar off
+  - docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=3.6 .
 
 # command to run tests
 script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/integration_tests;
+      docker run test_image py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "FLAKE8" ]]; then
-      flake8;
+      docker run test_image flake8;
     else
-      PYTHONPATH=$PWD:$PYTHONPATH py.test tests/kerastuner --cov-config .coveragerc --cov=kerastuner;
+      docker run test_image py.test tests/kerastuner --cov-config .coveragerc --cov=kerastuner;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ install:
 # command to run tests
 script:
   - if [[ "$TEST_MODE" == "INTEGRATION_TESTS" ]]; then
-      docker run test_image py.test tests/integration_tests;
+      docker run -t test_image py.test tests/integration_tests;
     elif [[ "$TEST_MODE" == "FLAKE8" ]]; then
-      docker run test_image flake8;
+      docker run -t test_image flake8;
     else
-      docker run test_image py.test tests/kerastuner --cov-config .coveragerc --cov=kerastuner;
+      docker run -t test_image py.test tests/kerastuner --cov-config .coveragerc --cov=kerastuner;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ env:
   - TRAVIS=True TEST_MODE=FLAKE8
   - TRAVIS=True TEST_MODE=TF2
 install:
-  # code below is taken from https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/use-conda-with-travis-ci.html
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
   - docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=$TRAVIS_PYTHON_VERSION .
 
 # command to run tests

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,8 +1,5 @@
 ARG PY_VERSION=3.6
 FROM python:${PY_VERSION}
-ARG PY_VERSION=3.6
-
-RUN if [ "${PY_VERSION}" = "3.6" ]; then pip install mkdocs ; fi
 
 RUN pip install tensorflow \
                 future \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,8 +1,7 @@
 ARG PY_VERSION=3.6
 FROM python:${PY_VERSION}
-
 ARG PY_VERSION=3.6
-RUN echo ${PY_VERSION}
+
 RUN if [ "${PY_VERSION}" = "3.6" ]; then pip install mkdocs ; fi
 
 RUN pip install tensorflow>=2.0.0-beta1 \

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,27 @@
+ARG PY_VERSION=3.6
+FROM python:${PY_VERSION}
+
+ARG PY_VERSION=3.6
+RUN echo ${PY_VERSION}
+RUN if [ "${PY_VERSION}" = "3.6" ]; then pip install mkdocs ; fi
+
+RUN pip install tensorflow>=2.0.0-beta1 \
+                future \
+                numpy \
+                tabulate \
+                terminaltables \
+                colorama \
+                tqdm \
+                requests \
+                scipy \
+                scikit-learn \
+                pytest \
+                flake8 \
+                mock \
+                portpicker \
+                pytest-xdist \
+                pytest-cov
+
+COPY ./ /keras-tuner
+WORKDIR /keras-tuner
+RUN pip install -e .[tests] --progress-bar off

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,7 +4,7 @@ ARG PY_VERSION=3.6
 
 RUN if [ "${PY_VERSION}" = "3.6" ]; then pip install mkdocs ; fi
 
-RUN pip install tensorflow>=2.0.0-beta1 \
+RUN pip install tensorflow \
                 future \
                 numpy \
                 tabulate \


### PR DESCRIPTION
It provides easy steps to reproduce whatever happens on travis ci locally.

It will help newcomers to run the test as well as ensure we can debug locally whatever happens in the CI.

The Dockerfile has been optimized for using the cache as much as possible. Locally, we'll benefit from it. Unfortunately, in travis-ci, the cache isn't saved from run to run.  This might be solved in the future by using `docker buildx`, but for the moment, the build times are acceptable.

For example, if you want to run the integration tests locally, either do it yourself by installing python, pytest, etc... or if you have docker, just do:

```bash
docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=3.6 .
docker run -t test_image py.test tests/integration_tests
```
