### PR TITLE
fix test case bayesian with zero y

### DIFF
--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -10,6 +10,8 @@ from ..engine import multi_execution_tuner
 from ..engine import oracle as oracle_module
 from ..engine import trial as trial_lib
 
+from warnings import warn
+
 
 class BayesianOptimizationOracle(oracle_module.Oracle):
     """Bayesian optimization oracle.
@@ -106,6 +108,13 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         except exceptions.ConvergenceWarning:
             # If convergence of the GPR fails, create a random trial.
             return self._random_populate_space()
+        except ValueError as e:
+            if 'NaN' in str(e) and np.all(y == y[0]):
+                warn('All scores for the first {} are identically {}.'
+                     'Running one more random trial.'.format(len(y), y[0]),
+                     category=RuntimeWarning)
+                return self._random_populate_space()
+            raise e
 
         def _upper_confidence_bound(x):
             x = x.reshape(1, -1)

--- a/tests/kerastuner/tuners/bayesian_test.py
+++ b/tests/kerastuner/tuners/bayesian_test.py
@@ -8,6 +8,7 @@ from kerastuner.engine import trial as trial_module
 from kerastuner.tuners import bayesian as bo_module
 
 
+
 @pytest.fixture(scope='function')
 def tmp_dir(tmpdir_factory):
     return tmpdir_factory.mktemp('bayesian_test', numbered=True)
@@ -63,6 +64,7 @@ def test_bayesian_oracle_with_zero_y(tmp_dir):
     oracle._set_project_dir(tmp_dir, 'untitled')
     for i in range(5):
         trial = oracle.create_trial(str(i))
+        #with pytest.warns(RuntimeWarning):
         oracle.update_trial(trial.trial_id, {'score': 0})
         oracle.end_trial(trial.trial_id, "COMPLETED")
 


### PR DESCRIPTION
The test case bayesian with zero y is highly unnatural. 
Here I fix it by using random parameters when scores for the initial points are exactly the same. 
Because it is unnatural, having repeating score likely hint something wrong. Hence warning message is shown. 

#326 