### PR TITLE
Reimplementation of support for conditional parameters

### DIFF
--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -68,7 +68,7 @@ class BaseTuner(stateful.Stateful):
             raise ValueError('Expected oracle to be '
                              'an instance of Oracle, got: %s' % (oracle,))
         self.oracle = oracle
-        self.oracle.set_project_dir(
+        self.oracle._set_project_dir(
             self.directory, self.project_name, overwrite=overwrite)
 
         # Run in distributed mode.

--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -68,7 +68,7 @@ class BaseTuner(stateful.Stateful):
             raise ValueError('Expected oracle to be '
                              'an instance of Oracle, got: %s' % (oracle,))
         self.oracle = oracle
-        self.oracle._set_project_dir(
+        self.oracle.set_project_dir(
             self.directory, self.project_name, overwrite=overwrite)
 
         # Run in distributed mode.

--- a/kerastuner/engine/conditions.py
+++ b/kerastuner/engine/conditions.py
@@ -71,16 +71,16 @@ class Condition(object):
     @classmethod
     def from_proto(self, proto):
         kind = proto.WhichOneof('kind')
-        if kind == 'is_in':
-            is_in = getattr(proto, kind)
-            name = is_in.name
-            values = is_in.values
+        if kind == 'parent':
+            parent = getattr(proto, kind)
+            name = parent.name
+            values = parent.values
             values = [getattr(v, v.WhichOneof('kind')) for v in values]
-            return IsIn(name=name, values=values)
+            return Parent(name=name, values=values)
         raise ValueError('Unrecognized condition of type: {}'.format(kind))
 
 
-class IsIn(Condition):
+class Parent(Condition):
     """Condition that checks a value is equal to one of a list of values.
 
     This object can be passed to a `HyperParameter` to specify that this
@@ -91,7 +91,7 @@ class IsIn(Condition):
 
     ```
     a = Choice('model', ['linear', 'dnn'])
-    b = Int('num_layers', 5, 10, conditions=[kt.conditions.OneOf('a', ['dnn'])])
+    b = Int('num_layers', 5, 10, conditions=[kt.conditions.Parent('a', ['dnn'])])
     ```
 
     # Arguments:
@@ -120,7 +120,7 @@ class IsIn(Condition):
         return (self.name in values and values[self.name] in self.values)
 
     def __eq__(self, other):
-        return (isinstance(other, IsIn) and
+        return (isinstance(other, Parent) and
                 other.name == self.name and
                 other.values == self.values)
 
@@ -137,7 +137,7 @@ class IsIn(Condition):
             values = [kerastuner_pb2.Value(float_value=v) for v in self.values]
 
         return kerastuner_pb2.Condition(
-            is_in=kerastuner_pb2.Condition.IsIn(
+            parent=kerastuner_pb2.Condition.Parent(
                 name=self.name,
                 values=values))
 

--- a/kerastuner/engine/conditions.py
+++ b/kerastuner/engine/conditions.py
@@ -1,0 +1,113 @@
+# Copyright 2019 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"HyperParameters logic."
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import six
+
+from ..protos import kerastuner_pb2
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Condition(object):
+    """Abstract condition for a conditional hyperparameter.
+
+    Subclasses of this object can be passed to a `HyperParameter` to
+    specify that this condition must be met in order for that hyperparameter
+    to be considered active for the `Trial`.
+
+    Example:
+
+    ```
+    condition = kt.conditions.OneOf('a', 'dnn')
+
+    a = Choice('model', ['linear', 'dnn'])
+    b = Int('num_layers', 5, 10, conditions=[condition])
+    ```
+    """
+
+    @abc.abstractmethod
+    def is_active(self, values):
+        """Whether this condition should be considered active.
+
+        Determines whether this condition is true for the current `Trial`.
+
+        # Arguments:
+            values: Dict. The active values for this `Trial`. Keys are the
+               names of the hyperparameters.
+
+        # Returns:
+            bool.
+        """
+        raise NotImplementedError('Must be implemented in subclasses.')
+
+    @abc.abstractmethod
+    def __eq__(self, other):
+        raise NotImplementedError('Must be implemented in subclasses.')
+
+    @abc.abstractmethod
+    def get_config(self):
+        raise NotImplementedError('Must be implemented in subclasses.')
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
+
+class OneOf(Condition):
+    """Condition that checks a value is equal to one of a list of values.
+
+    This object can be passed to a `HyperParameter` to specify that this
+    condition must be met in order for that hyperparameter to be considered
+    active for the `Trial`.
+
+    Example:
+
+    ```
+    a = Choice('model', ['linear', 'dnn'])
+    b = Int('num_layers', 5, 10, conditions=[kt.conditions.OneOf('a', ['dnn'])])
+    ```
+
+    # Arguments:
+        name: The name of a `HyperParameter`.
+        values: Values for which the `HyperParameter` this object is
+            passed to should be considered active.
+    """
+    def __init__(self, name, values):
+        self.name = name
+        self.values = _to_list(values)
+
+    def is_active(self, values):
+        return (self.name in values and values[self.name] in self.values)
+
+    def __eq__(self, other):
+        return (isinstance(other, OneOf) and
+                other.name == self.name and
+                other.values == self.values)
+
+    def get_config(self):
+        return {'name': self.name,
+                'values': self.values}
+
+
+def _to_list(values):
+    if isinstance(values, list):
+        return values
+    if isinstance(values, tuple):
+        return list(values)
+    return [values]

--- a/kerastuner/engine/conditions.py
+++ b/kerastuner/engine/conditions.py
@@ -34,9 +34,9 @@ class Condition(object):
     Example:
 
     ```
-    condition = kt.conditions.OneOf('a', 'dnn')
 
     a = Choice('model', ['linear', 'dnn'])
+    condition = kt.conditions.Parent(name='a', value=['dnn'])
     b = Int('num_layers', 5, 10, conditions=[condition])
     ```
     """

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -571,7 +571,7 @@ class HyperParameters(object):
                 '`HyperParameter` named: ' + parent_name + ' '
                 'not defined.')
 
-        self._conditions.append(conditions_mod.IsIn(parent_name, parent_values))
+        self._conditions.append(conditions_mod.Parent(parent_name, parent_values))
         try:
             yield
         finally:
@@ -985,7 +985,7 @@ def deserialize(config):
     # have to enumerate them manually here.
     objects = [HyperParameter, Fixed, Float, Int, Choice,
                Boolean, HyperParameters, conditions_mod.Condition,
-               conditions_mod.IsIn]
+               conditions_mod.Parent]
     for obj in objects:
         if isinstance(config, obj):
             return config  # Already deserialized.

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -618,7 +618,7 @@ class HyperParameters(object):
             if self._conditions_are_active(hp.conditions):
                 return self.values[hp.name]
             return None  # Ensures inactive values are not relied on by user.
-        return self.register(hp)
+        return self._register(hp)
 
     def _register(self, hyperparameter):
         """Registers a `HyperParameter` into this container."""

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -297,7 +297,7 @@ class Oracle(stateful.Stateful):
         self.hyperparameters = hp_module.HyperParameters.from_config(
             state['hyperparameters'])
 
-    def set_project_dir(self, directory, project_name, overwrite=False):
+    def _set_project_dir(self, directory, project_name, overwrite=False):
         """Sets the project directory and reloads the Oracle."""
         self._directory = directory
         self._project_name = project_name

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -229,21 +229,19 @@ class Oracle(stateful.Stateful):
         Args:
             hyperparameters: An updated HyperParameters object.
         """
-        ref_names = {hp.name for hp in self.hyperparameters.space}
-        new_hps = [hp for hp in hyperparameters.space
-                   if hp.name not in ref_names]
+        hps = hyperparameters.space
+        new_hps = []
+        for hp in hps:
+            if not self.hyperparameters._hp_exists(hp.name, hp.conditions):
+                new_hps.append(hp)
 
         if new_hps and not self.allow_new_entries:
             raise RuntimeError('`allow_new_entries` is `False`, but found '
                                'new entries {}'.format(new_hps))
-
         if not self.tune_new_entries:
             # New entries should always use the default value.
             return
-
-        for hp in new_hps:
-            self.hyperparameters.register(
-                hp.name, hp.__class__.__name__, hp.get_config())
+        self.hyperparameters.merge(new_hps)
 
     def get_trial(self, trial_id):
         """Returns the `Trial` specified by `trial_id`."""

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -243,7 +243,7 @@ class Oracle(stateful.Stateful):
         hps = hyperparameters.space
         new_hps = []
         for hp in hps:
-            if not self.hyperparameters._hp_exists(hp.name, hp.conditions):
+            if not self.hyperparameters._exists(hp.name, hp.conditions):
                 new_hps.append(hp)
 
         if new_hps and not self.allow_new_entries:

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -297,7 +297,7 @@ class Oracle(stateful.Stateful):
         self.hyperparameters = hp_module.HyperParameters.from_config(
             state['hyperparameters'])
 
-    def _set_project_dir(self, directory, project_name, overwrite=False):
+    def set_project_dir(self, directory, project_name, overwrite=False):
         """Sets the project directory and reloads the Oracle."""
         self._directory = directory
         self._project_name = project_name
@@ -387,7 +387,7 @@ class Oracle(stateful.Stateful):
             # Generate a set of random values.
             for hp in self.hyperparameters.space:
                 hps.merge([hp])
-                if hps.is_active(hp):
+                if hps.is_active(hp):  # Only active params in `values`.
                     hps.values[hp.name] = hp.random_sample(self._seed_state)
                     self._seed_state += 1
             values = hps.values

--- a/kerastuner/engine/oracle.py
+++ b/kerastuner/engine/oracle.py
@@ -21,6 +21,7 @@ import collections
 import json
 import hashlib
 import os
+import random
 import tensorflow as tf
 
 from .. import utils
@@ -53,6 +54,7 @@ class Oracle(stateful.Stateful):
         allow_new_entries: Whether the hypermodel is allowed
             to request hyperparameter entries not listed in
             `hyperparameters`.
+        seed: Int. Random seed.
     """
 
     def __init__(self,
@@ -60,7 +62,8 @@ class Oracle(stateful.Stateful):
                  max_trials=None,
                  hyperparameters=None,
                  allow_new_entries=True,
-                 tune_new_entries=True):
+                 tune_new_entries=True,
+                 seed=None):
         self.objective = _format_objective(objective)
         self.max_trials = max_trials
         if not hyperparameters:
@@ -84,6 +87,14 @@ class Oracle(stateful.Stateful):
         self.trials = {}
         # tuner_id -> Trial
         self.ongoing_trials = {}
+
+        self.seed = seed or random.randint(1, 1e4)
+        self._seed_state = self.seed
+        # Hashes of values tried so far.
+        self._tried_so_far = set()
+        # Maximum number of identical values that can be generated
+        # before we consider the space to be exhausted.
+        self._max_collisions = 5
 
         # Set in `BaseTuner` via `set_project_dir`.
         self.directory = None
@@ -363,6 +374,34 @@ class Oracle(stateful.Stateful):
         trial.save(os.path.join(
             self._get_trial_dir(trial_id),
             'trial.json'))
+
+    def _random_values(self):
+        """Fills the hyperparameter space with random values.
+
+        Returns:
+            A dictionary mapping parameter names to suggested values.
+        """
+        collisions = 0
+        while 1:
+            hps = hp_module.HyperParameters()
+            # Generate a set of random values.
+            for hp in self.hyperparameters.space:
+                hps.merge([hp])
+                if hps.is_active(hp):
+                    hps.values[hp.name] = hp.random_sample(self._seed_state)
+                    self._seed_state += 1
+            values = hps.values
+            # Keep trying until the set of values is unique,
+            # or until we exit due to too many collisions.
+            values_hash = self._compute_values_hash(values)
+            if values_hash in self._tried_so_far:
+                collisions += 1
+                if collisions > self._max_collisions:
+                    return None
+                continue
+            self._tried_so_far.add(values_hash)
+            break
+        return values
 
 
 def _format_objective(objective):

--- a/kerastuner/protos/kerastuner.proto
+++ b/kerastuner/protos/kerastuner.proto
@@ -41,6 +41,7 @@ message Float {
     double step = 4;
     Sampling sampling = 5;
     double default = 6;
+    repeated Condition conditions = 7;
 }
 
 message Int {
@@ -50,6 +51,7 @@ message Int {
     sint64 step = 4;
     Sampling sampling = 5;
     sint64 default = 6;
+    repeated Condition conditions = 7;
 }
 
 message Choice {
@@ -57,16 +59,19 @@ message Choice {
     repeated Value values = 2;
     Value default = 3;
     bool ordered = 4;
+    repeated Condition conditions = 5;
 }
 
 message Boolean {
     string name = 1;
     bool default = 2;
+    repeated Condition conditions = 3;
 }
 
 message Fixed {
     string name = 1;
-    Value value = 3;
+    Value value = 2;
+    repeated Condition conditions = 3;
 }
 
 message HyperParameters {
@@ -119,4 +124,17 @@ message Trial {
         int64 step = 2;
     }
     Score score = 5;
+}
+
+
+message Condition {
+
+    message IsIn {
+        string name = 1;
+        repeated Value values = 2;
+    }
+
+    oneof kind {
+        IsIn is_in = 1;
+    }
 }

--- a/kerastuner/protos/kerastuner.proto
+++ b/kerastuner/protos/kerastuner.proto
@@ -129,12 +129,12 @@ message Trial {
 
 message Condition {
 
-    message IsIn {
+    message Parent {
         string name = 1;
         repeated Value values = 2;
     }
 
     oneof kind {
-        IsIn is_in = 1;
+        Parent parent = 1;
     }
 }

--- a/kerastuner/protos/kerastuner_pb2.py
+++ b/kerastuner/protos/kerastuner_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='kerastuner',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"l\n\x05Value\x12\x13\n\tint_value\x18\x01 \x01(\x12H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x03 \x01(\tH\x00\x12\x17\n\rboolean_value\x18\x04 \x01(\x08H\x00\x42\x06\n\x04kind\"\x82\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\"\x80\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\"n\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.Value\x12\"\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\"(\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\"7\n\x05\x46ixed\x12\x0c\n\x04name\x18\x01 \x01(\t\x12 \n\x05value\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\"\xd8\x03\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x32\n\x06values\x18\x02 \x01(\x0b\x32\".kerastuner.HyperParameters.Values\x1a\xd1\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x12&\n\x0b\x66ixed_space\x18\x05 \x03(\x0b\x32\x11.kerastuner.Fixed\x1a\x8a\x01\n\x06Values\x12>\n\x06values\x18\x01 \x03(\x0b\x32..kerastuner.HyperParameters.Values.ValuesEntry\x1a@\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
+  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"l\n\x05Value\x12\x13\n\tint_value\x18\x01 \x01(\x12H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x03 \x01(\tH\x00\x12\x17\n\rboolean_value\x18\x04 \x01(\x08H\x00\x42\x06\n\x04kind\"\xad\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\xab\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\x99\x01\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.Value\x12\"\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\x12)\n\nconditions\x18\x05 \x03(\x0b\x32\x15.kerastuner.Condition\"S\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"b\n\x05\x46ixed\x12\x0c\n\x04name\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"\xd8\x03\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x32\n\x06values\x18\x02 \x01(\x0b\x32\".kerastuner.HyperParameters.Values\x1a\xd1\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x12&\n\x0b\x66ixed_space\x18\x05 \x03(\x0b\x32\x11.kerastuner.Fixed\x1a\x8a\x01\n\x06Values\x12>\n\x06values\x18\x01 \x03(\x0b\x32..kerastuner.HyperParameters.Values.ValuesEntry\x1a@\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"y\n\tCondition\x12+\n\x05is_in\x18\x01 \x01(\x0b\x32\x1a.kerastuner.Condition.IsInH\x00\x1a\x37\n\x04IsIn\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.ValueB\x06\n\x04kind*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
 )
 
 _SAMPLING = _descriptor.EnumDescriptor(
@@ -49,8 +49,8 @@ _SAMPLING = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1646,
-  serialized_end=1704,
+  serialized_start=1985,
+  serialized_end=2043,
 )
 _sym_db.RegisterEnumDescriptor(_SAMPLING)
 
@@ -88,8 +88,8 @@ _TRIALSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1706,
-  serialized_end=1796,
+  serialized_start=2045,
+  serialized_end=2135,
 )
 _sym_db.RegisterEnumDescriptor(_TRIALSTATUS)
 
@@ -211,6 +211,13 @@ _FLOAT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='kerastuner.Float.conditions', index=6,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -224,7 +231,7 @@ _FLOAT = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=161,
-  serialized_end=291,
+  serialized_end=334,
 )
 
 
@@ -277,6 +284,13 @@ _INT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='kerastuner.Int.conditions', index=6,
+      number=7, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -289,8 +303,8 @@ _INT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=294,
-  serialized_end=422,
+  serialized_start=337,
+  serialized_end=508,
 )
 
 
@@ -329,6 +343,13 @@ _CHOICE = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='kerastuner.Choice.conditions', index=4,
+      number=5, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -341,8 +362,8 @@ _CHOICE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=424,
-  serialized_end=534,
+  serialized_start=511,
+  serialized_end=664,
 )
 
 
@@ -367,6 +388,13 @@ _BOOLEAN = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='kerastuner.Boolean.conditions', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -379,8 +407,8 @@ _BOOLEAN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=536,
-  serialized_end=576,
+  serialized_start=666,
+  serialized_end=749,
 )
 
 
@@ -400,8 +428,15 @@ _FIXED = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='kerastuner.Fixed.value', index=1,
-      number=3, type=11, cpp_type=10, label=1,
+      number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='conditions', full_name='kerastuner.Fixed.conditions', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
@@ -417,8 +452,8 @@ _FIXED = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=578,
-  serialized_end=633,
+  serialized_start=751,
+  serialized_end=849,
 )
 
 
@@ -476,8 +511,8 @@ _HYPERPARAMETERS_SPACE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=758,
-  serialized_end=967,
+  serialized_start=974,
+  serialized_end=1183,
 )
 
 _HYPERPARAMETERS_VALUES_VALUESENTRY = _descriptor.Descriptor(
@@ -513,8 +548,8 @@ _HYPERPARAMETERS_VALUES_VALUESENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1044,
-  serialized_end=1108,
+  serialized_start=1260,
+  serialized_end=1324,
 )
 
 _HYPERPARAMETERS_VALUES = _descriptor.Descriptor(
@@ -543,8 +578,8 @@ _HYPERPARAMETERS_VALUES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=970,
-  serialized_end=1108,
+  serialized_start=1186,
+  serialized_end=1324,
 )
 
 _HYPERPARAMETERS = _descriptor.Descriptor(
@@ -580,8 +615,8 @@ _HYPERPARAMETERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=636,
-  serialized_end=1108,
+  serialized_start=852,
+  serialized_end=1324,
 )
 
 
@@ -618,8 +653,8 @@ _METRICOBSERVATION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1110,
-  serialized_end=1158,
+  serialized_start=1326,
+  serialized_end=1374,
 )
 
 
@@ -656,8 +691,8 @@ _METRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1160,
-  serialized_end=1246,
+  serialized_start=1376,
+  serialized_end=1462,
 )
 
 
@@ -694,8 +729,8 @@ _METRICSTRACKER_METRICSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1325,
-  serialized_end=1398,
+  serialized_start=1541,
+  serialized_end=1614,
 )
 
 _METRICSTRACKER = _descriptor.Descriptor(
@@ -724,8 +759,8 @@ _METRICSTRACKER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1249,
-  serialized_end=1398,
+  serialized_start=1465,
+  serialized_end=1614,
 )
 
 
@@ -762,8 +797,8 @@ _TRIAL_SCORE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1608,
-  serialized_end=1644,
+  serialized_start=1824,
+  serialized_end=1860,
 )
 
 _TRIAL = _descriptor.Descriptor(
@@ -820,8 +855,79 @@ _TRIAL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1401,
-  serialized_end=1644,
+  serialized_start=1617,
+  serialized_end=1860,
+)
+
+
+_CONDITION_ISIN = _descriptor.Descriptor(
+  name='IsIn',
+  full_name='kerastuner.Condition.IsIn',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='kerastuner.Condition.IsIn.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='values', full_name='kerastuner.Condition.IsIn.values', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1920,
+  serialized_end=1975,
+)
+
+_CONDITION = _descriptor.Descriptor(
+  name='Condition',
+  full_name='kerastuner.Condition',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='is_in', full_name='kerastuner.Condition.is_in', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_CONDITION_ISIN, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+    _descriptor.OneofDescriptor(
+      name='kind', full_name='kerastuner.Condition.kind',
+      index=0, containing_type=None, fields=[]),
+  ],
+  serialized_start=1862,
+  serialized_end=1983,
 )
 
 _VALUE.oneofs_by_name['kind'].fields.append(
@@ -837,10 +943,15 @@ _VALUE.oneofs_by_name['kind'].fields.append(
   _VALUE.fields_by_name['boolean_value'])
 _VALUE.fields_by_name['boolean_value'].containing_oneof = _VALUE.oneofs_by_name['kind']
 _FLOAT.fields_by_name['sampling'].enum_type = _SAMPLING
+_FLOAT.fields_by_name['conditions'].message_type = _CONDITION
 _INT.fields_by_name['sampling'].enum_type = _SAMPLING
+_INT.fields_by_name['conditions'].message_type = _CONDITION
 _CHOICE.fields_by_name['values'].message_type = _VALUE
 _CHOICE.fields_by_name['default'].message_type = _VALUE
+_CHOICE.fields_by_name['conditions'].message_type = _CONDITION
+_BOOLEAN.fields_by_name['conditions'].message_type = _CONDITION
 _FIXED.fields_by_name['value'].message_type = _VALUE
+_FIXED.fields_by_name['conditions'].message_type = _CONDITION
 _HYPERPARAMETERS_SPACE.fields_by_name['float_space'].message_type = _FLOAT
 _HYPERPARAMETERS_SPACE.fields_by_name['int_space'].message_type = _INT
 _HYPERPARAMETERS_SPACE.fields_by_name['choice_space'].message_type = _CHOICE
@@ -862,6 +973,12 @@ _TRIAL.fields_by_name['hyperparameters'].message_type = _HYPERPARAMETERS
 _TRIAL.fields_by_name['status'].enum_type = _TRIALSTATUS
 _TRIAL.fields_by_name['metrics'].message_type = _METRICSTRACKER
 _TRIAL.fields_by_name['score'].message_type = _TRIAL_SCORE
+_CONDITION_ISIN.fields_by_name['values'].message_type = _VALUE
+_CONDITION_ISIN.containing_type = _CONDITION
+_CONDITION.fields_by_name['is_in'].message_type = _CONDITION_ISIN
+_CONDITION.oneofs_by_name['kind'].fields.append(
+  _CONDITION.fields_by_name['is_in'])
+_CONDITION.fields_by_name['is_in'].containing_oneof = _CONDITION.oneofs_by_name['kind']
 DESCRIPTOR.message_types_by_name['Value'] = _VALUE
 DESCRIPTOR.message_types_by_name['Float'] = _FLOAT
 DESCRIPTOR.message_types_by_name['Int'] = _INT
@@ -873,6 +990,7 @@ DESCRIPTOR.message_types_by_name['MetricObservation'] = _METRICOBSERVATION
 DESCRIPTOR.message_types_by_name['MetricHistory'] = _METRICHISTORY
 DESCRIPTOR.message_types_by_name['MetricsTracker'] = _METRICSTRACKER
 DESCRIPTOR.message_types_by_name['Trial'] = _TRIAL
+DESCRIPTOR.message_types_by_name['Condition'] = _CONDITION
 DESCRIPTOR.enum_types_by_name['Sampling'] = _SAMPLING
 DESCRIPTOR.enum_types_by_name['TrialStatus'] = _TRIALSTATUS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -993,6 +1111,21 @@ Trial = _reflection.GeneratedProtocolMessageType('Trial', (_message.Message,), {
   })
 _sym_db.RegisterMessage(Trial)
 _sym_db.RegisterMessage(Trial.Score)
+
+Condition = _reflection.GeneratedProtocolMessageType('Condition', (_message.Message,), {
+
+  'IsIn' : _reflection.GeneratedProtocolMessageType('IsIn', (_message.Message,), {
+    'DESCRIPTOR' : _CONDITION_ISIN,
+    '__module__' : 'kerastuner.protos.kerastuner_pb2'
+    # @@protoc_insertion_point(class_scope:kerastuner.Condition.IsIn)
+    })
+  ,
+  'DESCRIPTOR' : _CONDITION,
+  '__module__' : 'kerastuner.protos.kerastuner_pb2'
+  # @@protoc_insertion_point(class_scope:kerastuner.Condition)
+  })
+_sym_db.RegisterMessage(Condition)
+_sym_db.RegisterMessage(Condition.IsIn)
 
 
 _HYPERPARAMETERS_VALUES_VALUESENTRY._options = None

--- a/kerastuner/protos/kerastuner_pb2.py
+++ b/kerastuner/protos/kerastuner_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='kerastuner',
   syntax='proto3',
   serialized_options=None,
-  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"l\n\x05Value\x12\x13\n\tint_value\x18\x01 \x01(\x12H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x03 \x01(\tH\x00\x12\x17\n\rboolean_value\x18\x04 \x01(\x08H\x00\x42\x06\n\x04kind\"\xad\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\xab\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\x99\x01\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.Value\x12\"\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\x12)\n\nconditions\x18\x05 \x03(\x0b\x32\x15.kerastuner.Condition\"S\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"b\n\x05\x46ixed\x12\x0c\n\x04name\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"\xd8\x03\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x32\n\x06values\x18\x02 \x01(\x0b\x32\".kerastuner.HyperParameters.Values\x1a\xd1\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x12&\n\x0b\x66ixed_space\x18\x05 \x03(\x0b\x32\x11.kerastuner.Fixed\x1a\x8a\x01\n\x06Values\x12>\n\x06values\x18\x01 \x03(\x0b\x32..kerastuner.HyperParameters.Values.ValuesEntry\x1a@\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"y\n\tCondition\x12+\n\x05is_in\x18\x01 \x01(\x0b\x32\x1a.kerastuner.Condition.IsInH\x00\x1a\x37\n\x04IsIn\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.ValueB\x06\n\x04kind*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
+  serialized_pb=_b('\n\"kerastuner/protos/kerastuner.proto\x12\nkerastuner\"l\n\x05Value\x12\x13\n\tint_value\x18\x01 \x01(\x12H\x00\x12\x15\n\x0b\x66loat_value\x18\x02 \x01(\x01H\x00\x12\x16\n\x0cstring_value\x18\x03 \x01(\tH\x00\x12\x17\n\rboolean_value\x18\x04 \x01(\x08H\x00\x42\x06\n\x04kind\"\xad\x01\n\x05\x46loat\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x01\x12\x11\n\tmax_value\x18\x03 \x01(\x01\x12\x0c\n\x04step\x18\x04 \x01(\x01\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x01\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\xab\x01\n\x03Int\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tmin_value\x18\x02 \x01(\x12\x12\x11\n\tmax_value\x18\x03 \x01(\x12\x12\x0c\n\x04step\x18\x04 \x01(\x12\x12&\n\x08sampling\x18\x05 \x01(\x0e\x32\x14.kerastuner.Sampling\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x06 \x01(\x12\x12)\n\nconditions\x18\x07 \x03(\x0b\x32\x15.kerastuner.Condition\"\x99\x01\n\x06\x43hoice\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.Value\x12\"\n\x07\x64\x65\x66\x61ult\x18\x03 \x01(\x0b\x32\x11.kerastuner.Value\x12\x0f\n\x07ordered\x18\x04 \x01(\x08\x12)\n\nconditions\x18\x05 \x03(\x0b\x32\x15.kerastuner.Condition\"S\n\x07\x42oolean\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65\x66\x61ult\x18\x02 \x01(\x08\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"b\n\x05\x46ixed\x12\x0c\n\x04name\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value\x12)\n\nconditions\x18\x03 \x03(\x0b\x32\x15.kerastuner.Condition\"\xd8\x03\n\x0fHyperParameters\x12\x30\n\x05space\x18\x01 \x01(\x0b\x32!.kerastuner.HyperParameters.Space\x12\x32\n\x06values\x18\x02 \x01(\x0b\x32\".kerastuner.HyperParameters.Values\x1a\xd1\x01\n\x05Space\x12&\n\x0b\x66loat_space\x18\x01 \x03(\x0b\x32\x11.kerastuner.Float\x12\"\n\tint_space\x18\x02 \x03(\x0b\x32\x0f.kerastuner.Int\x12(\n\x0c\x63hoice_space\x18\x03 \x03(\x0b\x32\x12.kerastuner.Choice\x12*\n\rboolean_space\x18\x04 \x03(\x0b\x32\x13.kerastuner.Boolean\x12&\n\x0b\x66ixed_space\x18\x05 \x03(\x0b\x32\x11.kerastuner.Fixed\x1a\x8a\x01\n\x06Values\x12>\n\x06values\x18\x01 \x03(\x0b\x32..kerastuner.HyperParameters.Values.ValuesEntry\x1a@\n\x0bValuesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12 \n\x05value\x18\x02 \x01(\x0b\x32\x11.kerastuner.Value:\x02\x38\x01\"0\n\x11MetricObservation\x12\r\n\x05value\x18\x01 \x03(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"V\n\rMetricHistory\x12\x33\n\x0cobservations\x18\x01 \x03(\x0b\x32\x1d.kerastuner.MetricObservation\x12\x10\n\x08maximize\x18\x02 \x01(\x08\"\x95\x01\n\x0eMetricsTracker\x12\x38\n\x07metrics\x18\x01 \x03(\x0b\x32\'.kerastuner.MetricsTracker.MetricsEntry\x1aI\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12(\n\x05value\x18\x02 \x01(\x0b\x32\x19.kerastuner.MetricHistory:\x02\x38\x01\"\xf3\x01\n\x05Trial\x12\x34\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1b.kerastuner.HyperParameters\x12\x10\n\x08trial_id\x18\x02 \x01(\t\x12\'\n\x06status\x18\x03 \x01(\x0e\x32\x17.kerastuner.TrialStatus\x12+\n\x07metrics\x18\x04 \x01(\x0b\x32\x1a.kerastuner.MetricsTracker\x12&\n\x05score\x18\x05 \x01(\x0b\x32\x17.kerastuner.Trial.Score\x1a$\n\x05Score\x12\r\n\x05value\x18\x01 \x01(\x02\x12\x0c\n\x04step\x18\x02 \x01(\x03\"~\n\tCondition\x12.\n\x06parent\x18\x01 \x01(\x0b\x32\x1c.kerastuner.Condition.ParentH\x00\x1a\x39\n\x06Parent\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x06values\x18\x02 \x03(\x0b\x32\x11.kerastuner.ValueB\x06\n\x04kind*:\n\x08Sampling\x12\x08\n\x04NONE\x10\x00\x12\n\n\x06LINEAR\x10\x01\x12\x07\n\x03LOG\x10\x02\x12\x0f\n\x0bREVERSE_LOG\x10\x03*Z\n\x0bTrialStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07RUNNING\x10\x01\x12\x08\n\x04IDLE\x10\x02\x12\x0b\n\x07INVALID\x10\x03\x12\x0b\n\x07STOPPED\x10\x04\x12\r\n\tCOMPLETED\x10\x05\x62\x06proto3')
 )
 
 _SAMPLING = _descriptor.EnumDescriptor(
@@ -49,8 +49,8 @@ _SAMPLING = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1985,
-  serialized_end=2043,
+  serialized_start=1990,
+  serialized_end=2048,
 )
 _sym_db.RegisterEnumDescriptor(_SAMPLING)
 
@@ -88,8 +88,8 @@ _TRIALSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2045,
-  serialized_end=2135,
+  serialized_start=2050,
+  serialized_end=2140,
 )
 _sym_db.RegisterEnumDescriptor(_TRIALSTATUS)
 
@@ -860,22 +860,22 @@ _TRIAL = _descriptor.Descriptor(
 )
 
 
-_CONDITION_ISIN = _descriptor.Descriptor(
-  name='IsIn',
-  full_name='kerastuner.Condition.IsIn',
+_CONDITION_PARENT = _descriptor.Descriptor(
+  name='Parent',
+  full_name='kerastuner.Condition.Parent',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='kerastuner.Condition.IsIn.name', index=0,
+      name='name', full_name='kerastuner.Condition.Parent.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='values', full_name='kerastuner.Condition.IsIn.values', index=1,
+      name='values', full_name='kerastuner.Condition.Parent.values', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -893,8 +893,8 @@ _CONDITION_ISIN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1920,
-  serialized_end=1975,
+  serialized_start=1923,
+  serialized_end=1980,
 )
 
 _CONDITION = _descriptor.Descriptor(
@@ -905,7 +905,7 @@ _CONDITION = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='is_in', full_name='kerastuner.Condition.is_in', index=0,
+      name='parent', full_name='kerastuner.Condition.parent', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -914,7 +914,7 @@ _CONDITION = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_CONDITION_ISIN, ],
+  nested_types=[_CONDITION_PARENT, ],
   enum_types=[
   ],
   serialized_options=None,
@@ -927,7 +927,7 @@ _CONDITION = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=1862,
-  serialized_end=1983,
+  serialized_end=1988,
 )
 
 _VALUE.oneofs_by_name['kind'].fields.append(
@@ -973,12 +973,12 @@ _TRIAL.fields_by_name['hyperparameters'].message_type = _HYPERPARAMETERS
 _TRIAL.fields_by_name['status'].enum_type = _TRIALSTATUS
 _TRIAL.fields_by_name['metrics'].message_type = _METRICSTRACKER
 _TRIAL.fields_by_name['score'].message_type = _TRIAL_SCORE
-_CONDITION_ISIN.fields_by_name['values'].message_type = _VALUE
-_CONDITION_ISIN.containing_type = _CONDITION
-_CONDITION.fields_by_name['is_in'].message_type = _CONDITION_ISIN
+_CONDITION_PARENT.fields_by_name['values'].message_type = _VALUE
+_CONDITION_PARENT.containing_type = _CONDITION
+_CONDITION.fields_by_name['parent'].message_type = _CONDITION_PARENT
 _CONDITION.oneofs_by_name['kind'].fields.append(
-  _CONDITION.fields_by_name['is_in'])
-_CONDITION.fields_by_name['is_in'].containing_oneof = _CONDITION.oneofs_by_name['kind']
+  _CONDITION.fields_by_name['parent'])
+_CONDITION.fields_by_name['parent'].containing_oneof = _CONDITION.oneofs_by_name['kind']
 DESCRIPTOR.message_types_by_name['Value'] = _VALUE
 DESCRIPTOR.message_types_by_name['Float'] = _FLOAT
 DESCRIPTOR.message_types_by_name['Int'] = _INT
@@ -1114,10 +1114,10 @@ _sym_db.RegisterMessage(Trial.Score)
 
 Condition = _reflection.GeneratedProtocolMessageType('Condition', (_message.Message,), {
 
-  'IsIn' : _reflection.GeneratedProtocolMessageType('IsIn', (_message.Message,), {
-    'DESCRIPTOR' : _CONDITION_ISIN,
+  'Parent' : _reflection.GeneratedProtocolMessageType('Parent', (_message.Message,), {
+    'DESCRIPTOR' : _CONDITION_PARENT,
     '__module__' : 'kerastuner.protos.kerastuner_pb2'
-    # @@protoc_insertion_point(class_scope:kerastuner.Condition.IsIn)
+    # @@protoc_insertion_point(class_scope:kerastuner.Condition.Parent)
     })
   ,
   'DESCRIPTOR' : _CONDITION,
@@ -1125,7 +1125,7 @@ Condition = _reflection.GeneratedProtocolMessageType('Condition', (_message.Mess
   # @@protoc_insertion_point(class_scope:kerastuner.Condition)
   })
 _sym_db.RegisterMessage(Condition)
-_sym_db.RegisterMessage(Condition.IsIn)
+_sym_db.RegisterMessage(Condition.Parent)
 
 
 _HYPERPARAMETERS_VALUES_VALUESENTRY._options = None

--- a/kerastuner/tuners/randomsearch.py
+++ b/kerastuner/tuners/randomsearch.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from ..engine import hyperparameters as hp_lib
 from ..engine import multi_execution_tuner
 from ..engine import oracle as oracle_module
 from ..engine import trial as trial_lib
@@ -87,11 +88,14 @@ class RandomSearchOracle(oracle_module.Oracle):
         """
         collisions = 0
         while 1:
+            hps = hp_lib.HyperParameters()
             # Generate a set of random values.
-            values = {}
             for p in self.hyperparameters.space:
-                values[p.name] = p.random_sample(self._seed_state)
-                self._seed_state += 1
+                hps.merge([p])
+                if hps.is_active(p):
+                    hps.values[p.name] = p.random_sample(self._seed_state)
+                    self._seed_state += 1
+            values = hp.values
             # Keep trying until the set of values is unique,
             # or until we exit due to too many collisions.
             values_hash = self._compute_values_hash(values)

--- a/kerastuner/tuners/randomsearch.py
+++ b/kerastuner/tuners/randomsearch.py
@@ -18,12 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ..engine import hyperparameters as hp_lib
 from ..engine import multi_execution_tuner
 from ..engine import oracle as oracle_module
 from ..engine import trial as trial_lib
-
-import random
 
 
 class RandomSearchOracle(oracle_module.Oracle):
@@ -64,15 +61,8 @@ class RandomSearchOracle(oracle_module.Oracle):
             max_trials=max_trials,
             hyperparameters=hyperparameters,
             tune_new_entries=tune_new_entries,
-            allow_new_entries=allow_new_entries)
-        self.seed = seed or random.randint(1, 1e4)
-        # Incremented at every call to `populate_space`.
-        self._seed_state = self.seed
-        # Hashes of values tried so far.
-        self._tried_so_far = set()
-        # Maximum number of identical values that can be generated
-        # before we consider the space to be exhausted.
-        self._max_collisions = 5
+            allow_new_entries=allow_new_entries,
+            seed=seed)
 
     def _populate_space(self, _):
         """Fill the hyperparameter space with values.
@@ -86,44 +76,12 @@ class RandomSearchOracle(oracle_module.Oracle):
             is the TrialStatus that should be returned for this trial (one
             of "RUNNING", "IDLE", or "STOPPED").
         """
-        collisions = 0
-        while 1:
-            hps = hp_lib.HyperParameters()
-            # Generate a set of random values.
-            for p in self.hyperparameters.space:
-                hps.merge([p])
-                if hps.is_active(p):
-                    hps.values[p.name] = p.random_sample(self._seed_state)
-                    self._seed_state += 1
-            values = hp.values
-            # Keep trying until the set of values is unique,
-            # or until we exit due to too many collisions.
-            values_hash = self._compute_values_hash(values)
-            if values_hash in self._tried_so_far:
-                collisions += 1
-                if collisions > self._max_collisions:
-                    return {'status': trial_lib.TrialStatus.STOPPED,
-                            'values': None}
-                continue
-            self._tried_so_far.add(values_hash)
-            break
+        values = self._random_values()
+        if values is None:
+            return {'status': trial_lib.TrialStatus.STOPPED,
+                    'values': None}
         return {'status': trial_lib.TrialStatus.RUNNING,
                 'values': values}
-
-    def get_state(self):
-        state = super(RandomSearchOracle, self).get_state()
-        state.update({
-            'seed': self.seed,
-            'seed_state': self._seed_state,
-            'tried_so_far': list(self._tried_so_far),
-        })
-        return state
-
-    def set_state(self, state):
-        super(RandomSearchOracle, self).set_state(state)
-        self.seed = state['seed']
-        self._seed_state = state['seed_state']
-        self._tried_so_far = set(state['tried_so_far'])
 
 
 class RandomSearch(multi_execution_tuner.MultiExecutionTuner):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,9 +7,7 @@ filterwarnings =
     ignore::PendingDeprecationWarning
     ignore::FutureWarning
 
-addopts=-v
-        -n 2
-        --durations=10
+addopts=-vv
 
 # Do not run tests in the build folder
 norecursedirs= build

--- a/tests/kerastuner/tuners/sklearn_test.py
+++ b/tests/kerastuner/tuners/sklearn_test.py
@@ -202,4 +202,4 @@ def test_sklearn_real_data(tmp_dir):
     worst_model_score = worst_model.score(x_test, y_test)
 
     assert best_model_score > 0.8
-    assert best_model_score > worst_model_score
+    assert best_model_score >= worst_model_score


### PR DESCRIPTION
This design should be:

- much cleaner
- more robust
- more flexible

The only backwards-incompatible changes:

- `HyperParameters.register` is removed: This method was probably not meant to be public. It tries to register a `HyperParameter` from a name, class name, and config.
- `HyperParameters.values` now only contains active hyperparameters, brining it in-line with `HyperParameters.get` and other ways of accessing hyperparameters

Overview of changes:

- `Hyperparameter`s now track their conditions themselves via a list of `Condition`s. This simplifies the logic for checking whether a hyperparameter is active in the `HyperParameters` class, and makes it easier to trace back to a root parameter
- `Hyperparameters.values` now contains only active hyperparameters
- Simplifications of `Hyperparameters` class that this enables
- Oracles share a common `_random_values` method, that checks for collisions in a way that is now aware of conditional parameters
- Bayesian oracle sets all inactive parameters to their defaults during the gaussian process optimization, to avoid confusing the optimizer