### PR TITLE
Use default hp value only when not populated

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -636,8 +636,10 @@ class HyperParameters(object):
         value = hp.default
         # Only add active values to `self.values`.
         if self._conditions_are_active(hp.conditions):
-            self.values[hp.name] = value
-            return value
+            # Use the default value only if not populated.
+            if hp.name not in self.values:
+                self.values[hp.name] = value
+            return self.values[hp.name]
         return None  # Ensures inactive values are not relied on by user.
 
     def get(self, name):

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -533,3 +533,22 @@ def test_prob_one_choice():
 
     value = hp_module.cumulative_prob_to_value(0, hp)
     assert value == 0
+
+
+def test_return_populated_value_for_new_hp():
+    hp = hp_module.HyperParameters()
+
+    hp.values['hp_name'] = 'hp_value'
+    assert hp.Choice(
+        'hp_name',
+        ['hp_value', 'hp_value_default'],
+        default='hp_value_default') == 'hp_value'
+
+
+def test_return_default_value_if_not_populated():
+    hp = hp_module.HyperParameters()
+
+    assert hp.Choice(
+        'hp_name',
+        ['hp_value', 'hp_value_default'],
+        default='hp_value_default') == 'hp_value_default'

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -347,10 +347,10 @@ def save_model_setup_tuner():
 def test_save_model_delete_not_called(tmp_dir):
     tuner = save_model_setup_tuner()
     tuner.save_model('a', None, step=15)
-    assert not tuner.was_called 
+    assert not tuner.was_called
 
 
 def test_save_model_delete_called(tmp_dir):
     tuner = save_model_setup_tuner()
     tuner.save_model('a', None, step=16)
-    assert tuner.was_called 
+    assert tuner.was_called


### PR DESCRIPTION
AutoKeras need to know the space in advance and populate even some unreached hp values.
This PR let the hypermodel use those populated values if available instead of the default values.