### PR TITLE
lock sphinx version

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -17,6 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow-cpu keras_autodoc
+        pip install Sphinx==3.0.4
         pip install -e .[tests]
     - name: Run tests
       run: pytest ./tests/ --cov-config .coveragerc --cov=kerastuner


### PR DESCRIPTION
lock the sphinx version to 3.0.4.
The 3.1.0 version will crash during the test.