### PR TITLE
Fix numpy version conflict with tensorflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         'packaging',
         'future',
-        'numpy',
+        'numpy < 1.19.0',
         'tabulate',
         'terminaltables',
         'colorama',


### PR DESCRIPTION
Keras Tuner installs the latest version of numpy which is not compatible with tensorflow.
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/pip_package/setup.py#L64