### PR TITLE
hyperbrand max iterations check typo fix

### DIFF
--- a/kerastuner/tuners/hyperband.py
+++ b/kerastuner/tuners/hyperband.py
@@ -197,6 +197,8 @@ class HyperbandOracle(oracle_module.Oracle):
         if self._current_bracket < 0:
             self._current_bracket = self._get_num_brackets() - 1
             self._current_iteration += 1
+            if self._current_iteration > self.hyperband_iterations:
+                self._current_bracket = 0
 
     def _remove_completed_brackets(self):
         # Filter out completed brackets.

--- a/kerastuner/tuners/hyperband.py
+++ b/kerastuner/tuners/hyperband.py
@@ -172,7 +172,7 @@ class HyperbandOracle(oracle_module.Oracle):
 
         # Max sweeps has been reached, no more brackets should be created.
         if (self._current_bracket == 0 and
-                self._current_iteration + 1 == self.hyperband_iterations):
+                self._current_iteration + 1 >= self.hyperband_iterations):
             # Stop creating new brackets, but wait to complete other brackets.
             if self.ongoing_trials:
                 return {'status': 'IDLE'}


### PR DESCRIPTION
resolves #256

In a distributed setup if you have more worker - or start the same worker twice - the first exists as it reaches the max iterations limit but the second goes over the max iterations bound and continuously creates new and new brackets in an endless loop. It can be solved with that:

In tuners/hyperbrand.py 174
`
        if (self._current_bracket == 0 and
                self._current_iteration + 1 >= self.hyperband_iterations):`