### PR TITLE
add on_fit_begin for AutoKeras to override

### DIFF
--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -93,6 +93,8 @@ class MultiExecutionTuner(tuner_module.Tuner):
             copied_fit_kwargs['callbacks'] = callbacks
 
             model = self.hypermodel.build(trial.hyperparameters)
+            self._on_train_begin(model, trial.hyperparameters,
+                                 *fit_args, **copied_fit_kwargs)
             history = model.fit(*fit_args, **copied_fit_kwargs)
             for metric, epoch_values in history.history.items():
                 if self.oracle.objective.direction == 'min':

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -145,10 +145,10 @@ class Tuner(base_tuner.BaseTuner):
         copied_fit_kwargs['callbacks'] = callbacks
 
         model = self.hypermodel.build(trial.hyperparameters)
-        self.on_fit_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
+        self.on_train_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
 
-    def on_fit_begin(model, hp, *fit_args, **fit_kwargs):
+    def on_train_begin(model, hp, *fit_args, **fit_kwargs):
         # AutoKeras will override this function to support preprocessing layers and
         # fit args tuning.
         pass

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -145,12 +145,18 @@ class Tuner(base_tuner.BaseTuner):
         copied_fit_kwargs['callbacks'] = callbacks
 
         model = self.hypermodel.build(trial.hyperparameters)
-        self.on_train_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
+        self._on_train_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
 
-    def on_train_begin(model, hp, *fit_args, **fit_kwargs):
-        # AutoKeras will override this function to support preprocessing layers and
-        # fit args tuning.
+    def _on_train_begin(model, hp, *fit_args, **fit_kwargs):
+        """For AutoKeras to override.
+
+        DO NOT REMOVE this function until Keras Tuner support preprocessing layers.
+        AutoKeras overrides the function to support preprocessing layers and tuning
+        of other fit_args and fit_kwargs.
+
+        This is different from the callback's on_train_begin.
+        """
         pass
 
     def save_model(self, trial_id, model, step=0):

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -145,7 +145,8 @@ class Tuner(base_tuner.BaseTuner):
         copied_fit_kwargs['callbacks'] = callbacks
 
         model = self.hypermodel.build(trial.hyperparameters)
-        self._on_train_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
+        self._on_train_begin(model, trial.hyperparameters,
+                             *fit_args, **copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
 
     def _on_train_begin(model, hp, *fit_args, **fit_kwargs):

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -145,7 +145,13 @@ class Tuner(base_tuner.BaseTuner):
         copied_fit_kwargs['callbacks'] = callbacks
 
         model = self.hypermodel.build(trial.hyperparameters)
+        self.on_fit_begin(model, trial.hyperparameters, *fit_args, **copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
+
+    def on_fit_begin(model, hp, *fit_args, **fit_kwargs):
+        # AutoKeras will override this function to support preprocessing layers and
+        # fit args tuning.
+        pass
 
     def save_model(self, trial_id, model, step=0):
         epoch = step

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -272,3 +272,7 @@ def test_callbacks_run_each_execution(tmp_dir):
                  callbacks=[logging_callback])
 
     assert len(callback_instances) == 6
+
+
+def test_on_train_begin_existence(tmp_dir):
+    assert callable(tuner_module.Tuner._on_train_begin)

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -274,5 +274,48 @@ def test_callbacks_run_each_execution(tmp_dir):
     assert len(callback_instances) == 6
 
 
-def test_on_train_begin_existence(tmp_dir):
-    assert callable(tuner_module.Tuner._on_train_begin)
+def test_on_train_begin_in_multi_execution_tuner(tmp_dir):
+
+    class MyTuner(kerastuner.tuners.RandomSearch):
+        def _on_train_begin(self, model, hp, *fit_args, **fit_kwargs):
+            self.was_called = True
+
+    tuner = MyTuner(
+        hypermodel=build_model,
+        objective='val_accuracy',
+        max_trials=2,
+        executions_per_trial=3,
+        directory=tmp_dir)
+
+    tuner.run_trial(
+        tuner.oracle.create_trial('tuner0'),
+        TRAIN_INPUTS,
+        TRAIN_TARGETS,
+        validation_data=(VAL_INPUTS, VAL_TARGETS))
+
+    assert tuner.was_called
+
+
+def test_on_train_begin_in_tuner(tmp_dir):
+
+    class MyTuner(tuner_module.Tuner):
+        def _on_train_begin(self, model, hp, *fit_args, **fit_kwargs):
+            self.was_called = True
+
+    class MyOracle(kerastuner.engine.oracle.Oracle):
+        def update_trial(self, trial_id, metrics, step=0):
+            pass
+
+    tuner = MyTuner(
+        oracle=MyOracle(objective='val_accuracy'),
+        hypermodel=build_model,
+        directory=tmp_dir)
+
+    tuner.run_trial(
+        kerastuner.engine.trial.Trial(
+            kerastuner.engine.hyperparameters.HyperParameters()),
+        TRAIN_INPUTS,
+        TRAIN_TARGETS,
+        validation_data=(VAL_INPUTS, VAL_TARGETS))
+
+    assert tuner.was_called


### PR DESCRIPTION
Overriding this function would support preprocessing layers in AutoKeras.

Not sure why the tests fails. I don't think this would break any test.