### PR TITLE
 minor fix on readme and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ from kerastuner import HyperModel
 
 class MyHyperModel(HyperModel):
 
-    def __init__(self, num_classes):
-        self.num_classes = num_classes
+    def __init__(self, classes):
+        self.classes = classes
 
     def build(self, hp):
         model = keras.Sequential()
@@ -164,7 +164,7 @@ class MyHyperModel(HyperModel):
                                             max_value=512,
                                             step=32),
                                activation='relu'))
-        model.add(layers.Dense(self.num_classes, activation='softmax'))
+        model.add(layers.Dense(self.classes, activation='softmax'))
         model.compile(
             optimizer=keras.optimizers.Adam(
                 hp.Choice('learning_rate',
@@ -174,7 +174,7 @@ class MyHyperModel(HyperModel):
         return model
 
 
-hypermodel = MyHyperModel(num_classes=10)
+hypermodel = MyHyperModel(classes=10)
 
 tuner = RandomSearch(
     hypermodel,
@@ -198,7 +198,7 @@ They come pre-compiled with `loss="categorical_crossentropy"` and `metrics=["acc
 from kerastuner.applications import HyperResNet
 from kerastuner.tuners import Hyperband
 
-hypermodel = HyperResNet(input_shape=(128, 128, 3), num_classes=10)
+hypermodel = HyperResNet(input_shape=(128, 128, 3), classes=10)
 
 tuner = Hyperband(
     hypermodel,
@@ -222,7 +222,7 @@ value gets used.
 ```python
 from kerastuner import HyperParameters
 
-hypermodel = HyperXception(input_shape=(128, 128, 3), num_classes=10)
+hypermodel = HyperXception(input_shape=(128, 128, 3), classes=10)
 
 hp = HyperParameters()
 # This will override the `learning_rate` parameter with your
@@ -270,7 +270,7 @@ Pass a `hyperparameters` argument with a `Fixed` entry (or any number of `Fixed`
 
 
 ```python
-hypermodel = HyperXception(input_shape=(128, 128, 3), num_classes=10)
+hypermodel = HyperXception(input_shape=(128, 128, 3), classes=10)
 
 hp = HyperParameters()
 hp.Fixed('learning_rate', value=1e-4)
@@ -294,7 +294,7 @@ If you have a hypermodel for which you want to change the existing optimizer, lo
 to the tuner constructor:
 
 ```python
-hypermodel = HyperXception(input_shape=(128, 128, 3), num_classes=10)
+hypermodel = HyperXception(input_shape=(128, 128, 3), classes=10)
 
 tuner = Hyperband(
     hypermodel,

--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -82,9 +82,9 @@ tuner.search(x, y,
 
 class MyHyperModel(HyperModel):
 
-    def __init__(self, img_size, num_classes):
+    def __init__(self, img_size, classes):
         self.img_size = img_size
-        self.num_classes = num_classes
+        self.classes = classes
 
     def build(self, hp):
         model = keras.Sequential()
@@ -92,7 +92,7 @@ class MyHyperModel(HyperModel):
         for i in range(hp.Int('num_layers', 2, 20)):
             model.add(layers.Dense(units=hp.Int('units_' + str(i), 32, 512, 32),
                                    activation='relu'))
-        model.add(layers.Dense(self.num_classes, activation='softmax'))
+        model.add(layers.Dense(self.classes, activation='softmax'))
         model.compile(
             optimizer=keras.optimizers.Adam(
                 hp.Choice('learning_rate', [1e-2, 1e-3, 1e-4])),
@@ -102,7 +102,7 @@ class MyHyperModel(HyperModel):
 
 
 tuner = RandomSearch(
-    MyHyperModel(img_size=(28, 28), num_classes=10),
+    MyHyperModel(img_size=(28, 28), classes=10),
     objective='val_accuracy',
     max_trials=5,
     directory='test_dir')

--- a/tutorials/helloworld/helloworld.py
+++ b/tutorials/helloworld/helloworld.py
@@ -88,7 +88,7 @@ tuner.search_space_summary()
 
 # Perform the model search. The search function has the same signature
 # as `model.fit()`.
-tuner.search(x_train, y_train, batch_size=128, epochs=2,
+tuner.search(x_train, y_train, batch_size=128, epochs=EPOCHS,
              validation_data=(x_val, y_val))
 
 # Display the best models, their hyperparameters, and the resulting metrics.


### PR DESCRIPTION
In readme and examples, hypermodels in applications are called with `num_classes` while the actual keywords used are `classes`. To be consistent I changed all occurance of `num_classes` in readme to `classes`.

Also in the example, EPOCH constant is created but not used. 