### PR TITLE
Download tf-cpu instead of tf-gpu

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow keras_autodoc
+        pip install tensorflow-cpu keras_autodoc
         pip install -e .[tests]
     - name: Run tests
       run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,7 +1,7 @@
 ARG PY_VERSION=3.6
 FROM python:${PY_VERSION}
 
-RUN pip install tensorflow \
+RUN pip install tensorflow-cpu \
                 future \
                 numpy \
                 tabulate \


### PR DESCRIPTION
tensorflow gpu is ~400MB and tensorflow cpu is ~100MB. This should speed up the install in the CI.