### PR TITLE
Checkpointing with H5 format when running on TPU

### DIFF
--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -290,7 +290,7 @@ class Tuner(base_tuner.BaseTuner):
             # Each checkpoint is saved in its own directory.
             self._get_checkpoint_dir(trial_id, epoch),
             'checkpoint')
-        if (isinstance(tf.distribute.get_strategy(), tf.distribute.TPUStrategy) and
+        if (isinstance(self.distribution_strategy, tf.distribute.TPUStrategy) and
                 'gs://' not in self.project_dir):
             # TPU strategy only support saving h5 format on local path
             return checkpoint_fname + '.h5'

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -291,7 +291,7 @@ class Tuner(base_tuner.BaseTuner):
             self._get_checkpoint_dir(trial_id, epoch),
             'checkpoint')
         if (isinstance(tf.distribute.get_strategy(), tf.distribute.TPUStrategy) and
-            'gs://' not in self.project_dir):
+                'gs://' not in self.project_dir):
             # TPU strategy only support saving h5 format on local path
             return checkpoint_fname + '.h5'
         return checkpoint_fname

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -291,7 +291,7 @@ class Tuner(base_tuner.BaseTuner):
             self._get_checkpoint_dir(trial_id, epoch),
             'checkpoint')
         if (isinstance(self.distribution_strategy, tf.distribute.TPUStrategy) and
-                'gs://' not in self.project_dir):
+                not self.project_dir.startswith('gs://')):
             # TPU strategy only support saving h5 format on local path
             return checkpoint_fname + '.h5'
         return checkpoint_fname

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -278,16 +278,23 @@ class Tuner(base_tuner.BaseTuner):
                     str(trial_id))
 
     def _get_checkpoint_dir(self, trial_id, epoch):
-        return os.path.join(
+        checkpoint_dir = os.path.join(
             self.get_trial_dir(trial_id),
             'checkpoints',
             'epoch_' + str(epoch))
+        tf.io.gfile.makedirs(checkpoint_dir)
+        return checkpoint_dir
 
     def _get_checkpoint_fname(self, trial_id, epoch):
-        return os.path.join(
+        checkpoint_fname = os.path.join(
             # Each checkpoint is saved in its own directory.
             self._get_checkpoint_dir(trial_id, epoch),
             'checkpoint')
+        if (isinstance(tf.distribute.get_strategy(), tf.distribute.TPUStrategy) and
+            'gs://' not in self.project_dir):
+            # TPU strategy only support saving h5 format on local path
+            return checkpoint_fname + '.h5'
+        return checkpoint_fname
 
     def _checkpoint_model(self, model, trial_id, epoch):
         fname = self._get_checkpoint_fname(trial_id, epoch)


### PR DESCRIPTION
Keras Tuner has not been able to run on TPU only because of unimplemented local file system checkpointing. However, h5 file checkpointing is available with TPU. Hence when TPU is used and no GCS bucket is specified, we use H5 for checkpointing; if not, TF format is still used due to performance advantage of TF format. 

This solves #308 