### PR TITLE
Add missing self

### DIFF
--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -289,7 +289,7 @@ class Tuner(base_tuner.BaseTuner):
         for callback in callbacks:
             if callback.__class__.__name__ == 'TensorBoard':
                 # Patch TensorBoard log_dir and add HParams KerasCallback
-                logdir = _get_tensorboard_dir(callback.log_dir, trial.trial_id)
+                logdir = self._get_tensorboard_dir(callback.log_dir, trial.trial_id)
                 callback.log_dir = logdir
                 hparams = tuner_utils.convert_hyperparams_to_hparams(
                     trial.hyperparameters)


### PR DESCRIPTION
Unless there's some runtime magic that I'm missing, `_get_tensorboard_dir` isn't defined at this point so I assume the intention was to call the class method here.