### PR TITLE
resolve the ValueError. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ results faster, you could set `executions_per_trial=1` (single round of training
 ```python
 tuner = RandomSearch(
     build_model,
-    objective='val_accuracy',
+    objective='val_acc',
     max_trials=5,
     executions_per_trial=3,
     directory='my_dir',
@@ -178,7 +178,7 @@ hypermodel = MyHyperModel(num_classes=10)
 
 tuner = RandomSearch(
     hypermodel,
-    objective='val_accuracy',
+    objective='val_acc',
     max_trials=10,
     directory='my_dir',
     project_name='helloworld')
@@ -202,7 +202,7 @@ hypermodel = HyperResNet(input_shape=(128, 128, 3), num_classes=10)
 
 tuner = Hyperband(
     hypermodel,
-    objective='val_accuracy',
+    objective='val_acc',
     max_epochs=40,
     directory='my_dir',
     project_name='helloworld')
@@ -281,7 +281,7 @@ tuner = Hyperband(
     hypermodel,
     hyperparameters=hp,
     tune_new_entries=True,
-    objective='val_accuracy',
+    objective='val_acc',
     max_epochs=40,
     directory='my_dir',
     project_name='helloworld')

--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -43,7 +43,7 @@ def build_model(hp):
 
 tuner = RandomSearch(
     build_model,
-    objective='val_accuracy',
+    objective='val_acc',
     max_trials=5,
     executions_per_trial=3,
     directory='test_dir')
@@ -64,7 +64,7 @@ tuner.results_summary()
 
 tuner = RandomSearch(
     build_model,
-    objective='val_accuracy',
+    objective='val_acc',
     loss=keras.losses.SparseCategoricalCrossentropy(name='my_loss'),
     metrics=['accuracy', 'mse'],
     max_trials=5,
@@ -103,7 +103,7 @@ class MyHyperModel(HyperModel):
 
 tuner = RandomSearch(
     MyHyperModel(img_size=(28, 28), num_classes=10),
-    objective='val_accuracy',
+    objective='val_acc',
     max_trials=5,
     directory='test_dir')
 
@@ -144,7 +144,7 @@ tuner = RandomSearch(
     max_trials=5,
     hyperparameters=hp,
     tune_new_entries=True,
-    objective='val_accuracy')
+    objective='val_acc')
 
 tuner.search(x=x,
              y=y,
@@ -165,7 +165,7 @@ tuner = RandomSearch(
     max_trials=5,
     hyperparameters=hp,
     tune_new_entries=True,
-    objective='val_accuracy')
+    objective='val_acc')
 
 tuner.search(x=x,
              y=y,
@@ -202,7 +202,7 @@ tuner = RandomSearch(
     max_trials=5,
     hyperparameters=hp,
     allow_new_entries=False,
-    objective='val_accuracy')
+    objective='val_acc')
 
 tuner.search(x=x,
              y=y,


### PR DESCRIPTION
ValueError: Objective value missing in metrics reported to the Oracle, expected: ['val_accuracy'], found: dict_keys(['loss', 'acc', 'val_loss', 'val_acc'])