### PR TITLE
Fixed hyperparameter handles boolean value

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -460,7 +460,9 @@ class Fixed(HyperParameter):
             name=name, default=value, **kwargs)
         self.name = name
 
-        if isinstance(value, six.integer_types):
+        if isinstance(value, bool):
+            value = bool(value)
+        elif isinstance(value, six.integer_types):
             value = int(value)
         elif isinstance(value, six.string_types):
             value = str(value)

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -346,6 +346,26 @@ def test_Fixed():
     assert fixed.default == 'value'
     assert fixed.random_sample() == 'value'
 
+    fixed = hp_module.Fixed('fixed', True)
+    assert fixed.default is True
+    assert fixed.random_sample() is True
+
+    fixed = hp_module.Fixed('fixed', False)
+    fixed = hp_module.Fixed.from_config(fixed.get_config())
+    assert fixed.default is False
+    assert fixed.random_sample() is False
+
+    fixed = hp_module.Fixed('fixed', 1)
+    assert fixed.value == 1
+    assert fixed.random_sample() == 1
+
+    fixed = hp_module.Fixed('fixed', 8.2)
+    assert fixed.value == 8.2
+    assert fixed.random_sample() == 8.2
+
+    with pytest.raises(ValueError, match='value must be an'):
+        hp_module.Fixed('fixed', None)
+
 
 def test_merge():
     hp = hp_module.HyperParameters()


### PR DESCRIPTION
resolves #305 

Boolean is a subclass of int, it should be checked before integer types.
```
>>> int.__subclasses__()
[<class 'bool'>]
```
