### PR TITLE
Update tensorflow requirement to 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Keras Tuner
 
-A hyperparameter tuner for [Keras](https://keras.io), specifically for `tf.keras` with TensorFlow 2.0.
+A hyperparameter tuner for [Keras](https://keras.io), specifically for `tf.keras` with TensorFlow 2.2.
 
 Full documentation and tutorials available on the [Keras Tuner website.](https://keras-team.github.io/keras-tuner/)
 


### PR DESCRIPTION
[augment.py](https://github.com/keras-team/keras-tuner/blob/master/kerastuner/applications/augment.py#L34) references `experimental.preprocessing.RandomRotation`, which, according to #448, is available since tf 2.2.

If keras-tuner 1.0.3 is installed with tf 2.1, `import kerastuner` throws exceptions right away.

