### PR TITLE
add application: HyperModel for augmentation

### DIFF
--- a/kerastuner/applications/__init__.py
+++ b/kerastuner/applications/__init__.py
@@ -16,4 +16,4 @@ from __future__ import absolute_import
 
 from .resnet import HyperResNet
 from .xception import HyperXception
-from .augment import HyperImageAugment, HyperImageFixedAugment, HyperImageRandAugment
+from .augment import HyperImageAugment

--- a/kerastuner/applications/__init__.py
+++ b/kerastuner/applications/__init__.py
@@ -16,4 +16,4 @@ from __future__ import absolute_import
 
 from .resnet import HyperResNet
 from .xception import HyperXception
-from .augment import HyperAugment, HyperFixedAugment, HyperRandAugment
+from .augment import HyperImageAugment, HyperImageFixedAugment, HyperImageRandAugment

--- a/kerastuner/applications/__init__.py
+++ b/kerastuner/applications/__init__.py
@@ -16,3 +16,4 @@ from __future__ import absolute_import
 
 from .resnet import HyperResNet
 from .xception import HyperXception
+from .augment import HyperAugment, HyperFixedAugment, HyperRandAugment

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -101,7 +101,7 @@ class HyperFixedAugment(HyperAugment):
     """
 
     def build(self, hp):
-        model = keras.Sequential(name='FixedAugment')
+        model = keras.Sequential(name='fixed_augment')
 
         if self.input_tensor is not None:
             model.add(self.input_tensor)
@@ -186,6 +186,6 @@ class HyperRandAugment(HyperAugment):
                 # selection matches the transform index `i`
                 x = tf.where(tf.equal(i, selection), x_trans, x)
                 
-        model = keras.Model(inputs, x, name='RandAugment')
+        model = keras.Model(inputs, x, name='rand_augment')
         return model
 

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -31,10 +31,10 @@ import random
 # Each function takes a factor (0 to 1) for the strength
 # of the transform.
 TRANSFORMS = {
-'translate_x': lambda x: preprocessing.RandomTranslation(x, 0),
-'translate_y': lambda y: preprocessing.RandomTranslation(0, y),
-'rotate': preprocessing.RandomRotation,
-'contrast': preprocessing.RandomContrast,
+    'translate_x': lambda x: preprocessing.RandomTranslation(x, 0),
+    'translate_y': lambda y: preprocessing.RandomTranslation(0, y),
+    'rotate': preprocessing.RandomRotation,
+    'contrast': preprocessing.RandomContrast,
 }
 
 class HyperAugment(hypermodel.HyperModel):
@@ -52,12 +52,12 @@ class HyperAugment(hypermodel.HyperModel):
             HyperModels. See `kerastuner.HyperModel`.
     """
     def __init__(self,
-        input_shape=None,
-        input_tensor=None,
-        rotate=True,
-        translate_x=True,
-        translate_y=True,
-        contrast=True):
+                 input_shape=None,
+                 input_tensor=None,
+                 rotate=True,
+                 translate_x=True,
+                 translate_y=True,
+                 contrast=True):
         self.transforms = []
         if rotate:
             self.transforms.append('rotate')
@@ -153,8 +153,8 @@ class HyperRandAugment(HyperAugment):
                  input_tensor=None,
                  **kwargs):
         super(HyperRandAugment, self).__init__(input_shape=input_shape,
-            input_tensor=input_tensor,
-            **kwargs)
+                                               input_tensor=input_tensor,
+                                               **kwargs)
         if input_shape is None and input_tensor is None:
             raise ValueError('You must specify either `input_shape` or '
                              '`intput_tensor` when using HyperRandAugment.')
@@ -171,12 +171,11 @@ class HyperRandAugment(HyperAugment):
         randaug_count = hp.Int('randaug_count', 0, 5, default=2)
 
         for _ in range(randaug_count):
-            # selection tensor determines for each sample, which operation
-            # is used.
+            # selection tensor determines operation for each sample.
             batch_size = tf.shape(x)[0]
             selection = tf.random.uniform([batch_size, 1, 1, 1],
-                maxval=len(self.transforms),
-                dtype='int32')
+                                          maxval=len(self.transforms),
+                                          dtype='int32')
 
             for (i, transform) in enumerate(self.transforms):
                 transform_layer = TRANSFORMS[transform](randaug_mag)

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -38,41 +38,100 @@ TRANSFORMS = {
 
 class HyperImageAugment(hypermodel.HyperModel):
     """ Builds HyperModel for image augmentation.
+    Only supporting augmentations available in Keras preprocessing layers currently.
 
     # Arguments:
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
         rotate: A number between [0, 1], a list of two numbers between [0, 1]
-            or None. It configures the range of factor of rotation
-            transform in the augmentation. Default is 0.2.
+            or None. Configures the search space of the factor of random
+            rotation transform in the augmentation. A factor is chosen for each
+            trial. It sets maximum of clockwise and counterclockwise rotation
+            in terms of fraction of pi, among all samples in the trial.
+            Default is 0.5. When `rotate` is a single number, the search range is
+            [0, `rotate`].
+            The transform is off when set to None.
         translate_x: A number between [0, 1], a list of two numbers between [0, 1]
-            or None. It configures the range of factor of horizontal translation
-            transform in the augmentation. Default is 0.1.
+            or None. Configures the search space of the factor of random
+            horizontal translation transform in the augmentation. A factor is
+            chosen for each trial. It sets maximum of horizontal translation in
+            terms of ratio over the width among all samples in the trial.
+            Default is 0.3. When `translate_x` is a single number, the search range
+            is [0, `translate_x`].
+            The transform is off when set to None.
         translate_y: A number between [0, 1], a list of two numbers between [0, 1]
-            or None. It configures the range of factor of vertical translation
-            transform in the augmentation. Default is 0.1.
+            or None. Configures the search space of the factor of random vertical
+            translation transform in the augmentation. A factor is chosen for each
+            trial. It sets maximum of vertical translation in terms of ratio over
+            the height among all samples in the trial. Default is 0.3. When
+            `translate_y` is a single number ,the search range is [0, `translate_y`].
+            The transform is off when set to None.
         contrast: A number between [0, 1], a list of two numbers between [0, 1]
-            or None. It configures the range of factor of contrast
-            transform in the augmentation. Default is 0.1.
+            or None. Configures the search space of the factor of random contrast
+            transform in the augmentation. A factor is chosen for each trial. It
+            sets maximum ratio of contrast change among all samples in the trial.
+            Default is 0.3. When `contrast` is a single number, the search rnage is
+            [0, `contrast`].
+            The transform is off when set to None.
+        augment_layers: None, int or list of two ints, controlling the number
+            of augment applied. Default is 3.
+            When `augment_layers` is 0, all transform are applied sequentially.
+            When `augment_layers` is nonzero, or a list of two ints, a simple
+            version of RandAugment(https://arxiv.org/abs/1909.13719) is used.
+            A search space for 'augment_layers' is created to search [0,
+            `augment_layers`], or between the two ints if a `augment_layers` is
+            a list. For each trial, the hyperparameter 'augment_layers'
+            determines number of layers of augment transforms are applied,
+            each randomly picked from all available transform types with equal
+            probability on each sample.
         **kwargs: Additional keyword arguments that apply to all
             HyperModels. See `kerastuner.HyperModel`.
 
-    # Notes for keyword args that configures range of factor of transform:
-        rotate, translate_x, translate_y and contrast:
-            If two numbers are given, they represent minimum and maximum
-            factors; if one number is given, it represents maximum factor, and
-            minimum factor is 0; if None, the transform is disabled. All factors
-            are within [0, 1].
+    # Search space:
+        'factor_{transform}' for each of the transforms chosen:
+            Float, range is set through corresponding keyword argument.
+        'augment_layers' for number of transform applied to each sample:
+            Int, range is set through keyword argument `augment_layers`.
+            This is only active when `augment_layers` is non zero.
+
+    # Usage example:
+        ```
+        hm_aug = HyperImageAugment(input_shape=(32, 32, 3),
+                                   augment_layers=0,
+                                   rotate=[0.2, 0.3],
+                                   translate_x=0.1,
+                                   translate_y=None,
+                                   contrast=None)
+        ```
+        Then the hypermodel `hm_aug` will search 'factor_rotate' between [0.2, 0.3]
+        and 'factor_translate_x' between [0, 0.1]. These two augments are applied
+        on all samples with factor picked per each trial.
+        ```
+        hm_aug = HyperImageAugment(input_shape=(32, 32, 3),
+                                   translate_x=0.5,
+                                   translate_y=[0.2, 0.4]
+                                   contrast=None)
+        ```
+        Then the hypermodel `hm_aug` will search 'factor_rotate' between [0, 0.2],
+        'factor_translate_x' between [0, 0.5], 'factor_translate_y' between
+        [0.2, 0.4]. It will use RandAugment, searching 'augment_layers'
+        between [0, 3]. Each layer on each sample will be chosen from rotate,
+        translate_x and translate_y.
     """
     def __init__(self,
                  input_shape=None,
                  input_tensor=None,
-                 rotate=0.2,
-                 translate_x=0.1,
-                 translate_y=0.1,
-                 contrast=0.1,
+                 rotate=0.5,
+                 translate_x=0.3,
+                 translate_y=0.3,
+                 contrast=0.3,
+                 augment_layers=3,
                  **kwargs):
+
+        if input_shape is None and input_tensor is None:
+            raise ValueError('You must specify either `input_shape` or '
+                             '`intput_tensor`.')
 
         self.transforms = []
         self._register_transform('rotate', rotate)
@@ -82,10 +141,87 @@ class HyperImageAugment(hypermodel.HyperModel):
 
         self.input_shape = input_shape
         self.input_tensor = input_tensor
+
+        if augment_layers:
+            self.model_name = 'image_rand_augment'
+            try:
+                augment_layers_min = augment_layers[0]
+                augment_layers_max = augment_layers[1]
+            except TypeError:
+                augment_layers_min = 0
+                augment_layers_max = augment_layers
+            if not (isinstance(augment_layers_min, int) and
+                    isinstance(augment_layers_max, int)):
+                raise ValueError('Keyword argument `augment_layers` must be int,'
+                                 'but received {}. '.format(randaug_mag))
+
+            self.augment_layers_min = augment_layers_min
+            self.augment_layers_max = augment_layers_max
+        else:
+            # Separatedly tune and apply all augment transforms if
+            # `randaug_count` is set to 0.
+            self.model_name = 'image_augment'
+
         super(HyperImageAugment, self).__init__(**kwargs)
 
     def build(self, hp):
-        raise NotImplementedError
+        if self.input_tensor is not None:
+            inputs = keras.utils.get_source_inputs(self.input_tensor)
+            x = self.input_tensor
+        else:
+            inputs = layers.Input(shape=self.input_shape)
+            x = inputs
+
+        if self.model_name == 'image_rand_augment':
+            x = self._build_randaug_layers(x, hp)
+        else:
+            x = self._build_fixedaug_layers(x, hp)
+
+        model = keras.Model(inputs, x, name=self.model_name)
+        return model
+
+    def _build_randaug_layers(self, inputs, hp):
+        augment_layers = hp.Int('augment_layers',
+                                self.augment_layers_min,
+                                self.augment_layers_max,
+                                default=self.augment_layers_min)
+        x = inputs
+        for _ in range(augment_layers):
+            # selection tensor determines operation for each sample.
+            batch_size = tf.shape(x)[0]
+            selection = tf.random.uniform([batch_size, 1, 1, 1],
+                                          maxval=len(self.transforms),
+                                          dtype='int32')
+
+            for i, (transform, (f_min, f_max)) in enumerate(self.transforms):
+                # Factor for each transform is determined per each trial.
+                factor = hp.Float(f'factor_{transform}',
+                                  f_min,
+                                  f_max,
+                                  default=f_min)
+                if factor == 0:
+                    continue
+                transform_layer = TRANSFORMS[transform](factor)
+                x_trans = transform_layer(x)
+
+                # For each sample, apply the transform if and only if
+                # selection matches the transform index `i`
+                x = tf.where(tf.equal(i, selection), x_trans, x)
+        return x
+
+    def _build_fixedaug_layers(self, inputs, hp):
+        x = inputs
+        for transform, (factor_min, factor_max) in self.transforms:
+            transform_factor = hp.Float(f'factor_{transform}',
+                                        factor_min,
+                                        factor_max,
+                                        step=0.05,
+                                        default=factor_min)
+            if transform_factor == 0:
+                continue
+            transform_layer = TRANSFORMS[transform](transform_factor)
+            x = transform_layer(x)
+        return x
 
     def _register_transform(self, transform_name, transform_params):
         """Register a transform and format parameters for tuning the transform.
@@ -118,186 +254,3 @@ class HyperImageAugment(hypermodel.HyperModel):
 
         self.transforms.append((transform_name,
                                 (transform_factor_min, transform_factor_max)))
-
-
-class HyperImageFixedAugment(HyperImageAugment):
-    """An HyperModel for fixed policy augmentation.
-       A tunable hyperparameter is assigned to each of the
-       transforms chosen, and the transforms are applied
-       sequentially.
-       Only supporting augmentations in Keras preprocessing layers.
-
-    # Arguments:
-        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-        input_tensor: Optional Keras tensor (i.e. output of
-            `layers.Input()`) to use as image input for the model.
-        **kwargs: Additional keyword arguments that apply to all
-            HyperImageAugment. See `HyperImageAugment`.
-
-    # Search space:
-        'factor_{transform}' for each of the transforms chosen:
-            Float, range is set through corresponding keyword argument.
-
-    # Usage example:
-        ```
-        hm_aug = HyperImageFixedAugment(input_shape=(32, 32, 3),
-                                        translate_x=0.5,
-                                        translate_y=[0.2, 0.4]
-                                        contrast=0)
-        ```
-        Then the hypermodel `hm_aug` will search 'factor_rotate' in [0, 0.2],
-        'factor_translate_x' in [0, 0.5], 'factor_translate_y' in [0.2, 0.4].
-    """
-
-    def build(self, hp):
-        model = keras.Sequential(name='fixed_augment')
-
-        if self.input_tensor is not None:
-            model.add(self.input_tensor)
-        elif self.input_shape is not None:
-            model.add(keras.Input(shape=self.input_shape))
-
-        for transform, (factor_min, factor_max) in self.transforms:
-            transform_factor = hp.Float(f'factor_{transform}',
-                                        factor_min,
-                                        factor_max,
-                                        step=0.05,
-                                        default=factor_min)
-            if transform_factor == 0:
-                continue
-            transform_layer = TRANSFORMS[transform](transform_factor)
-            model.add(transform_layer)
-
-        return model
-
-
-class HyperImageRandAugment(HyperImageAugment):
-    """An HyperModel for RandAugment for image.
-       Based on https://arxiv.org/abs/1909.13719.
-       This augmentation randomly picks `randaug_count` augmentation transforms
-       from a pool of transforms for each sample, and control the augmentation
-       magnitude of all transforms using one parameter `randaug_mag`.
-       Only supporting augmentations in Keras preprocessing layers, which is a
-       subset of the larger pool of augmentation transforms in the original
-       paper.
-
-    # Arguments:
-        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-            One of `input_shape` or `input_tensor` must be
-            specified.
-        input_tensor: Optional Keras tensor (i.e. output of
-            `layers.Input()`) to use as image input for the model.
-            One of `input_shape` or `input_tensor` must be
-            specified.
-        randaug_mag: Number or list of 2 numbers. Default is 1. It
-            configures search space 'randaug_mag'. When there is one number x,
-            this hyperparameter is tuned betwee [0, x]; when there are two
-            numbers x and y, this hyperparameter is tuned between [x, y].
-        randaug_count: int or list of 2 int. Default is 4.  It
-            configures search space 'randaug_count'. When there is one number
-            x, this hyperparameter is tuned betwee [0, x]; when there are two
-            numbers x and y, this hyperparameter is tuned between [x, y].
-        **kwargs: Additional keyword arguments that apply to all
-            HyperImageAugment. See `HyperImageAugment`.
-
-    # Search space:
-        'randaug_mag': Float, set through `randaug_mag` keyword argument. Always
-            within [0, 1]. Controls the strength of each augmentation applied
-            to each image. For a transform with factor range set to [a, b],
-            factor in a trial will be a + (b - a) * randaug_mag.
-        'randaug_count': Int, set through `randaug_count` keyword argument. Always
-            nonnegative. Controls the number of augmentations layers applied to
-            each image.
-
-    # Usage example:
-        ```
-        hm_aug = HyperImageRandAugment(input_shape=(32, 32, 3),
-                                       translate_x=0.5,
-                                       translate_y=[0.2, 0.4]
-                                       contrast=0,
-                                       randaug_mag=[0.4, 0.6])
-        ```
-        Then the hypermodel `hm_aug` will search 'randaug_mag' in [0.2, 0.4],
-        'randaug_count' in [0, 5]. Contrast transform is turned off.
-        In a trial with randaug_mag = 0.5, we have factors for rotate,
-        translate_x, translate_y at 0.1, 0.25, 0.3 respectively.
-    """
-    def __init__(self,
-                 input_shape=None,
-                 input_tensor=None,
-                 randaug_mag=1,
-                 randaug_count=4,
-                 **kwargs):
-        if input_shape is None and input_tensor is None:
-            raise ValueError('You must specify either `input_shape` or '
-                             '`intput_tensor` when using HyperImageRandAugment.')
-
-        try:
-            randaug_mag_min = randaug_mag[0]
-            randaug_mag_max = randaug_mag[1]
-        except TypeError:
-            randaug_mag_min = 0
-            randaug_mag_max = randaug_mag
-        if not (isinstance(randaug_mag_min, (int, float)) and
-                isinstance(randaug_mag_max, (int, float))):
-            raise ValueError('Keyword argument `randaug_mag` must be float or int,'
-                             'but received {}. '.format(randaug_mag))
-
-        try:
-            randaug_count_min = randaug_count[0]
-            randaug_count_max = randaug_count[1]
-        except TypeError:
-            randaug_count_min = 0
-            randaug_count_max = randaug_count
-        if not (isinstance(randaug_count_min, int) and
-                isinstance(randaug_count_max, int)):
-            raise ValueError('Keyword argument `randaug_count` must be int,'
-                             'but received {}. '.format(randaug_mag))
-
-        self.randaug_mag_min = randaug_mag_min
-        self.randaug_mag_max = randaug_mag_max
-        self.randaug_count_min = randaug_count_min
-        self.randaug_count_max = randaug_count_max
-
-        super(HyperImageRandAugment, self).__init__(input_shape=input_shape,
-                                                    input_tensor=input_tensor,
-                                                    **kwargs)
-
-    def build(self, hp):
-        if self.input_tensor is not None:
-            inputs = keras.utils.get_source_inputs(self.input_tensor)
-            x = self.input_tensor
-        else:
-            inputs = layers.Input(shape=self.input_shape)
-            x = inputs
-
-        randaug_mag = hp.Float('randaug_mag',
-                               self.randaug_mag_min,
-                               self.randaug_mag_max,
-                               step=0.1,
-                               default=self.randaug_mag_min)
-        randaug_count = hp.Int('randaug_count',
-                               self.randaug_count_min,
-                               self.randaug_count_max,
-                               default=self.randaug_count_min)
-
-        for _ in range(randaug_count):
-            # selection tensor determines operation for each sample.
-            batch_size = tf.shape(x)[0]
-            selection = tf.random.uniform([batch_size, 1, 1, 1],
-                                          maxval=len(self.transforms),
-                                          dtype='int32')
-
-            for i, (transform, (f_min, f_max)) in enumerate(self.transforms):
-                factor = f_min + (f_max - f_min) * randaug_mag
-                if factor == 0:
-                    continue
-                transform_layer = TRANSFORMS[transform](factor)
-                x_trans = transform_layer(x)
-
-                # for each sample, apply the transform if and only if
-                # selection matches the transform index `i`
-                x = tf.where(tf.equal(i, selection), x_trans, x)
-
-        model = keras.Model(inputs, x, name='rand_augment')
-        return model

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -1,0 +1,191 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import tensorflow.keras as keras
+
+from kerastuner.engine import hypermodel
+
+from tensorflow.keras import layers
+from tensorflow.keras.layers.experimental import preprocessing
+
+import random
+
+# dict of functions that create layers for transforms.
+# Each function takes a factor (0 to 1) for the strength
+# of the transform.
+TRANSFORMS = {
+'translate_x': lambda x: preprocessing.RandomTranslation(x, 0),
+'translate_y': lambda y: preprocessing.RandomTranslation(0, y),
+'rotate': preprocessing.RandomRotation,
+'contrast': preprocessing.RandomContrast,
+}
+
+class HyperAugment(hypermodel.HyperModel):
+    """ Builds HyperModel for image augmentation.
+
+    # Arguments:
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
+        input_tensor: Optional Keras tensor (i.e. output of
+            `layers.Input()`) to use as image input for the model.
+        rotate: Whether to include rotation in augmentation.
+        translate_x: Whether to include horizontal translation in augmentation.
+        translate_y: Whether to include vertical translation in augmentation.
+        contrast: Whether to include random contrast in augmentation.
+        **kwargs: Additional keyword arguments that apply to all
+            HyperModels. See `kerastuner.HyperModel`.
+    """
+    def __init__(self,
+        input_shape=None,
+        input_tensor=None,
+        rotate=True,
+        translate_x=True,
+        translate_y=True,
+        contrast=True):
+        self.transforms = []
+        if rotate:
+            self.transforms.append('rotate')
+        if translate_x:
+            self.transforms.append('translate_x')
+        if translate_y:
+            self.transforms.append('translate_y')
+        if contrast:
+            self.transforms.append('contrast')
+
+        self.input_shape = input_shape
+        self.input_tensor = input_tensor
+
+    def build(self, hp):
+        raise NotImplemented
+
+class HyperFixedAugment(HyperAugment):
+    """An HyperModel for fixed policy augmentation.
+       A tunable hyperparameter is assigned to each of the
+       transforms chosen, and the transforms are applied
+       sequentially.
+       Only supporting augmentations in Keras preprocessing layers.
+
+    # Arguments:
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
+        input_tensor: Optional Keras tensor (i.e. output of
+            `layers.Input()`) to use as image input for the model.
+        rotate: Whether to include rotation in augmentation. When
+             set to True, RandomRotation layer will be added to the
+             pool of augmentations to select from.
+        translate_x: Whether to include horizontal translation in augmentation.
+        translate_y: Whether to include vertical translation in augmentation.
+        contrast: Whether to include random contrast in augmentation.
+        **kwargs: Additional keyword arguments that apply to all
+            HyperModels. See `kerastuner.HyperModel`.
+
+    # Search space:
+        'factor_{transform}' for each of the transforms chosen:
+            Float, default range [0.05, 1]. Controls the strength
+            of the given transformation.
+    """
+
+    def build(self, hp):
+        model = keras.Sequential(name='FixedAugment')
+
+        if self.input_tensor is not None:
+            model.add(self.input_tensor)
+        elif self.input_shape is not None:
+            model.add(keras.Input(shape=self.input_shape))
+
+        for transform in self.transforms:
+            transform_factor = hp.Float(f'factor_{transform}', 0.05, 1, step=0.05, default=0.15)
+            transform_layer = TRANSFORMS[transform](transform_factor)
+            model.add(transform_layer)
+
+        return model
+
+class HyperRandAugment(HyperAugment):
+    """An HyperModel for Rand augmentation.
+       Based on https://arxiv.org/abs/1909.13719.
+       This augmentation randomly picks `randaug_count` augmentation transforms
+       from a pool of transforms for each sample, and set the augmentation
+       magnitude to `randaug_mag`.
+       Only supporting augmentations in Keras preprocessing layers.
+
+    # Arguments:
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
+              One of `input_shape` or `input_tensor` must be
+              specified.
+        input_tensor: Optional Keras tensor (i.e. output of
+            `layers.Input()`) to use as image input for the model.
+              One of `input_shape` or `input_tensor` must be
+              specified.
+        rotate: Whether to include rotation in augmentation. When
+             set to True, RandomRotation layer will be added to the
+             pool of augmentations to select from.
+        translate_x: Whether to include horizontal translation in augmentation.
+        translate_y: Whether to include vertical translation in augmentation.
+        contrast: Whether to include random contrast in augmentation.
+        **kwargs: Additional keyword arguments that apply to all
+            HyperModels. See `kerastuner.HyperModel`.
+
+    # Search space:
+        'randaug_mag': Float, default range [0.05, 1].
+                       Controls the strength of each augmentation
+                       applied to each image.
+        'randaug_count': Int, default range [0, 5].
+                       Controls the number of augmentations layers
+                       applied to each image.
+    """
+    def __init__(self,
+                 input_shape=None,
+                 input_tensor=None,
+                 **kwargs):
+        super(HyperRandAugment, self).__init__(input_shape=input_shape,
+            input_tensor=input_tensor,
+            **kwargs)
+        if input_shape is None and input_tensor is None:
+            raise ValueError('You must specify either `input_shape` or '
+                             '`intput_tensor` when using HyperRandAugment.')
+
+    def build(self, hp):
+        if self.input_tensor is not None:
+            inputs = keras.utils.get_source_inputs(self.input_tensor)
+            x = self.input_tensor
+        else:
+            inputs = layers.Input(shape=self.input_shape)
+            x = inputs
+
+        randaug_mag = hp.Float('randaug_mag', 0.05, 1.0, step=0.1, default=0.2)
+        randaug_count = hp.Int('randaug_count', 0, 5, default=2)
+
+        for _ in range(randaug_count):
+            # selection tensor determines for each sample, which operation
+            # is used.
+            batch_size = tf.shape(x)[0]
+            selection = tf.random.uniform([batch_size, 1, 1, 1],
+                maxval=len(self.transforms),
+                dtype='int32')
+
+            for (i, transform) in enumerate(self.transforms):
+                transform_layer = TRANSFORMS[transform](randaug_mag)
+                x_trans = transform_layer(x)
+
+                # for each sample, apply the transform if and only if
+                # selection matches the transform index `i`
+                x = tf.where(tf.equal(i, selection), x_trans, x)
+                
+        model = keras.Model(inputs, x, name='RandAugment')
+        return model
+

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -36,7 +36,7 @@ TRANSFORMS = {
 }
 
 
-class HyperAugment(hypermodel.HyperModel):
+class HyperImageAugment(hypermodel.HyperModel):
     """ Builds HyperModel for image augmentation.
 
     # Arguments:
@@ -74,7 +74,7 @@ class HyperAugment(hypermodel.HyperModel):
         raise NotImplementedError
 
 
-class HyperFixedAugment(HyperAugment):
+class HyperImageFixedAugment(HyperImageAugment):
     """An HyperModel for fixed policy augmentation.
        A tunable hyperparameter is assigned to each of the
        transforms chosen, and the transforms are applied
@@ -120,8 +120,8 @@ class HyperFixedAugment(HyperAugment):
         return model
 
 
-class HyperRandAugment(HyperAugment):
-    """An HyperModel for Rand augmentation.
+class HyperImageRandAugment(HyperImageAugment):
+    """An HyperModel for RandAugment for image.
        Based on https://arxiv.org/abs/1909.13719.
        This augmentation randomly picks `randaug_count` augmentation transforms
        from a pool of transforms for each sample, and set the augmentation
@@ -157,12 +157,12 @@ class HyperRandAugment(HyperAugment):
                  input_shape=None,
                  input_tensor=None,
                  **kwargs):
-        super(HyperRandAugment, self).__init__(input_shape=input_shape,
+        super(HyperImageRandAugment, self).__init__(input_shape=input_shape,
                                                input_tensor=input_tensor,
                                                **kwargs)
         if input_shape is None and input_tensor is None:
             raise ValueError('You must specify either `input_shape` or '
-                             '`intput_tensor` when using HyperRandAugment.')
+                             '`intput_tensor` when using HyperImageRandAugment.')
 
     def build(self, hp):
         if self.input_tensor is not None:

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -57,14 +57,14 @@ class HyperImageAugment(hypermodel.HyperModel):
             horizontal translation transform in the augmentation. A factor is
             chosen for each trial. It sets maximum of horizontal translation in
             terms of ratio over the width among all samples in the trial.
-            Default is 0.3. When `translate_x` is a single number, the search range
+            Default is 0.4. When `translate_x` is a single number, the search range
             is [0, `translate_x`].
             The transform is off when set to None.
         translate_y: A number between [0, 1], a list of two numbers between [0, 1]
             or None. Configures the search space of the factor of random vertical
             translation transform in the augmentation. A factor is chosen for each
             trial. It sets maximum of vertical translation in terms of ratio over
-            the height among all samples in the trial. Default is 0.3. When
+            the height among all samples in the trial. Default is 0.4. When
             `translate_y` is a single number ,the search range is [0, `translate_y`].
             The transform is off when set to None.
         contrast: A number between [0, 1], a list of two numbers between [0, 1]
@@ -123,8 +123,8 @@ class HyperImageAugment(hypermodel.HyperModel):
                  input_shape=None,
                  input_tensor=None,
                  rotate=0.5,
-                 translate_x=0.3,
-                 translate_y=0.3,
+                 translate_x=0.4,
+                 translate_y=0.4,
                  contrast=0.3,
                  augment_layers=3,
                  **kwargs):
@@ -153,7 +153,7 @@ class HyperImageAugment(hypermodel.HyperModel):
             if not (isinstance(augment_layers_min, int) and
                     isinstance(augment_layers_max, int)):
                 raise ValueError('Keyword argument `augment_layers` must be int,'
-                                 'but received {}. '.format(randaug_mag))
+                                 'but received {}. '.format(augment_layers))
 
             self.augment_layers_min = augment_layers_min
             self.augment_layers_max = augment_layers_max

--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -43,35 +43,81 @@ class HyperImageAugment(hypermodel.HyperModel):
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
-        rotate: Whether to include rotation in augmentation.
-        translate_x: Whether to include horizontal translation in augmentation.
-        translate_y: Whether to include vertical translation in augmentation.
-        contrast: Whether to include random contrast in augmentation.
+        rotate: A number between [0, 1], a list of two numbers between [0, 1]
+            or None. It configures the range of factor of rotation
+            transform in the augmentation. Default is 0.2.
+        translate_x: A number between [0, 1], a list of two numbers between [0, 1]
+            or None. It configures the range of factor of horizontal translation
+            transform in the augmentation. Default is 0.1.
+        translate_y: A number between [0, 1], a list of two numbers between [0, 1]
+            or None. It configures the range of factor of vertical translation
+            transform in the augmentation. Default is 0.1.
+        contrast: A number between [0, 1], a list of two numbers between [0, 1]
+            or None. It configures the range of factor of contrast
+            transform in the augmentation. Default is 0.1.
         **kwargs: Additional keyword arguments that apply to all
             HyperModels. See `kerastuner.HyperModel`.
+
+    # Notes for keyword args that configures range of factor of transform:
+        rotate, translate_x, translate_y and contrast:
+            If two numbers are given, they represent minimum and maximum
+            factors; if one number is given, it represents maximum factor, and
+            minimum factor is 0; if None, the transform is disabled. All factors
+            are within [0, 1].
     """
     def __init__(self,
                  input_shape=None,
                  input_tensor=None,
-                 rotate=True,
-                 translate_x=True,
-                 translate_y=True,
-                 contrast=True):
+                 rotate=0.2,
+                 translate_x=0.1,
+                 translate_y=0.1,
+                 contrast=0.1,
+                 **kwargs):
+
         self.transforms = []
-        if rotate:
-            self.transforms.append('rotate')
-        if translate_x:
-            self.transforms.append('translate_x')
-        if translate_y:
-            self.transforms.append('translate_y')
-        if contrast:
-            self.transforms.append('contrast')
+        self._register_transform('rotate', rotate)
+        self._register_transform('translate_x', translate_x)
+        self._register_transform('translate_y', translate_y)
+        self._register_transform('contrast', contrast)
 
         self.input_shape = input_shape
         self.input_tensor = input_tensor
+        super(HyperImageAugment, self).__init__(**kwargs)
 
     def build(self, hp):
         raise NotImplementedError
+
+    def _register_transform(self, transform_name, transform_params):
+        """Register a transform and format parameters for tuning the transform.
+        # Arguments:
+            transform_name: str, the name of the transform.
+            trnasform_params: A number between [0, 1], a list of two numbers
+                between [0, 1] or None. If set to a single number x, the
+                corresponding transform factor will be between [0, x].
+                If set to a list of 2 numbers [x, y], the factor will be
+                between [x, y]. If set to None, the transform will be excluded.
+        """
+        if not transform_params:
+            return
+
+        try:
+            transform_factor_min = transform_params[0]
+            transform_factor_max = transform_params[1]
+            if len(transform_params) > 2:
+                raise ValueError('Length of keyword argument {} must not exceed 2.'
+                                 .format(transform_name))
+        except TypeError:
+            transform_factor_min = 0
+            transform_factor_max = transform_params
+
+        if not (isinstance(transform_factor_max, (int, float)) and
+                isinstance(transform_factor_min, (int, float))):
+            raise ValueError('Keyword argument {} must be int or float, '
+                             'but received {}. '
+                             .format(transform_name, transform_params))
+
+        self.transforms.append((transform_name,
+                                (transform_factor_min, transform_factor_max)))
 
 
 class HyperImageFixedAugment(HyperImageAugment):
@@ -85,19 +131,22 @@ class HyperImageFixedAugment(HyperImageAugment):
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
-        rotate: Whether to include rotation in augmentation. When
-             set to True, RandomRotation layer will be added to the
-             pool of augmentations to select from.
-        translate_x: Whether to include horizontal translation in augmentation.
-        translate_y: Whether to include vertical translation in augmentation.
-        contrast: Whether to include random contrast in augmentation.
         **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `kerastuner.HyperModel`.
+            HyperImageAugment. See `HyperImageAugment`.
 
     # Search space:
         'factor_{transform}' for each of the transforms chosen:
-            Float, default range [0.05, 1]. Controls the strength
-            of the given transformation.
+            Float, range is set through corresponding keyword argument.
+
+    # Usage example:
+        ```
+        hm_aug = HyperImageFixedAugment(input_shape=(32, 32, 3),
+                                        translate_x=0.5,
+                                        translate_y=[0.2, 0.4]
+                                        contrast=0)
+        ```
+        Then the hypermodel `hm_aug` will search 'factor_rotate' in [0, 0.2],
+        'factor_translate_x' in [0, 0.5], 'factor_translate_y' in [0.2, 0.4].
     """
 
     def build(self, hp):
@@ -108,12 +157,14 @@ class HyperImageFixedAugment(HyperImageAugment):
         elif self.input_shape is not None:
             model.add(keras.Input(shape=self.input_shape))
 
-        for transform in self.transforms:
+        for transform, (factor_min, factor_max) in self.transforms:
             transform_factor = hp.Float(f'factor_{transform}',
-                                        min_value=0.05,
-                                        max_value=1,
+                                        factor_min,
+                                        factor_max,
                                         step=0.05,
-                                        default=0.15)
+                                        default=factor_min)
+            if transform_factor == 0:
+                continue
             transform_layer = TRANSFORMS[transform](transform_factor)
             model.add(transform_layer)
 
@@ -124,45 +175,93 @@ class HyperImageRandAugment(HyperImageAugment):
     """An HyperModel for RandAugment for image.
        Based on https://arxiv.org/abs/1909.13719.
        This augmentation randomly picks `randaug_count` augmentation transforms
-       from a pool of transforms for each sample, and set the augmentation
-       magnitude to `randaug_mag`.
-       Only supporting augmentations in Keras preprocessing layers.
+       from a pool of transforms for each sample, and control the augmentation
+       magnitude of all transforms using one parameter `randaug_mag`.
+       Only supporting augmentations in Keras preprocessing layers, which is a
+       subset of the larger pool of augmentation transforms in the original
+       paper.
 
     # Arguments:
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-              One of `input_shape` or `input_tensor` must be
-              specified.
+            One of `input_shape` or `input_tensor` must be
+            specified.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        rotate: Whether to include rotation in augmentation. When
-             set to True, RandomRotation layer will be added to the
-             pool of augmentations to select from.
-        translate_x: Whether to include horizontal translation in augmentation.
-        translate_y: Whether to include vertical translation in augmentation.
-        contrast: Whether to include random contrast in augmentation.
+            One of `input_shape` or `input_tensor` must be
+            specified.
+        randaug_mag: Number or list of 2 numbers. Default is 1. It
+            configures search space 'randaug_mag'. When there is one number x,
+            this hyperparameter is tuned betwee [0, x]; when there are two
+            numbers x and y, this hyperparameter is tuned between [x, y].
+        randaug_count: int or list of 2 int. Default is 4.  It
+            configures search space 'randaug_count'. When there is one number
+            x, this hyperparameter is tuned betwee [0, x]; when there are two
+            numbers x and y, this hyperparameter is tuned between [x, y].
         **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `kerastuner.HyperModel`.
+            HyperImageAugment. See `HyperImageAugment`.
 
     # Search space:
-        'randaug_mag': Float, default range [0.05, 1].
-                       Controls the strength of each augmentation
-                       applied to each image.
-        'randaug_count': Int, default range [0, 5].
-                       Controls the number of augmentations layers
-                       applied to each image.
+        'randaug_mag': Float, set through `randaug_mag` keyword argument. Always
+            within [0, 1]. Controls the strength of each augmentation applied
+            to each image. For a transform with factor range set to [a, b],
+            factor in a trial will be a + (b - a) * randaug_mag.
+        'randaug_count': Int, set through `randaug_count` keyword argument. Always
+            nonnegative. Controls the number of augmentations layers applied to
+            each image.
+
+    # Usage example:
+        ```
+        hm_aug = HyperImageRandAugment(input_shape=(32, 32, 3),
+                                       translate_x=0.5,
+                                       translate_y=[0.2, 0.4]
+                                       contrast=0,
+                                       randaug_mag=[0.4, 0.6])
+        ```
+        Then the hypermodel `hm_aug` will search 'randaug_mag' in [0.2, 0.4],
+        'randaug_count' in [0, 5]. Contrast transform is turned off.
+        In a trial with randaug_mag = 0.5, we have factors for rotate,
+        translate_x, translate_y at 0.1, 0.25, 0.3 respectively.
     """
     def __init__(self,
                  input_shape=None,
                  input_tensor=None,
+                 randaug_mag=1,
+                 randaug_count=4,
                  **kwargs):
-        super(HyperImageRandAugment, self).__init__(input_shape=input_shape,
-                                               input_tensor=input_tensor,
-                                               **kwargs)
         if input_shape is None and input_tensor is None:
             raise ValueError('You must specify either `input_shape` or '
                              '`intput_tensor` when using HyperImageRandAugment.')
+
+        try:
+            randaug_mag_min = randaug_mag[0]
+            randaug_mag_max = randaug_mag[1]
+        except TypeError:
+            randaug_mag_min = 0
+            randaug_mag_max = randaug_mag
+        if not (isinstance(randaug_mag_min, (int, float)) and
+                isinstance(randaug_mag_max, (int, float))):
+            raise ValueError('Keyword argument `randaug_mag` must be float or int,'
+                             'but received {}. '.format(randaug_mag))
+
+        try:
+            randaug_count_min = randaug_count[0]
+            randaug_count_max = randaug_count[1]
+        except TypeError:
+            randaug_count_min = 0
+            randaug_count_max = randaug_count
+        if not (isinstance(randaug_count_min, int) and
+                isinstance(randaug_count_max, int)):
+            raise ValueError('Keyword argument `randaug_count` must be int,'
+                             'but received {}. '.format(randaug_mag))
+
+        self.randaug_mag_min = randaug_mag_min
+        self.randaug_mag_max = randaug_mag_max
+        self.randaug_count_min = randaug_count_min
+        self.randaug_count_max = randaug_count_max
+
+        super(HyperImageRandAugment, self).__init__(input_shape=input_shape,
+                                                    input_tensor=input_tensor,
+                                                    **kwargs)
 
     def build(self, hp):
         if self.input_tensor is not None:
@@ -172,8 +271,15 @@ class HyperImageRandAugment(HyperImageAugment):
             inputs = layers.Input(shape=self.input_shape)
             x = inputs
 
-        randaug_mag = hp.Float('randaug_mag', 0.05, 1.0, step=0.1, default=0.2)
-        randaug_count = hp.Int('randaug_count', 0, 5, default=2)
+        randaug_mag = hp.Float('randaug_mag',
+                               self.randaug_mag_min,
+                               self.randaug_mag_max,
+                               step=0.1,
+                               default=self.randaug_mag_min)
+        randaug_count = hp.Int('randaug_count',
+                               self.randaug_count_min,
+                               self.randaug_count_max,
+                               default=self.randaug_count_min)
 
         for _ in range(randaug_count):
             # selection tensor determines operation for each sample.
@@ -182,8 +288,11 @@ class HyperImageRandAugment(HyperImageAugment):
                                           maxval=len(self.transforms),
                                           dtype='int32')
 
-            for (i, transform) in enumerate(self.transforms):
-                transform_layer = TRANSFORMS[transform](randaug_mag)
+            for i, (transform, (f_min, f_max)) in enumerate(self.transforms):
+                factor = f_min + (f_max - f_min) * randaug_mag
+                if factor == 0:
+                    continue
+                transform_layer = TRANSFORMS[transform](factor)
                 x_trans = transform_layer(x)
 
                 # for each sample, apply the transform if and only if

--- a/tests/kerastuner/applications/augment_test.py
+++ b/tests/kerastuner/applications/augment_test.py
@@ -1,0 +1,127 @@
+# Copyright 2020 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for HyperAugment Models."""
+
+import numpy as np
+import os
+import pytest
+import tensorflow as tf
+
+from kerastuner.applications.augment import HyperAugment, HyperFixedAugment, HyperRandAugment
+from kerastuner.engine import hyperparameters as hp_module
+
+@pytest.mark.skipif('TRAVIS' in os.environ, reason='Causes CI to stall')
+@pytest.mark.parametrize('augment', [HyperAugment, HyperFixedAugment, HyperRandAugment])
+def test_transforms_choice(augment):
+    hypermodel = augment(input_shape=(32, 32, 3))
+    # Default choice
+    assert hypermodel.transforms == ['rotate',
+        'translate_x',
+        'translate_y',
+        'contrast']
+
+    hypermodel = augment(input_shape=(32, 32, 3),
+        rotate=True,
+        translate_x=False,
+        contrast=False)
+    assert hypermodel.transforms == ['rotate', 'translate_y']
+
+def test_input_requirement_fixed_aug():
+    hp = hp_module.HyperParameters()
+    # Allow not specifying input shape/tensor.
+    hypermodel = HyperFixedAugment()
+    model = hypermodel.build(hp)
+    assert model.built == False
+
+def test_input_requirement_rand_aug():
+    hp = hp_module.HyperParameters()
+    with pytest.raises(ValueError, match=r'.*must specify.*'):
+        hypermodel = HyperRandAugment()
+
+    hypermodel = HyperRandAugment(input_shape=(None, None, 3))
+    model = hypermodel.build(hp)
+    assert model.built
+
+    hypermodel = HyperRandAugment(input_tensor=tf.keras.Input(shape=(32, 32, 3)))
+    model = hypermodel.build(hp)
+    assert model.built
+
+def test_model_construction_fixed_aug():
+    hp = hp_module.HyperParameters()
+    hypermodel = HyperFixedAugment(input_shape=(None, None, 3))
+    model = hypermodel.build(hp)
+    assert model.layers
+    assert model.name == 'fixed_augment'
+
+    # Output shape includes batch dimension.
+    assert model.output_shape == (None, None, None, 3)
+    out = model.predict(np.ones((1, 32, 32, 3)))
+    assert out.shape == (1, 32, 32, 3)
+    # Augment does not distort image when inferencing.
+    assert (out != 1).sum() == 0
+
+
+def test_model_construction_rand_aug():
+    hp = hp_module.HyperParameters()
+    hypermodel = HyperRandAugment(input_shape=(None, None, 3))
+    model = hypermodel.build(hp)
+    assert model.layers
+    assert model.name == 'rand_augment'
+
+    # Output shape includes batch dimension.
+    assert model.output_shape == (None, None, None, 3)
+    out = model.predict(np.ones((1, 32, 32, 3)))
+    assert out.shape == (1, 32, 32, 3)
+    # Augment does not distort image when inferencing.
+    assert (out != 1).sum() == 0
+
+
+def test_hyperparameter_selection_and_defaults_fixed_aug():
+    hp = hp_module.HyperParameters()
+    hypermodel = HyperFixedAugment(input_shape=(32, 32, 3),
+        contrast=False)
+    hypermodel.build(hp)
+    assert hp.get('factor_rotate') == 0.15
+    assert hp.get('factor_translate_x') == 0.15
+    assert hp.get('factor_translate_y') == 0.15
+    assert 'factor_contrast' not in hp.values
+
+
+def test_hyperparameter_existence_and_defaults_rand_aug():
+    hp = hp_module.HyperParameters()
+    hypermodel = HyperRandAugment(input_shape=(32, 32, 3),
+        contrast=False)
+    hypermodel.build(hp)
+    assert hp.get('randaug_mag') == 0.2
+    assert hp.get('randaug_count') == 2
+
+def test_hyperparameter_override_fixed_aug():
+    hp = hp_module.HyperParameters()
+    hp.Fixed('factor_rotate', 0.9)
+    hp.Choice('factor_translate_x', [0.8])
+    hypermodel = HyperFixedAugment(input_shape=(32, 32, 3))
+    hypermodel.build(hp)
+    assert hp.get('factor_rotate') == 0.9
+    assert hp.get('factor_translate_x') == 0.8
+    assert hp.get('factor_translate_y') == 0.15
+    assert hp.get('factor_contrast') == 0.15
+
+def test_hyperparameter_override_rand_aug():
+    hp = hp_module.HyperParameters()
+    hp.Fixed('randaug_mag', 1.0)
+    hp.Choice('randaug_count', [4])
+    hypermodel = HyperRandAugment(input_shape=(32, 32, 3))
+    hypermodel.build(hp)
+    assert hp.get('randaug_mag') == 1.0
+    assert hp.get('randaug_count') == 4

--- a/tests/kerastuner/applications/augment_test.py
+++ b/tests/kerastuner/applications/augment_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for HyperAugment Models."""
+"""Tests for HyperImageAugment Models."""
 
 import numpy as np
 import os
@@ -24,9 +24,9 @@ from kerastuner.engine import hyperparameters as hp_module
 
 @pytest.mark.skipif('TRAVIS' in os.environ, reason='Causes CI to stall')
 @pytest.mark.parametrize('augment',
-                         [aug_module.HyperAugment,
-                          aug_module.HyperFixedAugment,
-                          aug_module.HyperRandAugment])
+                         [aug_module.HyperImageAugment,
+                          aug_module.HyperImageFixedAugment,
+                          aug_module.HyperImageRandAugment])
 def test_transforms_choice(augment):
     hm = augment(input_shape=(32, 32, 3))
     # Default choice
@@ -45,7 +45,7 @@ def test_transforms_choice(augment):
 def test_input_requirement_fixed_aug():
     hp = hp_module.HyperParameters()
     # Allow not specifying input shape/tensor.
-    hm = aug_module.HyperFixedAugment()
+    hm = aug_module.HyperImageFixedAugment()
     model = hm.build(hp)
     assert not model.built
 
@@ -53,20 +53,21 @@ def test_input_requirement_fixed_aug():
 def test_input_requirement_rand_aug():
     hp = hp_module.HyperParameters()
     with pytest.raises(ValueError, match=r'.*must specify.*'):
-        hm = aug_module.HyperRandAugment()
+        hm = aug_module.HyperImageRandAugment()
 
-    hm = aug_module.HyperRandAugment(input_shape=(None, None, 3))
+    hm = aug_module.HyperImageRandAugment(input_shape=(None, None, 3))
     model = hm.build(hp)
     assert model.built
 
-    hm = aug_module.HyperRandAugment(input_tensor=keras.Input(shape=(32, 32, 3)))
+    hm = aug_module.HyperImageRandAugment(
+        input_tensor=keras.Input(shape=(32, 32, 3)))
     model = hm.build(hp)
     assert model.built
 
 
 def test_model_construction_fixed_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperFixedAugment(input_shape=(None, None, 3))
+    hm = aug_module.HyperImageFixedAugment(input_shape=(None, None, 3))
     model = hm.build(hp)
     assert model.layers
     assert model.name == 'fixed_augment'
@@ -81,7 +82,7 @@ def test_model_construction_fixed_aug():
 
 def test_model_construction_rand_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperRandAugment(input_shape=(None, None, 3))
+    hm = aug_module.HyperImageRandAugment(input_shape=(None, None, 3))
     model = hm.build(hp)
     assert model.layers
     assert model.name == 'rand_augment'
@@ -96,8 +97,8 @@ def test_model_construction_rand_aug():
 
 def test_hyperparameter_selection_and_defaults_fixed_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperFixedAugment(input_shape=(32, 32, 3),
-                                      contrast=False)
+    hm = aug_module.HyperImageFixedAugment(input_shape=(32, 32, 3),
+                                           contrast=False)
     hm.build(hp)
     assert hp.get('factor_rotate') == 0.15
     assert hp.get('factor_translate_x') == 0.15
@@ -107,8 +108,8 @@ def test_hyperparameter_selection_and_defaults_fixed_aug():
 
 def test_hyperparameter_existence_and_defaults_rand_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperRandAugment(input_shape=(32, 32, 3),
-                                     contrast=False)
+    hm = aug_module.HyperImageRandAugment(input_shape=(32, 32, 3),
+                                          contrast=False)
     hm.build(hp)
     assert hp.get('randaug_mag') == 0.2
     assert hp.get('randaug_count') == 2
@@ -118,7 +119,7 @@ def test_hyperparameter_override_fixed_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('factor_rotate', 0.9)
     hp.Choice('factor_translate_x', [0.8])
-    hm = aug_module.HyperFixedAugment(input_shape=(32, 32, 3))
+    hm = aug_module.HyperImageFixedAugment(input_shape=(32, 32, 3))
     hm.build(hp)
     assert hp.get('factor_rotate') == 0.9
     assert hp.get('factor_translate_x') == 0.8
@@ -130,7 +131,7 @@ def test_hyperparameter_override_rand_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('randaug_mag', 1.0)
     hp.Choice('randaug_count', [4])
-    hm = aug_module.HyperRandAugment(input_shape=(32, 32, 3))
+    hm = aug_module.HyperImageRandAugment(input_shape=(32, 32, 3))
     hm.build(hp)
     assert hp.get('randaug_mag') == 1.0
     assert hp.get('randaug_count') == 4

--- a/tests/kerastuner/applications/augment_test.py
+++ b/tests/kerastuner/applications/augment_test.py
@@ -23,65 +23,61 @@ from kerastuner.engine import hyperparameters as hp_module
 
 
 @pytest.mark.skipif('TRAVIS' in os.environ, reason='Causes CI to stall')
-@pytest.mark.parametrize('augment',
-                         [aug_module.HyperImageAugment,
-                          aug_module.HyperImageFixedAugment,
-                          aug_module.HyperImageRandAugment])
-def test_transforms_choice(augment):
-    hm = augment(input_shape=(32, 32, 3))
+def test_transforms_search_space():
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3))
     # Default choice
-    assert hm.transforms == [('rotate', (0, 0.2)),
-                             ('translate_x', (0, 0.1)),
-                             ('translate_y', (0, 0.1)),
-                             ('contrast', (0, 0.1))]
+    assert hm.transforms == [('rotate', (0, 0.5)),
+                             ('translate_x', (0, 0.4)),
+                             ('translate_y', (0, 0.4)),
+                             ('contrast', (0, 0.3))]
 
-    hm = augment(input_shape=(32, 32, 3),
-                 rotate=0.3,
-                 translate_x=[0.1, 0.5],
-                 contrast=None)
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3),
+                                      rotate=0.3,
+                                      translate_x=[0.1, 0.5],
+                                      contrast=None)
     assert hm.transforms == [('rotate', (0, 0.3)),
                              ('translate_x', (0.1, 0.5)),
-                             ('translate_y', (0, 0.1))]
+                             ('translate_y', (0, 0.4))]
 
 
-def test_input_requirement_fixed_aug():
-    hp = hp_module.HyperParameters()
-    # Allow not specifying input shape/tensor.
-    hm = aug_module.HyperImageFixedAugment()
-    model = hm.build(hp)
-    assert not model.built
-
-
-def test_input_requirement_rand_aug():
+def test_input_requirement():
     hp = hp_module.HyperParameters()
     with pytest.raises(ValueError, match=r'.*must specify.*'):
-        hm = aug_module.HyperImageRandAugment()
+        hm = aug_module.HyperImageAugment()
 
-    hm = aug_module.HyperImageRandAugment(input_shape=(None, None, 3))
+    hm = aug_module.HyperImageAugment(input_shape=(None, None, 3))
     model = hm.build(hp)
     assert model.built
 
-    hm = aug_module.HyperImageRandAugment(
+    hm = aug_module.HyperImageAugment(
         input_tensor=keras.Input(shape=(32, 32, 3)))
     model = hm.build(hp)
     assert model.built
 
 
-def test_model_construction_factor_zero_fixed_aug():
+def test_model_construction_factor_zero():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageFixedAugment(input_shape=(None, None, 3))
+    hm = aug_module.HyperImageAugment(input_shape=(None, None, 3))
     model = hm.build(hp)
-    # factors default all zero, the model should be empty
-    assert not model.layers
+    # augment_layers search default space [0, 4], with default zero.
+    assert len(model.layers) == 1
+
+    hp = hp_module.HyperParameters()
+    hm = aug_module.HyperImageAugment(input_shape=(None, None, 3),
+                                      augment_layers=0)
+    model = hm.build(hp)
+    # factors default all zero, the model should only have input layer
+    assert len(model.layers) == 1
 
 
 def test_model_construction_fixed_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageFixedAugment(input_shape=(None, None, 3),
-                                           rotate=[0.2, 0.5])
+    hm = aug_module.HyperImageAugment(input_shape=(None, None, 3),
+                                      rotate=[0.2, 0.5],
+                                      augment_layers=0)
     model = hm.build(hp)
     assert model.layers
-    assert model.name == 'fixed_augment'
+    assert model.name == 'image_augment'
 
     # Output shape includes batch dimension.
     assert model.output_shape == (None, None, None, 3)
@@ -91,21 +87,13 @@ def test_model_construction_fixed_aug():
     assert (out != 1).sum() == 0
 
 
-def test_model_construction_factor_zero_rand_aug():
-    hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageRandAugment(input_shape=(None, None, 3))
-    model = hm.build(hp)
-    # factors default all zero, the model should only have input layer
-    assert len(model.layers) == 1
-
-
 def test_model_construction_rand_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageRandAugment(input_shape=(None, None, 3),
-                                          rotate=[0.2, 0.5])
+    hm = aug_module.HyperImageAugment(input_shape=(None, None, 3),
+                                      rotate=[0.2, 0.5])
     model = hm.build(hp)
     assert model.layers
-    assert model.name == 'rand_augment'
+    assert model.name == 'image_rand_augment'
 
     # Output shape includes batch dimension.
     assert model.output_shape == (None, None, None, 3)
@@ -117,10 +105,12 @@ def test_model_construction_rand_aug():
 
 def test_hyperparameter_selection_and_hp_defaults_fixed_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageFixedAugment(input_shape=(32, 32, 3),
-                                           translate_x=[0.2, 0.4],
-                                           contrast=None)
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3),
+                                      translate_x=[0.2, 0.4],
+                                      contrast=None,
+                                      augment_layers=0)
     hm.build(hp)
+    # default value of default search space are always minimum.
     assert hp.get('factor_rotate') == 0
     assert hp.get('factor_translate_x') == 0.2
     assert hp.get('factor_translate_y') == 0
@@ -129,19 +119,18 @@ def test_hyperparameter_selection_and_hp_defaults_fixed_aug():
 
 def test_hyperparameter_existence_and_hp_defaults_rand_aug():
     hp = hp_module.HyperParameters()
-    hm = aug_module.HyperImageRandAugment(input_shape=(32, 32, 3),
-                                          randaug_count=[2, 5],
-                                          contrast=False)
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3),
+                                      augment_layers=[2, 5],
+                                      contrast=False)
     hm.build(hp)
-    assert hp.get('randaug_mag') == 0
-    assert hp.get('randaug_count') == 2
+    assert hp.get('augment_layers') == 2
 
 
 def test_hyperparameter_override_fixed_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('factor_rotate', 0.9)
     hp.Choice('factor_translate_x', [0.8])
-    hm = aug_module.HyperImageFixedAugment(input_shape=(32, 32, 3))
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3), augment_layers=0)
     hm.build(hp)
     assert hp.get('factor_rotate') == 0.9
     assert hp.get('factor_translate_x') == 0.8
@@ -153,7 +142,7 @@ def test_hyperparameter_override_rand_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('randaug_mag', 1.0)
     hp.Choice('randaug_count', [4])
-    hm = aug_module.HyperImageRandAugment(input_shape=(32, 32, 3))
+    hm = aug_module.HyperImageAugment(input_shape=(32, 32, 3), augment_layers=[2, 4])
     hm.build(hp)
     assert hp.get('randaug_mag') == 1.0
     assert hp.get('randaug_count') == 4

--- a/tests/kerastuner/applications/augment_test.py
+++ b/tests/kerastuner/applications/augment_test.py
@@ -16,51 +16,58 @@
 import numpy as np
 import os
 import pytest
-import tensorflow as tf
+from tensorflow import keras
 
-from kerastuner.applications.augment import HyperAugment, HyperFixedAugment, HyperRandAugment
+from kerastuner.applications import augment as aug_module
 from kerastuner.engine import hyperparameters as hp_module
 
-@pytest.mark.skipif('TRAVIS' in os.environ, reason='Causes CI to stall')
-@pytest.mark.parametrize('augment', [HyperAugment, HyperFixedAugment, HyperRandAugment])
-def test_transforms_choice(augment):
-    hypermodel = augment(input_shape=(32, 32, 3))
-    # Default choice
-    assert hypermodel.transforms == ['rotate',
-        'translate_x',
-        'translate_y',
-        'contrast']
 
-    hypermodel = augment(input_shape=(32, 32, 3),
-        rotate=True,
-        translate_x=False,
-        contrast=False)
-    assert hypermodel.transforms == ['rotate', 'translate_y']
+@pytest.mark.skipif('TRAVIS' in os.environ, reason='Causes CI to stall')
+@pytest.mark.parametrize('augment',
+                         [aug_module.HyperAugment,
+                          aug_module.HyperFixedAugment,
+                          aug_module.HyperRandAugment])
+def test_transforms_choice(augment):
+    hm = augment(input_shape=(32, 32, 3))
+    # Default choice
+    assert hm.transforms == ['rotate',
+                             'translate_x',
+                             'translate_y',
+                             'contrast']
+
+    hm = augment(input_shape=(32, 32, 3),
+                 rotate=True,
+                 translate_x=False,
+                 contrast=False)
+    assert hm.transforms == ['rotate', 'translate_y']
+
 
 def test_input_requirement_fixed_aug():
     hp = hp_module.HyperParameters()
     # Allow not specifying input shape/tensor.
-    hypermodel = HyperFixedAugment()
-    model = hypermodel.build(hp)
-    assert model.built == False
+    hm = aug_module.HyperFixedAugment()
+    model = hm.build(hp)
+    assert not model.built
+
 
 def test_input_requirement_rand_aug():
     hp = hp_module.HyperParameters()
     with pytest.raises(ValueError, match=r'.*must specify.*'):
-        hypermodel = HyperRandAugment()
+        hm = aug_module.HyperRandAugment()
 
-    hypermodel = HyperRandAugment(input_shape=(None, None, 3))
-    model = hypermodel.build(hp)
+    hm = aug_module.HyperRandAugment(input_shape=(None, None, 3))
+    model = hm.build(hp)
     assert model.built
 
-    hypermodel = HyperRandAugment(input_tensor=tf.keras.Input(shape=(32, 32, 3)))
-    model = hypermodel.build(hp)
+    hm = aug_module.HyperRandAugment(input_tensor=keras.Input(shape=(32, 32, 3)))
+    model = hm.build(hp)
     assert model.built
+
 
 def test_model_construction_fixed_aug():
     hp = hp_module.HyperParameters()
-    hypermodel = HyperFixedAugment(input_shape=(None, None, 3))
-    model = hypermodel.build(hp)
+    hm = aug_module.HyperFixedAugment(input_shape=(None, None, 3))
+    model = hm.build(hp)
     assert model.layers
     assert model.name == 'fixed_augment'
 
@@ -74,8 +81,8 @@ def test_model_construction_fixed_aug():
 
 def test_model_construction_rand_aug():
     hp = hp_module.HyperParameters()
-    hypermodel = HyperRandAugment(input_shape=(None, None, 3))
-    model = hypermodel.build(hp)
+    hm = aug_module.HyperRandAugment(input_shape=(None, None, 3))
+    model = hm.build(hp)
     assert model.layers
     assert model.name == 'rand_augment'
 
@@ -89,9 +96,9 @@ def test_model_construction_rand_aug():
 
 def test_hyperparameter_selection_and_defaults_fixed_aug():
     hp = hp_module.HyperParameters()
-    hypermodel = HyperFixedAugment(input_shape=(32, 32, 3),
-        contrast=False)
-    hypermodel.build(hp)
+    hm = aug_module.HyperFixedAugment(input_shape=(32, 32, 3),
+                                      contrast=False)
+    hm.build(hp)
     assert hp.get('factor_rotate') == 0.15
     assert hp.get('factor_translate_x') == 0.15
     assert hp.get('factor_translate_y') == 0.15
@@ -100,28 +107,30 @@ def test_hyperparameter_selection_and_defaults_fixed_aug():
 
 def test_hyperparameter_existence_and_defaults_rand_aug():
     hp = hp_module.HyperParameters()
-    hypermodel = HyperRandAugment(input_shape=(32, 32, 3),
-        contrast=False)
-    hypermodel.build(hp)
+    hm = aug_module.HyperRandAugment(input_shape=(32, 32, 3),
+                                     contrast=False)
+    hm.build(hp)
     assert hp.get('randaug_mag') == 0.2
     assert hp.get('randaug_count') == 2
+
 
 def test_hyperparameter_override_fixed_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('factor_rotate', 0.9)
     hp.Choice('factor_translate_x', [0.8])
-    hypermodel = HyperFixedAugment(input_shape=(32, 32, 3))
-    hypermodel.build(hp)
+    hm = aug_module.HyperFixedAugment(input_shape=(32, 32, 3))
+    hm.build(hp)
     assert hp.get('factor_rotate') == 0.9
     assert hp.get('factor_translate_x') == 0.8
     assert hp.get('factor_translate_y') == 0.15
     assert hp.get('factor_contrast') == 0.15
 
+
 def test_hyperparameter_override_rand_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed('randaug_mag', 1.0)
     hp.Choice('randaug_count', [4])
-    hypermodel = HyperRandAugment(input_shape=(32, 32, 3))
-    hypermodel.build(hp)
+    hm = aug_module.HyperRandAugment(input_shape=(32, 32, 3))
+    hm.build(hp)
     assert hp.get('randaug_mag') == 1.0
     assert hp.get('randaug_count') == 4


### PR DESCRIPTION
This PR implements hyper model for augments.  

HyperAugment class collects the transforms to be used in each of the subclasses. Two HyperModels are implemented:

A) HyperFixedAugment: for each of the transforms assign a tuning knob.
B) RandAugment: https://arxiv.org/abs/1909.13719

These augments are only using preprocessing layers, and can be inserted as a part of other hypermodels. This usage is supported in efficientnet hypermodel (#363) and is crucial for using the hypermodel.