### PR TITLE
Fix #284. Parent condition should not be checked.

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -566,7 +566,7 @@ class HyperParameters(object):
               HyperParameters under this scope should be considered active.
         """
         parent_name = self._get_name(parent_name)  # Add name_scopes.
-        if not self._exists(parent_name):
+        if not self._exists(parent_name, conditions='any'):
             raise ValueError(
                 '`HyperParameter` named: ' + parent_name + ' '
                 'not defined.')
@@ -602,6 +602,9 @@ class HyperParameters(object):
 
     def _exists(self, name, conditions=None):
         """Checks for a `HyperParameter` with the same name and conditions."""
+        if conditions == 'any':
+            return name in self._hps
+
         if conditions is None:
             conditions = self._conditions
 

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -499,3 +499,11 @@ def test_prob_one_choice():
 
     value = hp_module.cumulative_prob_to_value(0, hp)
     assert value == 0
+
+
+def test_nested_parent():
+    hp = hp_module.HyperParameters()
+    hp.Choice('a', [1, 2, 3], default=1)
+    hp.Choice('b', [1, 2, 3], default=2, parent_name='a', parent_values=1)
+    hp.Choice('c', [1, 2, 3], default=3, parent_name='b', parent_values=1)
+    assert hp.values == {'a': 1, 'b': 2}


### PR DESCRIPTION
This error is because when registering new parameter, checking the existence of the parent parameter requires the condition of current scope to match with the condition of the parent's, which is always false.  