### PR TITLE
fix typo in Tuner class description

### DIFF
--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -60,7 +60,7 @@ class Tuner(base_tuner.BaseTuner):
         distribution_strategy: Optional. A TensorFlow
             `tf.distribute` DistributionStrategy instance. If
             specified, each trial will run under this scope. For
-            example, `tf.distribute.MirroredStrategy(['/gpu:0, /'gpu:1])`
+            example, `tf.distribute.MirroredStrategy(['/gpu:0', '/gpu:1'])`
             will run each trial on two GPUs. Currently only
             single-worker strategies are supported.
         directory: String. Path to the working directory (relative).


### PR DESCRIPTION
the `tf.distribute.MirroredStrategy` example has missing apostrophes. Example now matches https://www.tensorflow.org/api_docs/python/tf/distribute/MirroredStrategy