### PR TITLE
Added CI for windows.

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -9,17 +9,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-
     - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
     - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          pip install tensorflow
-          pip install -e .[tests]
-
+      run: |
+        python -m pip install --upgrade pip
+        pip install tensorflow
+        pip install -e .[tests]
     - name: Run tests
       run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow
+        pip install tensorflow keras_autodoc
         pip install -e .[tests]
     - name: Run tests
       run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -1,0 +1,25 @@
+name: Unit testing on Windows
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+    - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install tensorflow
+          pip install -e .[tests]
+
+    - name: Run tests
+      run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install
       run: |
         python -m pip install --upgrade pip

--- a/tests/kerastuner_docs_test.py
+++ b/tests/kerastuner_docs_test.py
@@ -1,15 +1,15 @@
-from kerastuner_docs import autogen
+from docs.autogen import generate
 import pytest
 import pathlib
 
 
 def test_docs_in_custom_destination_dir(tmpdir):
     tmpdir = pathlib.Path(tmpdir)
-    autogen.generate(tmpdir)
+    generate(tmpdir)
     assert (tmpdir / 'examples').is_dir()
     assert (tmpdir / 'tutorials').is_dir()
     assert (tmpdir / 'documentation').is_dir()
-    assert 'An hyperparameter tuner' in (tmpdir / 'index.md').read_text()
+    assert 'hyperparameter tuning' in (tmpdir / 'index.md').read_text()
     tuners_file = tmpdir / 'documentation' / 'tuners.md'
     assert 'Random search tuner' in tuners_file.read_text()
 


### PR DESCRIPTION
For this to work, I believe a project collaborator must click on the tab "Actions" and enable Github actions.

The support for windows on travis CI isn't very good. This is why I picked github actions for running the windows build. Similarly to travis, we won't pay as we're on the open source plan.

I also fixed the docs tests to make the windows CI work. 

On my fork, the windows test is passing. See the logs here: https://github.com/gabrieldemarmiesse/keras-tuner/commit/cf2dc1938efe8e35e82c97ba76daf95cfcb8ae38/checks?check_suite_id=365260325