### PR TITLE
Control trial output verbosity

### DIFF
--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -115,7 +115,8 @@ class BaseTuner(stateful.Stateful):
             *fit_kwargs: Keyword arguments that should be passed to
               `run_trial`, for example the training and validation data.
         """
-        verbose = fit_kwargs.get('verbose', 1)
+        if 'verbose' in fit_kwargs:
+            self._display.verbose = fit_kwargs.get('verbose')
         self.on_search_begin()
         while True:
             trial = self.oracle.create_trial(self.tuner_id)
@@ -127,9 +128,9 @@ class BaseTuner(stateful.Stateful):
                 # Oracle is calculating, resend request.
                 continue
 
-            self.on_trial_begin(trial, verbose)
+            self.on_trial_begin(trial)
             self.run_trial(trial, *fit_args, **fit_kwargs)
-            self.on_trial_end(trial, verbose)
+            self.on_trial_end(trial)
         self.on_search_end()
 
     def run_trial(self, trial, *fit_args, **fit_kwargs):
@@ -190,7 +191,7 @@ class BaseTuner(stateful.Stateful):
         if self.logger:
             self.logger.register_tuner(self.get_state())
 
-    def on_trial_begin(self, trial, verbose=1):
+    def on_trial_begin(self, trial):
         """A hook called before starting each trial.
 
         # Arguments:
@@ -198,9 +199,9 @@ class BaseTuner(stateful.Stateful):
         """
         if self.logger:
             self.logger.register_trial(trial.trial_id, trial.get_state())
-        self._display.on_trial_begin(self.oracle.get_trial(trial.trial_id), verbose)
+        self._display.on_trial_begin(self.oracle.get_trial(trial.trial_id))
 
-    def on_trial_end(self, trial, verbose=1):
+    def on_trial_end(self, trial):
         """A hook called after each trial is run.
 
         # Arguments:
@@ -214,7 +215,7 @@ class BaseTuner(stateful.Stateful):
             trial.trial_id, trial_module.TrialStatus.COMPLETED)
         self.oracle.update_space(trial.hyperparameters)
         # Display needs the updated trial scored by the Oracle.
-        self._display.on_trial_end(self.oracle.get_trial(trial.trial_id), verbose)
+        self._display.on_trial_end(self.oracle.get_trial(trial.trial_id))
         self.save()
 
     def on_search_end(self):

--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -115,6 +115,7 @@ class BaseTuner(stateful.Stateful):
             *fit_kwargs: Keyword arguments that should be passed to
               `run_trial`, for example the training and validation data.
         """
+        verbose = fit_kwargs.get('verbose', 1)
         self.on_search_begin()
         while True:
             trial = self.oracle.create_trial(self.tuner_id)
@@ -126,9 +127,9 @@ class BaseTuner(stateful.Stateful):
                 # Oracle is calculating, resend request.
                 continue
 
-            self.on_trial_begin(trial)
+            self.on_trial_begin(trial, verbose)
             self.run_trial(trial, *fit_args, **fit_kwargs)
-            self.on_trial_end(trial)
+            self.on_trial_end(trial, verbose)
         self.on_search_end()
 
     def run_trial(self, trial, *fit_args, **fit_kwargs):
@@ -189,7 +190,7 @@ class BaseTuner(stateful.Stateful):
         if self.logger:
             self.logger.register_tuner(self.get_state())
 
-    def on_trial_begin(self, trial):
+    def on_trial_begin(self, trial, verbose=1):
         """A hook called before starting each trial.
 
         # Arguments:
@@ -197,8 +198,9 @@ class BaseTuner(stateful.Stateful):
         """
         if self.logger:
             self.logger.register_trial(trial.trial_id, trial.get_state())
+        self._display.on_trial_begin(self.oracle.get_trial(trial.trial_id), verbose)
 
-    def on_trial_end(self, trial):
+    def on_trial_end(self, trial, verbose=1):
         """A hook called after each trial is run.
 
         # Arguments:
@@ -212,7 +214,7 @@ class BaseTuner(stateful.Stateful):
             trial.trial_id, trial_module.TrialStatus.COMPLETED)
         self.oracle.update_space(trial.hyperparameters)
         # Display needs the updated trial scored by the Oracle.
-        self._display.on_trial_end(self.oracle.get_trial(trial.trial_id))
+        self._display.on_trial_end(self.oracle.get_trial(trial.trial_id), verbose)
         self.save()
 
     def on_search_end(self):

--- a/kerastuner/engine/tuner_utils.py
+++ b/kerastuner/engine/tuner_utils.py
@@ -94,12 +94,15 @@ class TunerCallback(keras.callbacks.Callback):
 # TODO: Add more extensive display.
 class Display(object):
 
-    def on_trial_begin(self, trial, verbose=1):
-        if verbose >= 1:
+    def __init__(self, verbose=1):
+        self.verbose = verbose
+
+    def on_trial_begin(self, trial):
+        if self.verbose >= 1:
             display.section('Starting new trial')
 
-    def on_trial_end(self, trial, verbose=1):
-        if verbose >= 1:
+    def on_trial_end(self, trial):
+        if self.verbose >= 1:
             display.section('Trial complete')
             trial.summary()
 

--- a/kerastuner/engine/tuner_utils.py
+++ b/kerastuner/engine/tuner_utils.py
@@ -94,13 +94,14 @@ class TunerCallback(keras.callbacks.Callback):
 # TODO: Add more extensive display.
 class Display(object):
 
-    def on_trial_begin(self, trial):
-        display.section('New model')
-        trial.summary()
+    def on_trial_begin(self, trial, verbose=1):
+        if verbose >= 1:
+            display.section('Starting new trial')
 
-    def on_trial_end(self, trial):
-        display.section('Trial complete')
-        trial.summary()
+    def on_trial_end(self, trial, verbose=1):
+        if verbose >= 1:
+            display.section('Trial complete')
+            trial.summary()
 
 
 def average_histories(histories):

--- a/tests/kerastuner/engine/tuner_workflows_test.py
+++ b/tests/kerastuner/engine/tuner_workflows_test.py
@@ -15,6 +15,9 @@
 import pytest
 import os
 
+from io import StringIO
+from unittest.mock import patch
+
 import numpy as np
 
 import tensorflow as tf
@@ -641,3 +644,19 @@ def test_reloading_error_message(tmp_dir):
             max_trials=2,
             executions_per_trial=3,
             directory=shared_dir)
+
+def test_search_logging_verbosity(tmp_dir):
+    tuner = kerastuner.tuners.RandomSearch(
+        build_model,
+        objective='val_accuracy',
+        max_trials=2,
+        executions_per_trial=3,
+        directory=tmp_dir)
+
+    with patch('sys.stdout', new=StringIO()) as output:
+        tuner.search(x=TRAIN_INPUTS,
+                     y=TRAIN_TARGETS,
+                     epochs=2,
+                     validation_data=(VAL_INPUTS, VAL_TARGETS),
+                     verbose=0)
+        assert output.getvalue().strip() == ""


### PR DESCRIPTION
Allows individual trial outputs to be suppressed during a search by specifying `verbose=0`.