### PR TITLE
single out training loop to a _run_fit method

### DIFF
--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -147,7 +147,7 @@ class BaseTuner(stateful.Stateful):
         ```python
         def run_trial(self, trial, x, y, val_x, val_y):
             model = self.hypermodel.build(trial.hyperparameters)
-            model.fit(x, y)
+            self._run_fit(model, trial.hyperparameters, x, y, val_x, val_y)
             loss = model.evaluate(val_x, val_y)
             self.oracle.update_trial(
               trial.trial_id, {'loss': loss})
@@ -158,6 +158,38 @@ class BaseTuner(stateful.Stateful):
             trial: A `Trial` instance that contains the information
               needed to run this trial. Hyperparameters can be accessed
               via `trial.hyperparameters`.
+            *fit_args: Positional arguments passed by `search`.
+            *fit_kwargs: Keyword arguments passed by `search`.
+        """
+        raise NotImplementedError
+
+    def _run_fit(self, model, hp, *args, **kwargs):
+        """Model fitting part of `run_trial`.
+
+        This method is called by `run_trial` to fit a model. In
+        certain use cases people may want subclass a tuner class
+        (such as MultiExecutionTuner) other than the bare tuner
+        for a modified training loop. In such a case,
+        overriding the entire `run_trial` method may not be ideal
+        as `run_trial` function includes lots of essential code (such as
+        `MultiExecutionTuner`).
+
+        This is currently a private method as experimental.
+
+        For subclass implementers: This method is responsible solely
+        for fitting the model, and should return the history that
+        `model.fit()` return or a compatible structure.
+
+        Simplest example:
+
+        ```python
+        def _run_fit(self, model, hp, *fit_args, **fit_kwargs):
+            return model.fit(*fit_args, **fit_kwargs)
+        ```
+
+        # Arguments:
+            model: The model to train, passed by `run_trial`.
+            hp: The HyperParameters instance passed by `run_trial`.
             *fit_args: Positional arguments passed by `search`.
             *fit_kwargs: Keyword arguments passed by `search`.
         """

--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -147,7 +147,7 @@ class BaseTuner(stateful.Stateful):
         ```python
         def run_trial(self, trial, x, y, val_x, val_y):
             model = self.hypermodel.build(trial.hyperparameters)
-            self._run_fit(model, trial.hyperparameters, x, y, val_x, val_y)
+            model.fit(x, y, val_x, val_y)
             loss = model.evaluate(val_x, val_y)
             self.oracle.update_trial(
               trial.trial_id, {'loss': loss})
@@ -158,38 +158,6 @@ class BaseTuner(stateful.Stateful):
             trial: A `Trial` instance that contains the information
               needed to run this trial. Hyperparameters can be accessed
               via `trial.hyperparameters`.
-            *fit_args: Positional arguments passed by `search`.
-            *fit_kwargs: Keyword arguments passed by `search`.
-        """
-        raise NotImplementedError
-
-    def _run_fit(self, model, hp, *args, **kwargs):
-        """Model fitting part of `run_trial`.
-
-        This method is called by `run_trial` to fit a model. In
-        certain use cases people may want subclass a tuner class
-        (such as MultiExecutionTuner) other than the bare tuner
-        for a modified training loop. In such a case,
-        overriding the entire `run_trial` method may not be ideal
-        as `run_trial` function includes lots of essential code (such as
-        `MultiExecutionTuner`).
-
-        This is currently a private method as experimental.
-
-        For subclass implementers: This method is responsible solely
-        for fitting the model, and should return the history that
-        `model.fit()` return or a compatible structure.
-
-        Simplest example:
-
-        ```python
-        def _run_fit(self, model, hp, *fit_args, **fit_kwargs):
-            return model.fit(*fit_args, **fit_kwargs)
-        ```
-
-        # Arguments:
-            model: The model to train, passed by `run_trial`.
-            hp: The HyperParameters instance passed by `run_trial`.
             *fit_args: Positional arguments passed by `search`.
             *fit_kwargs: Keyword arguments passed by `search`.
         """

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -95,7 +95,8 @@ class MultiExecutionTuner(tuner_module.Tuner):
             model = self.hypermodel.build(trial.hyperparameters)
             self._on_train_begin(model, trial.hyperparameters,
                                  *fit_args, **copied_fit_kwargs)
-            history = model.fit(*fit_args, **copied_fit_kwargs)
+            history = self._run_fit(model, trial.hyperparameters,
+                                    *fit_args, **copied_fit_kwargs)
             for metric, epoch_values in history.history.items():
                 if self.oracle.objective.direction == 'min':
                     best_value = np.min(epoch_values)

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -124,9 +124,6 @@ class Tuner(base_tuner.BaseTuner):
         This method is called during `search` to evaluate a set of
         hyperparameters.
 
-        The training loop should be in `_run_fit` method for easier
-        override.
-
         # Arguments:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
@@ -170,8 +167,8 @@ class Tuner(base_tuner.BaseTuner):
     def _run_fit(self, model, hp, *fit_args, **fit_kwargs):
         """ The training loop for run_trial.
 
-        When subclassing a tuner or a subclass of tuner, override this method rather
-        than `run_trial` if the only intended change is on training loop.
+        When subclassing a tuner or a subclass of tuner, we can override this
+        method rather than `run_trial` if the only difference is the training loop.
 
         # Arguments:
             model: The model to train, passed by `run_trial`.

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -124,6 +124,9 @@ class Tuner(base_tuner.BaseTuner):
         This method is called during `search` to evaluate a set of
         hyperparameters.
 
+        The training loop should be in `_run_fit` method for easier
+        override.
+
         # Arguments:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
@@ -150,7 +153,8 @@ class Tuner(base_tuner.BaseTuner):
         model = self.hypermodel.build(trial.hyperparameters)
         self._on_train_begin(model, trial.hyperparameters,
                              *fit_args, **copied_fit_kwargs)
-        model.fit(*fit_args, **copied_fit_kwargs)
+        self._run_fit(model, trial.hyperparameters,
+                      *fit_args, **copied_fit_kwargs)
 
     def _on_train_begin(model, hp, *fit_args, **fit_kwargs):
         """For AutoKeras to override.
@@ -162,6 +166,20 @@ class Tuner(base_tuner.BaseTuner):
         This is different from the callback's on_train_begin.
         """
         pass
+
+    def _run_fit(self, model, hp, *fit_args, **fit_kwargs):
+        """ The training loop for run_trial.
+
+        When subclassing a tuner or a subclass of tuner, override this method rather
+        than `run_trial` if the only intended change is on training loop.
+
+        # Arguments:
+            model: The model to train, passed by `run_trial`.
+            hp: The HyperParameters instance passed by `run_trial`.
+            *fit_args: Positional arguments passed by `search`.
+            *fit_kwargs: Keyword arguments passed by `search`.
+        """
+        return model.fit(*fit_args, **fit_kwargs)
 
     def save_model(self, trial_id, model, step=0):
         epoch = step


### PR DESCRIPTION
Put the `model.fit()` part of tuners into a separate method `_run_fit`, so that `run_trial` will call this method. This change makes easier to override a tuner if we only need to change the training loop. For example, if we want to override `MultiExecutionTuner` to modify training loop, we need to still include everything that is not related to the training loop itself.  