### PR TITLE
show only active parameters in summary

### DIFF
--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -208,3 +208,88 @@ tuner.search(x=x,
              y=y,
              epochs=5,
              validation_data=(val_x, val_y))
+
+
+
+#"""Case #8:
+#- Similar to Base Case.
+#- However, specify conditions on units so that the summary show only relevant hyperparameters
+#"""
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten(input_shape=(28, 28)))
+    min_layers = 2
+    max_layers = 5
+    for i in range(hp.Int('num_layers', min_layers, max_layers)):
+        with hp.conditional_scope('num_layers', list(range(i + 1, max_layers + 1))):
+            model.add(layers.Dense(units=hp.Int('units_' + str(i), 32, 256, 32),
+                                   activation='relu'))
+    model.add(layers.Dense(10, activation='softmax'))
+    model.compile(
+        optimizer=keras.optimizers.Adam(1e-4),
+        loss='sparse_categorical_crossentropy',
+        metrics=['accuracy'])
+    return model
+
+
+tuner = RandomSearch(
+    build_model,
+    objective='val_accuracy',
+    max_trials=10,
+    executions_per_trial=3,
+    directory='test_dir')
+
+tuner.search_space_summary()
+
+tuner.search(x=x,
+             y=y,
+             epochs=3,
+             validation_data=(val_x, val_y))
+
+tuner.results_summary()
+
+
+#"""Case #9:
+#- Similar to Case #8, but use parent_name, parent_value keywords pair for conditional scope
+#- Using keywords for conditional scope does not support nested conditions.
+#"""
+
+
+def build_model(hp):
+    model = keras.Sequential()
+    model.add(layers.Flatten(input_shape=(28, 28)))
+    min_layers = 2
+    max_layers = 5
+    for i in range(hp.Int('num_layers', min_layers, max_layers)):
+        model.add(layers.Dense(units=hp.Int('units_' + str(i),
+                                            32,
+                                            256,
+                                            32,
+                                            parent_name='num_layers',
+                                            parent_values=list(range(i + 1, max_layers + 1))),
+                               activation='relu'))
+    model.add(layers.Dense(10, activation='softmax'))
+    model.compile(
+        optimizer=keras.optimizers.Adam(1e-4),
+        loss='sparse_categorical_crossentropy',
+        metrics=['accuracy'])
+    return model
+
+
+tuner = RandomSearch(
+    build_model,
+    objective='val_accuracy',
+    max_trials=10,
+    executions_per_trial=3,
+    directory='test_dir')
+
+tuner.search_space_summary()
+
+tuner.search(x=x,
+             y=y,
+             epochs=3,
+             validation_data=(val_x, val_y))
+
+tuner.results_summary()

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -482,7 +482,11 @@ class Fixed(HyperParameter):
         return self.value
 
     def get_config(self):
-        return {'name': self.name, 'value': self.value}
+        config = super(Fixed, self).get_config()
+        config['name'] = self.name
+        config.pop('default')
+        config['value'] = self.value
+        return config
 
     @classmethod
     def from_proto(cls, proto):

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -633,7 +633,7 @@ class HyperParameters(object):
         self._space.append(hp)
         value = hp.default
         # Only add active values to `self.values`.
-        if self._conditions_are_active():
+        if self._conditions_are_active(hp.conditions):
             self.values[hp.name] = value
             return value
         return None  # Ensures inactive values are not relied on by user.

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -182,6 +182,20 @@ def test_get_with_conditional_scopes():
     assert hp.get('b') == 4
 
 
+def test_merge_inactive_hp_with_conditional_scopes():
+    hp = hp_module.HyperParameters()
+    hp.Choice('a', [1, 2, 3], default=3)
+    assert hp.get('a') == 3
+    with hp.conditional_scope('a', 2):
+        hp.Fixed('b', 4)
+
+    hp2 = hp_module.HyperParameters()
+    hp2.merge(hp)
+    # only active hp should be included to values
+    assert 'a' in hp2.values
+    assert 'b' not in hp2.values
+
+
 def test_Choice():
     choice = hp_module.Choice('choice', [1, 2, 3], default=2)
     choice = hp_module.Choice.from_config(choice.get_config())


### PR DESCRIPTION
Trying to fix #321. 

Inactive parameters show up in summary because in `_register()`, the `hp.conditions` is not checked before adding the name-value pair to hps.values dictionary. Hence all hyperparameters, active or not, are in `hps.values`. 
Usually `_register()` is called by `_retrieve()` who already test the conditions, but when calling `merge()` the conditions are not tested. 

A test on `merge` for inactive hyperparameter is added to unit test. 

When fixing above problem it emerges that Fixed values do not carry condition in `get_config()` as other subclasses of `HyperParameter`, which causes `Fixed` to lost its `conditions` when deep copying `hp` in `_register`. This is added to `get_config` method in `Fixed`.

I also added the code in #321 into helloworld example as case 8 and 9 to demonstrate how to get a summary that show correctly, since the mismatch in hyperparameters has been asked by lots of people. 