### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         'packaging',
         'future',
-        'numpy < 1.19.0',
+        'numpy',
         'tabulate',
         'terminaltables',
         'colorama',


### PR DESCRIPTION
From TF 2.4, we don't need to limit the version of numpy.