### PR TITLE
Format hyperparameters and values during search

### DIFF
--- a/kerastuner/engine/tuner_utils.py
+++ b/kerastuner/engine/tuner_utils.py
@@ -168,13 +168,13 @@ class Display(object):
             print('default configuration')
 
     def format_value(self, val):
-        if isinstance(val, (bool, str)):
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return '{:.5g}'.format(val)
+        else:
             val_str = str(val)
             if len(val_str) > self.col_width:
                 val_str = val_str[:self.col_width-3] + '...'
             return val_str
-        else:
-            return '{:.5g}'.format(val)
 
     def format_time(self, t):
         return time.strftime("%Hh %Mm %Ss", time.gmtime(t))

--- a/kerastuner/engine/tuner_utils.py
+++ b/kerastuner/engine/tuner_utils.py
@@ -100,6 +100,7 @@ class Display(object):
         self.verbose = verbose
         self.oracle = oracle
         self.trial_number = 0
+        self.col_width = 18
 
         # Start time for the overall search
         self.search_start = None
@@ -145,7 +146,7 @@ class Display(object):
             print('Total elapsed time: {}'.format(time_elapsed_str))
 
     def show_hyperparameter_table(self, trial):
-        template = "{0:20}|{1:10}|{2:20}"
+        template = '{{0:{0}}}|{{1:{0}}}|{{2:{0}}}'.format(self.col_width)
         best_trials = self.oracle.get_best_trials()
         if len(best_trials) > 0:
             best_trial = best_trials[0]
@@ -155,12 +156,25 @@ class Display(object):
             print(template.format('Hyperparameter', 'Value', 'Best Value So Far'))
             for hp, value in trial.hyperparameters.values.items():
                 if best_trial:
-                    best_value = str(best_trial.hyperparameters.values.get(hp))
+                    best_value = best_trial.hyperparameters.values.get(hp)
                 else:
                     best_value = '?'
-                print(template.format(hp, str(value), best_value))
+                print(template.format(
+                    self.format_value(hp),
+                    self.format_value(value),
+                    self.format_value(best_value)
+                ))
         else:
             print('default configuration')
+
+    def format_value(self, val):
+        if isinstance(val, (bool, str)):
+            val_str = str(val)
+            if len(val_str) > self.col_width:
+                val_str = val_str[:self.col_width-3] + '...'
+            return val_str
+        else:
+            return '{:.5g}'.format(val)
 
     def format_time(self, t):
         return time.strftime("%Hh %Mm %Ss", time.gmtime(t))


### PR DESCRIPTION
This change updates the table shown during a Keras Tuner search to truncate/format long hyperparameter names and values.

In a (somewhat extreme) case, the table doesn't format properly:
```
Hyperparameter      |Value     |Best Value So Far
nodes               |110       |150
float_value         |0.1330384000391946|0.19749227748114415
float_value_2       |0.00015313100179945483|7.812425828565088e-05
small_value         |1.5417698018097114e-72|4.5275481762432145e-72
large_value         |314159265358979323846264338327|314159265358979323846264338327
boolean_value       |False     |False
string_value        |first_string_option|second_string_option
super_long_hyperparameter_name|20        |10
```

After the update, it will properly format to look like this:
```
Hyperparameter    |Value             |Best Value So Far
nodes             |110               |150
float_value       |0.18072           |0.1008
float_value_2     |0.00084762        |0.0018323
small_value       |1.6724e-72        |7.7685e-73
large_value       |3.1416e+29        |3.1416e+29
boolean_value     |True              |False
string_value      |first_string_op...|second_string_o...
super_long_hype...|20                |10
```