### PR TITLE
update to fix issue #224

### DIFF
--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -76,6 +76,9 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         self._tried_so_far = set()
         self._max_collisions = 20
         self._random_state = np.random.RandomState(self.seed)
+        self.gpr = self.make_gpr()
+        
+    def make_gpr(self):
         self.gpr = gaussian_process.GaussianProcessRegressor(
             kernel=gaussian_process.kernels.Matern(nu=2.5),
             n_restarts_optimizer=20,
@@ -154,9 +157,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         self._seed_state = state['seed_state']
         self._tried_so_far = set(state['tried_so_far'])
         self._max_collisions = state['max_collisions']
-        self.gpr = gaussian_process.GaussianProcessRegressor(
-            kernel=gaussian_process.kernels.ConstantKernel(1.0),
-            alpha=self.alpha)
+        self.gpr = self.make_gpr()
 
     def _random_trial(self):
         """Fill a given hyperparameter space with values.


### PR DESCRIPTION
Put the GPR initialization code in one function and then add the wrapper to BayesianOptimizationOracle init and load as they should both be creating and loading the same base GPR instance. #224 