### PR TITLE
Load mnist before starting the tests.

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow keras_autodoc
+        python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"
         pip install -e .[tests]
     - name: Run tests
       run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - TRAVIS=True TEST_MODE=FLAKE8
   - TRAVIS=True TEST_MODE=TF2
 install:
-  - docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=$TRAVIS_PYTHON_VERSION .
+  - travis_retry docker build -f tests/Dockerfile -t test_image --build-arg PY_VERSION=$TRAVIS_PYTHON_VERSION .
 
 # command to run tests
 script:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -18,6 +18,8 @@ RUN pip install tensorflow \
                 pytest-xdist \
                 pytest-cov
 
+RUN python -c "import tensorflow as tf; tf.keras.datasets.mnist.load_data()"
+
 COPY ./ /keras-tuner
 WORKDIR /keras-tuner
 RUN pip install -e .[tests] --progress-bar off


### PR DESCRIPTION
We have some issues with downloading mnist during the tests. I propose here to make it a separate step so that it becomes more visible if the error comes from here in the CI. I added the retry on travis in case the connection breaks.