### PR TITLE
HyperParameters get now raises KeyError if _hps doesn't contain key.

### DIFF
--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -659,7 +659,7 @@ class HyperParameters(object):
         try:
             self.get(name)
             return True
-        except ValueError:
+        except (KeyError, ValueError):
             return False
 
     def Choice(self,

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -650,7 +650,7 @@ class HyperParameters(object):
         elif name in self._hps:
             raise ValueError('{} is currently inactive.'.format(name))
         else:
-            raise ValueError('{} does not exist.'.format(name))
+            raise KeyError('{} does not exist.'.format(name))
 
     def __getitem__(self, name):
         return self.get(name)

--- a/tests/kerastuner/engine/hyperparameters_test.py
+++ b/tests/kerastuner/engine/hyperparameters_test.py
@@ -46,7 +46,7 @@ def test_hyperparameters():
     assert hp.values == {'choice': 3}
     assert len(hp.space) == 1
     assert hp.space[0].name == 'choice'
-    with pytest.raises(ValueError, match='does not exist'):
+    with pytest.raises(KeyError, match='does not exist'):
         hp.get('wrong')
 
 
@@ -516,7 +516,7 @@ def test_dict_methods():
     assert hps['b'] == 2
     # Ok to access 'c' here since there is an active 'c'.
     assert hps['c'] == -25
-    with pytest.raises(ValueError, match='does not exist'):
+    with pytest.raises(KeyError, match='does not exist'):
         hps['d']
 
     assert 'a' in hps


### PR DESCRIPTION
resolves #411

The relevant method (get of HyperParameters) raised ValueError in two cases. 

1. If the key wasn't in values
2. If the key wasn't also in _hps

Since only the second case actually indicates non-existence of the hyperparameter by that name, I believe only it should be altered. as it is in this PR. 

