### PR TITLE
add a message when both hypermodel and tuner pass in compile arguments

### DIFF
--- a/kerastuner/engine/hypermodel.py
+++ b/kerastuner/engine/hypermodel.py
@@ -140,10 +140,22 @@ class KerasHyperModel(HyperModel):
                     'metrics': model.metrics,
                 }
                 if self.loss:
+                    if model.compiled_loss:
+                        print('The hypermodel {} already compiled loss;'
+                              'but is overriden by loss passed by Tuner.'
+                              .format(self.hypermodel))
                     compile_kwargs['loss'] = self.loss
                 if self.optimizer:
+                    if model.optimizer:
+                        print('The hypermodel {} already compiled optimizer;'
+                              'but is overriden by optimizer passed by Tuner.'
+                              .format(self.hypermodel))
                     compile_kwargs['optimizer'] = self.optimizer
                 if self.metrics:
+                    if model.compiled_metrics:
+                        print('The hypermodel {} already compiled metrics;'
+                              'but is overriden by metrics passed by Tuner.'
+                              .format(self.hypermodel))
                     compile_kwargs['metrics'] = self.metrics
                 model.compile(**compile_kwargs)
             return model


### PR DESCRIPTION
When search space include optimizer for example (like those in applications), passing optimizer through tuner would override them. The search space would then be traversed but have no effect, and the result may be misleading. So I add a message to clarify the situation. 