### PR TITLE
stop server after finish

### DIFF
--- a/kerastuner/distribute/oracle_chief.py
+++ b/kerastuner/distribute/oracle_chief.py
@@ -85,7 +85,6 @@ def start_server(oracle):
 
         if oracle_servicer.stop_triggered:
             while oracle.ongoing_trials:
-                print(f'Stop is triggered. Remaining open trials: {oracle.ongoing_trials}.')
                 time.sleep(10)
 
             print('Exiting in 10s.')

--- a/kerastuner/distribute/oracle_chief.py
+++ b/kerastuner/distribute/oracle_chief.py
@@ -87,6 +87,7 @@ def start_server(oracle):
             while oracle.ongoing_trials:
                 time.sleep(10)
 
-            print('Exiting in 10s.')
+            print('Oracle server on chief is exiting in 10s.'
+                  'The chief will go on with post-search code.')
             server.stop(10)
             break


### PR DESCRIPTION
When running distributed search, the chief_oracle server runs indefinitely after search finishes. This will hold the job running until someone manually tears it down. 

What I do is I add an attribute in `OracleServicer` that is set to True when `chief_oracle` is giving out `trial` with stopped status. Then in the loop that block the server, once the stopping is triggered it will wait for all ongoing trials to end before stopping the server and escape from the loop. 