### PR TITLE
Pass down tuner_id from Tuner class constructor

### DIFF
--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -67,6 +67,7 @@ class Tuner(base_tuner.BaseTuner):
             by this Tuner.
         logger: Optional. Instance of Logger class, used for streaming data
             to Cloud Service for monitoring.
+        tuner_id: Optional. If set, use this value as the id of this Tuner.
         overwrite: Bool, default `False`. If `False`, reloads an existing project
             of the same name if one is found. Otherwise, overwrites the project.
     """
@@ -106,6 +107,8 @@ class Tuner(base_tuner.BaseTuner):
 
         # Save only the last N checkpoints.
         self._save_n_checkpoints = 10
+
+        self.tuner_id = tuner_id or self.tuner_id
 
     def run_trial(self, trial, *fit_args, **fit_kwargs):
         """Evaluates a set of hyperparameter values.


### PR DESCRIPTION
There was an unused, undocumented named constructor `tuner_id` arg to Tuner class. I believe this was meant to override tuner_id, if given. 