### PR TITLE
cleanup the override functions for ak

### DIFF
--- a/kerastuner/engine/multi_execution_tuner.py
+++ b/kerastuner/engine/multi_execution_tuner.py
@@ -92,12 +92,7 @@ class MultiExecutionTuner(tuner_module.Tuner):
             callbacks.append(model_checkpoint)
             copied_fit_kwargs['callbacks'] = callbacks
 
-            self._on_build_begin(trial.trial_id, trial.hyperparameters,
-                                 fit_args, copied_fit_kwargs)
-            model = self.hypermodel.build(trial.hyperparameters)
-            self._on_train_begin(model, trial.hyperparameters,
-                                 fit_args, copied_fit_kwargs)
-            history = model.fit(*fit_args, **copied_fit_kwargs)
+            history = self._build_and_fit_model(trial, fit_args, copied_fit_kwargs)
             for metric, epoch_values in history.history.items():
                 if self.oracle.objective.direction == 'min':
                     best_value = np.min(epoch_values)

--- a/tests/kerastuner/engine/tuner_correctness_test.py
+++ b/tests/kerastuner/engine/tuner_correctness_test.py
@@ -317,11 +317,12 @@ def test_callbacks_run_each_execution(tmp_dir):
     assert len(callback_instances) == 6
 
 
-def test_on_train_begin_in_multi_execution_tuner(tmp_dir):
+def test_build_and_fit_model_in_multi_execution_tuner(tmp_dir):
 
     class MyTuner(kerastuner.tuners.RandomSearch):
-        def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
+        def _build_and_fit_model(self, trial, fit_args, fit_kwargs):
             self.was_called = True
+            return super()._build_and_fit_model(trial, fit_args, fit_kwargs)
 
     tuner = MyTuner(
         hypermodel=build_model,
@@ -339,11 +340,12 @@ def test_on_train_begin_in_multi_execution_tuner(tmp_dir):
     assert tuner.was_called
 
 
-def test_on_train_begin_in_tuner(tmp_dir):
+def test_build_and_fit_model_in_tuner(tmp_dir):
 
     class MyTuner(tuner_module.Tuner):
-        def _on_train_begin(self, model, hp, fit_args, fit_kwargs):
+        def _build_and_fit_model(self, trial, fit_args, fit_kwargs):
             self.was_called = True
+            return super()._build_and_fit_model(trial, fit_args, fit_kwargs)
 
     tuner = MyTuner(
         oracle=kerastuner.tuners.randomsearch.RandomSearchOracle(
@@ -351,51 +353,6 @@ def test_on_train_begin_in_tuner(tmp_dir):
             max_trials=2,
         ),
         hypermodel=build_model,
-        directory=tmp_dir)
-
-    tuner.run_trial(
-        tuner.oracle.create_trial('tuner0'),
-        TRAIN_INPUTS,
-        TRAIN_TARGETS,
-        validation_data=(VAL_INPUTS, VAL_TARGETS))
-
-    assert tuner.was_called
-
-
-def test_on_build_begin_in_tuner(tmp_dir):
-
-    class MyTuner(tuner_module.Tuner):
-        def _on_build_begin(self, trial_id, hp, fit_args, fit_kwargs):
-            self.was_called = True
-
-    tuner = MyTuner(
-        oracle=kerastuner.tuners.randomsearch.RandomSearchOracle(
-            objective='val_loss',
-            max_trials=2,
-        ),
-        hypermodel=build_model,
-        directory=tmp_dir)
-
-    tuner.run_trial(
-        tuner.oracle.create_trial('tuner0'),
-        TRAIN_INPUTS,
-        TRAIN_TARGETS,
-        validation_data=(VAL_INPUTS, VAL_TARGETS))
-
-    assert tuner.was_called
-
-
-def test_on_build_begin_in_multi_execution_tuner(tmp_dir):
-
-    class MyTuner(kerastuner.tuners.RandomSearch):
-        def _on_build_begin(self, trial_id, hp, fit_args, fit_kwargs):
-            self.was_called = True
-
-    tuner = MyTuner(
-        hypermodel=build_model,
-        objective='val_accuracy',
-        max_trials=2,
-        executions_per_trial=3,
         directory=tmp_dir)
 
     tuner.run_trial(


### PR DESCRIPTION
Removed `_on_build_begin` and `_on_train_begin`.
Extracted the build and fit process as a separate function for `Tuner` and `MultiExecutionTuner` to reuse,
and for AutoKeras to override.

The refactor is to support the adaptive batch size feature in AutoKeras, which needs to surround the fit function with a try and except for OOM.