### PR TITLE
Allow save_freq keyword for search

### DIFF
--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -72,13 +72,18 @@ class MultiExecutionTuner(tuner_module.Tuner):
         pass
 
     def run_trial(self, trial, *fit_args, **fit_kwargs):
+        save_freq = 'epoch'
+        if 'save_freq' in fit_kwargs:
+            save_freq = int(fit_kwargs.pop('save_freq'))
+
         model_checkpoint = keras.callbacks.ModelCheckpoint(
             filepath=self._get_checkpoint_fname(
                 trial.trial_id, self._reported_step),
             monitor=self.oracle.objective.name,
             mode=self.oracle.objective.direction,
             save_best_only=True,
-            save_weights_only=True)
+            save_weights_only=True, 
+            save_freq=save_freq)
         original_callbacks = fit_kwargs.pop('callbacks', [])
 
         # Run the training process multiple times.

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -26,7 +26,7 @@ import copy
 import numpy as np
 import os
 from tensorflow import keras
-import warning
+import warnings
 
 
 class MultiExecutionTuner(tuner_module.Tuner):

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -76,12 +76,17 @@ class MultiExecutionTuner(tuner_module.Tuner):
 
         model_checkpoint = None
         for callback in original_callbacks:
-            # Patching checkpoint dir
+            # Patching checkpoint path in callback
             if callback.__class__.__name__ == 'ModelCheckpoint':
-                callback.filepath = os.path.join(
-                    str(callback.filepath),
-                    self._get_checkpoint_fname(
-                        trial.trial_id, self._reported_step))
+                ckpt_path = self._get_checkpoint_fname(trial.trial_id,
+                                                       self._reported_step)
+
+                # if the path is absolute, pick only part under project_dir
+                if os.path.isabs(ckpt_path):
+                    ckpt_path = 'trial' + ckpt_path.split('/trial')[-1]
+
+                callback.filepath = os.path.join(str(callback.filepath),
+                                                 ckpt_path)
                 break
         else:
             # Creat checkpoint call back if not already passed in

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -26,6 +26,7 @@ import copy
 import numpy as np
 import os
 from tensorflow import keras
+import warning
 
 
 class MultiExecutionTuner(tuner_module.Tuner):
@@ -80,13 +81,21 @@ class MultiExecutionTuner(tuner_module.Tuner):
             if callback.__class__.__name__ == 'ModelCheckpoint':
                 ckpt_path = self._get_checkpoint_fname(trial.trial_id,
                                                        self._reported_step)
+                # if callback filepath is not specified, use project_dir
+                if callback.filepath == '':
+                    print('Custom checkpoint callback not changing filepath.')
+                    callback.filepath = ckpt_path
+                else:
+                    warning.warn('Setting custom checkpoint filepath {}. '
+                                 'Tuner will not be able to automatically '
+                                 'load best model.'.format(callback.filepath))
 
-                # if the path is absolute, pick only part under project_dir
-                if os.path.isabs(ckpt_path):
-                    ckpt_path = 'trial' + ckpt_path.split('/trial')[-1]
+                    # if the path is absolute, pick only part under project_dir
+                    if os.path.isabs(ckpt_path):
+                        ckpt_path = 'trial' + ckpt_path.split('/trial')[-1]
 
-                callback.filepath = os.path.join(str(callback.filepath),
-                                                 ckpt_path)
+                    callback.filepath = os.path.join(str(callback.filepath),
+                                                     ckpt_path)
                 break
         else:
             # Creat checkpoint call back if not already passed in

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -22,6 +22,8 @@ import os
 
 import tensorflow as tf
 
+import warnings
+
 from . import base_tuner
 from . import hypermodel as hm_module
 from . import tuner_utils
@@ -179,9 +181,13 @@ class Tuner(base_tuner.BaseTuner):
         # indicates at what epoch the best value of the objective was
         # obtained.
         best_epoch = trial.best_step
-        with hm_module.maybe_distribute(self.distribution_strategy):
-            model.load_weights(self._get_checkpoint_fname(
-                trial.trial_id, best_epoch))
+        try:
+            with hm_module.maybe_distribute(self.distribution_strategy):
+                model.load_weights(self._get_checkpoint_fname(
+                    trial.trial_id, best_epoch))
+        except:
+            warnings.warn('Model with best hyperparameter is created, but weights are not loaded.\nThe model needs to be retrained for weights.')
+
         return model
 
     def on_epoch_begin(self, trial, model, epoch, logs=None):

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -185,8 +185,11 @@ class Tuner(base_tuner.BaseTuner):
             with hm_module.maybe_distribute(self.distribution_strategy):
                 model.load_weights(self._get_checkpoint_fname(
                     trial.trial_id, best_epoch))
-        except:
-            warnings.warn('Model with best hyperparameter is created, but weights are not loaded.\nThe model needs to be retrained for weights.')
+        except ValueError as e:
+            if 'files' in str(e):
+                warnings.warn('Model with best hyperparameter is created, '
+                              'but weights are not loaded.\nThe model weights '
+                              'needs to be retrained or manually loaded.')
 
         return model
 

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -22,6 +22,8 @@ from kerastuner.engine import tuner as tuner_module
 import tensorflow as tf
 from tensorflow import keras
 
+import os
+
 INPUT_DIM = 2
 NUM_CLASSES = 3
 NUM_SAMPLES = 64
@@ -192,17 +194,19 @@ def test_custom_checkpoint_callback_on_multi_execution_tuner(tmp_dir):
     )
     x, y = np.ones((1, 5)), np.ones((1, 1))
     # save_freq larger than epochs suppresses checkpointing
-    model_checkpoint = keras.callbacks.ModelCheckpoint('', save_freq=1000)
+    model_checkpoint = keras.callbacks.ModelCheckpoint('', save_freq=11)
     tuner.search(x,
                  y,
                  validation_data=(x, y),
-                 epochs=5,
+                 epochs=10,
                  callbacks=[model_checkpoint])
+
     trial = list(tuner.oracle.trials.values())[0]
     trial_id = trial.trial_id
     # no checkpoint should be saved because of the callback
-    for epoch in range(5):
+    for epoch in range(10):
         assert not tf.io.gfile.exists(tuner._get_checkpoint_fname(trial_id, epoch))
+
 
 def test_checkpoint_removal(tmp_dir):
     def build_model(hp):


### PR DESCRIPTION
Pass down `save_freq` keyword from `search()` to the checkpointing callback in `run_trial`. This allows user to request less frequent (or even completely disable) saving epochs.

In case the best epoch (or even any epoch) is saved, at `load_model` any exception in loading weights is caught and give a warning saying the model need to retrained. This may be helpful in general, when checkpoint become unavailable for any reason. Then user will be able to still get the model with best hyperparameter, and retrain the model.

Allowing no-checkpoint and failed weight-loading provide work around for #308, and potentially also other issues caused by filesystem. 