### PR TITLE
Add _on_build_begin to tuner for AutoKeras to override

### DIFF
--- a/kerastuner/__init__.py
+++ b/kerastuner/__init__.py
@@ -35,4 +35,4 @@ from .tuners import RandomSearch
 from .utils import check_tf_version
 check_tf_version()
 
-__version__ = '1.0.2rc1dev'
+__version__ = '1.0.2rc2'

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -94,7 +94,7 @@ class MultiExecutionTuner(tuner_module.Tuner):
 
             model = self.hypermodel.build(trial.hyperparameters)
             self._on_train_begin(model, trial.hyperparameters,
-                                 *fit_args, **copied_fit_kwargs)
+                                 fit_args, copied_fit_kwargs)
             history = model.fit(*fit_args, **copied_fit_kwargs)
             for metric, epoch_values in history.history.items():
                 if self.oracle.objective.direction == 'min':

--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -92,6 +92,8 @@ class MultiExecutionTuner(tuner_module.Tuner):
             callbacks.append(model_checkpoint)
             copied_fit_kwargs['callbacks'] = callbacks
 
+            self._on_build_begin(trial.trial_id, trial.hyperparameters,
+                                 fit_args, copied_fit_kwargs)
             model = self.hypermodel.build(trial.hyperparameters)
             self._on_train_begin(model, trial.hyperparameters,
                                  fit_args, copied_fit_kwargs)

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -149,15 +149,15 @@ class Tuner(base_tuner.BaseTuner):
 
         model = self.hypermodel.build(trial.hyperparameters)
         self._on_train_begin(model, trial.hyperparameters,
-                             *fit_args, **copied_fit_kwargs)
+                             fit_args, copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
 
-    def _on_train_begin(model, hp, *fit_args, **fit_kwargs):
+    def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
         """For AutoKeras to override.
 
-        DO NOT REMOVE this function until Keras Tuner support preprocessing layers.
-        AutoKeras overrides the function to support preprocessing layers and tuning
-        of other fit_args and fit_kwargs.
+        DO NOT REMOVE this function. AutoKeras overrides the function to adapt
+        preprocessing layers, search tf.data preprocessing pipelines and tune
+        other fit_args and fit_kwargs.
 
         This is different from the callback's on_train_begin.
         """

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -147,21 +147,31 @@ class Tuner(base_tuner.BaseTuner):
         callbacks.append(tuner_utils.TunerCallback(self, trial))
         copied_fit_kwargs['callbacks'] = callbacks
 
+        self._on_build_begin(trial.trial_id, trial.hyperparameters,
+                             fit_args, copied_fit_kwargs)
         model = self.hypermodel.build(trial.hyperparameters)
         self._on_train_begin(model, trial.hyperparameters,
                              fit_args, copied_fit_kwargs)
         model.fit(*fit_args, **copied_fit_kwargs)
 
+    def _on_build_begin(self, trial_id, hp, fit_args, fit_kwargs):
+        """For AutoKeras to override.
+
+        DO NOT REMOVE this function. AutoKeras overrides the function to tune
+        tf.data preprocessing pipelines, and preprocess the dataset to obtain
+        the input shape before building the model.
+        """
+        return
+
     def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
         """For AutoKeras to override.
 
         DO NOT REMOVE this function. AutoKeras overrides the function to adapt
-        preprocessing layers, search tf.data preprocessing pipelines and tune
-        other fit_args and fit_kwargs.
+        preprocessing layers,  and tune other fit_args and fit_kwargs.
 
         This is different from the callback's on_train_begin.
         """
-        pass
+        return
 
     def save_model(self, trial_id, model, step=0):
         epoch = step

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -320,7 +320,7 @@ def test_callbacks_run_each_execution(tmp_dir):
 def test_on_train_begin_in_multi_execution_tuner(tmp_dir):
 
     class MyTuner(kerastuner.tuners.RandomSearch):
-        def _on_train_begin(self, model, hp, *fit_args, **fit_kwargs):
+        def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
             self.was_called = True
 
     tuner = MyTuner(
@@ -342,7 +342,7 @@ def test_on_train_begin_in_multi_execution_tuner(tmp_dir):
 def test_on_train_begin_in_tuner(tmp_dir):
 
     class MyTuner(tuner_module.Tuner):
-        def _on_train_begin(self, model, hp, *fit_args, **fit_kwargs):
+        def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
             self.was_called = True
 
     tuner = MyTuner(
@@ -351,6 +351,51 @@ def test_on_train_begin_in_tuner(tmp_dir):
             max_trials=2,
         ),
         hypermodel=build_model,
+        directory=tmp_dir)
+
+    tuner.run_trial(
+        tuner.oracle.create_trial('tuner0'),
+        TRAIN_INPUTS,
+        TRAIN_TARGETS,
+        validation_data=(VAL_INPUTS, VAL_TARGETS))
+
+    assert tuner.was_called
+
+
+def test_on_build_begin_in_tuner(tmp_dir):
+
+    class MyTuner(tuner_module.Tuner):
+        def _on_build_begin(self, trial_id, hp, fit_args, fit_kwargs):
+            self.was_called = True
+
+    tuner = MyTuner(
+        oracle=kerastuner.tuners.randomsearch.RandomSearchOracle(
+            objective='val_loss',
+            max_trials=2,
+        ),
+        hypermodel=build_model,
+        directory=tmp_dir)
+
+    tuner.run_trial(
+        tuner.oracle.create_trial('tuner0'),
+        TRAIN_INPUTS,
+        TRAIN_TARGETS,
+        validation_data=(VAL_INPUTS, VAL_TARGETS))
+
+    assert tuner.was_called
+
+
+def test_on_build_begin_in_multi_execution_tuner(tmp_dir):
+
+    class MyTuner(kerastuner.tuners.RandomSearch):
+        def _on_build_begin(self, trial_id, hp, fit_args, fit_kwargs):
+            self.was_called = True
+
+    tuner = MyTuner(
+        hypermodel=build_model,
+        objective='val_accuracy',
+        max_trials=2,
+        executions_per_trial=3,
         directory=tmp_dir)
 
     tuner.run_trial(


### PR DESCRIPTION
AutoKeras will need to use tf.data preprocessing pipelines to transform the training data and get the input shape of the Keras model.
So added _on_build_begin function before building the hypermodel in the tuner, and pass the fit_args as a dictionary by reference for modification.