### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/kerastuner/applications/augment.py
+++ b/kerastuner/applications/augment.py
@@ -40,7 +40,7 @@ class HyperImageAugment(hypermodel.HyperModel):
     """ Builds HyperModel for image augmentation.
     Only supporting augmentations available in Keras preprocessing layers currently.
 
-    # Arguments:
+    # Args:
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
@@ -225,7 +225,7 @@ class HyperImageAugment(hypermodel.HyperModel):
 
     def _register_transform(self, transform_name, transform_params):
         """Register a transform and format parameters for tuning the transform.
-        # Arguments:
+        # Args:
             transform_name: str, the name of the transform.
             trnasform_params: A number between [0, 1], a list of two numbers
                 between [0, 1] or None. If set to a single number x, the

--- a/kerastuner/applications/efficientnet.py
+++ b/kerastuner/applications/efficientnet.py
@@ -49,7 +49,7 @@ class HyperEfficientNet(hypermodel.HyperModel):
     ints [0, 255]. The output data should be one-hot encoded
     with number of classes matching `classes`.
 
-      # Arguments:
+      # Args:
 
         input_shape: shape tuple, e.g. `(256, 256, 3)`.
               Input images will be resized if different from

--- a/kerastuner/applications/resnet.py
+++ b/kerastuner/applications/resnet.py
@@ -25,7 +25,7 @@ from kerastuner.engine import hypermodel
 class HyperResNet(hypermodel.HyperModel):
     """A ResNet HyperModel.
 
-    # Arguments:
+    # Args:
 
         include_top: whether to include the fully-connected
             layer at the top of the network.

--- a/kerastuner/applications/xception.py
+++ b/kerastuner/applications/xception.py
@@ -22,7 +22,7 @@ from kerastuner.engine import hypermodel
 class HyperXception(hypermodel.HyperModel):
     """An Xception HyperModel.
 
-    # Arguments:
+    # Args:
 
         include_top: whether to include the fully-connected
             layer at the top of the network.

--- a/kerastuner/engine/base_tuner.py
+++ b/kerastuner/engine/base_tuner.py
@@ -36,7 +36,7 @@ class BaseTuner(stateful.Stateful):
 
     May be subclassed to create new tuners, including for non-Keras models.
 
-    # Arguments:
+    # Args:
         oracle: Instance of Oracle class.
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
@@ -108,7 +108,7 @@ class BaseTuner(stateful.Stateful):
     def search(self, *fit_args, **fit_kwargs):
         """Performs a search for best hyperparameter configuations.
 
-        # Arguments:
+        # Args:
             *fit_args: Positional arguments that should be passed to
               `run_trial`, for example the training and validation data.
             *fit_kwargs: Keyword arguments that should be passed to
@@ -154,7 +154,7 @@ class BaseTuner(stateful.Stateful):
             self.save_model(trial.trial_id, model)
         ```
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. Hyperparameters can be accessed
               via `trial.hyperparameters`.
@@ -166,7 +166,7 @@ class BaseTuner(stateful.Stateful):
     def save_model(self, trial_id, model, step=0):
         """Saves a Model for a given trial.
 
-        # Arguments:
+        # Args:
             trial_id: The ID of the `Trial` that corresponds to this Model.
             model: The trained model.
             step: For models that report intermediate results to the `Oracle`,
@@ -178,7 +178,7 @@ class BaseTuner(stateful.Stateful):
     def load_model(self, trial):
         """Loads a Model from a given trial.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance. For models that report intermediate
               results to the `Oracle`, generally `load_model` should load the
               best reported `step` by relying of `trial.best_step`
@@ -193,7 +193,7 @@ class BaseTuner(stateful.Stateful):
     def on_trial_begin(self, trial):
         """A hook called before starting each trial.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
         """
         if self.logger:
@@ -203,7 +203,7 @@ class BaseTuner(stateful.Stateful):
     def on_trial_end(self, trial):
         """A hook called after each trial is run.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
         """
         # Send status to Logger
@@ -229,7 +229,7 @@ class BaseTuner(stateful.Stateful):
         recommended to retrain your Model on the full dataset using the best
         hyperparameters found during `search`.
 
-        # Arguments:
+        # Args:
             num_models (int, optional). Number of best models to return.
                 Models will be returned in sorted order. Defaults to 1.
 
@@ -253,7 +253,7 @@ class BaseTuner(stateful.Stateful):
         model = tuner.hypermodel.build(best_hp)
         ```
 
-        # Arguments:
+        # Args:
             num_trials: (int, optional). Number of `HyperParameters` objects to
               return. `HyperParameters` will be returned in sorted order based on
               trial performance.

--- a/kerastuner/engine/conditions.py
+++ b/kerastuner/engine/conditions.py
@@ -47,7 +47,7 @@ class Condition(object):
 
         Determines whether this condition is true for the current `Trial`.
 
-        # Arguments:
+        # Args:
             values: Dict. The active values for this `Trial`. Keys are the
                names of the hyperparameters.
 
@@ -94,7 +94,7 @@ class Parent(Condition):
     b = Int('num_layers', 5, 10, conditions=[kt.conditions.Parent('a', ['dnn'])])
     ```
 
-    # Arguments:
+    # Args:
         name: The name of a `HyperParameter`.
         values: Values for which the `HyperParameter` this object is
             passed to should be considered active.

--- a/kerastuner/engine/hypermodel.py
+++ b/kerastuner/engine/hypermodel.py
@@ -48,7 +48,7 @@ class HyperModel(object):
     def build(self, hp):
         """Builds a model.
 
-        # Arguments:
+        # Args:
             hp: A `HyperParameters` instance.
 
         # Returns:

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -68,7 +68,7 @@ def _check_int(val, arg):
 class HyperParameter(object):
     """HyperParameter base class.
 
-    # Arguments:
+    # Args:
         name: Str. Name of parameter. Must be unique.
         default: Default value to return for the
             parameter.
@@ -104,7 +104,7 @@ class HyperParameter(object):
 class Choice(HyperParameter):
     """Choice of one value among a predefined set of possible values.
 
-    # Arguments:
+    # Args:
         name: Str. Name of parameter. Must be unique.
         values: List of possible values. Values must be int, float,
             str, or bool. All values must be of the same type.
@@ -226,7 +226,7 @@ class Int(HyperParameter):
     Note that unlike Python's `range` function, `max_value` is *included* in
     the possible values this parameter can take on.
 
-    # Arguments:
+    # Args:
         name: Str. Name of parameter. Must be unique.
         min_value: Int. Lower limit of range (included).
         max_value: Int. Upper limit of range (included).
@@ -314,7 +314,7 @@ class Int(HyperParameter):
 class Float(HyperParameter):
     """Floating point range, can be evenly divided.
 
-    # Arguments:
+    # Args:
         name: Str. Name of parameter. Must be unique.
         min_value: Float. Lower bound of the range.
         max_value: Float. Upper bound of the range.
@@ -566,7 +566,7 @@ class HyperParameters(object):
         Note that any Python code under this scope will execute
         regardless of whether the condition is met.
 
-        # Arguments:
+        # Args:
             parent_name: The name of the HyperParameter to condition on.
             parent_values: Values of the parent HyperParameter for which
               HyperParameters under this scope should be considered active.
@@ -586,7 +586,7 @@ class HyperParameters(object):
     def is_active(self, hyperparameter):
         """Checks if a hyperparameter is currently active for a `Trial`.
 
-        # Arguments:
+        # Args:
           hp: Str or `HyperParameter`. If str, checks if any
               `HyperParameter` with that name is active. If `HyperParameter`,
               checks that this object is active.
@@ -671,7 +671,7 @@ class HyperParameters(object):
                parent_values=None):
         """Choice of one value among a predefined set of possible values.
 
-        # Arguments:
+        # Args:
             name: Str. Name of parameter. Must be unique.
             values: List of possible values. Values must be int, float,
                 str, or bool. All values must be of the same type.
@@ -712,7 +712,7 @@ class HyperParameters(object):
         Note that unlike Python's `range` function, `max_value` is *included* in
         the possible values this parameter can take on.
 
-        # Arguments:
+        # Args:
             name: Str. Name of parameter. Must be unique.
             min_value: Int. Lower limit of range (included).
             max_value: Int. Upper limit of range (included).
@@ -754,7 +754,7 @@ class HyperParameters(object):
               parent_values=None):
         """Floating point range, can be evenly divided.
 
-        # Arguments:
+        # Args:
             name: Str. Name of parameter. Must be unique.
             min_value: Float. Lower bound of the range.
             max_value: Float. Upper bound of the range.
@@ -866,7 +866,7 @@ class HyperParameters(object):
     def merge(self, hps, overwrite=True):
         """Merges hyperparameters into this object.
 
-        Arguments:
+        Args:
           hps: A `HyperParameters` object or list of `HyperParameter`
             objects.
           overwrite: bool. Whether existing `HyperParameter`s should

--- a/kerastuner/engine/stateful.py
+++ b/kerastuner/engine/stateful.py
@@ -35,7 +35,7 @@ class Stateful(object):
 
         This method is called during `reload`.
 
-        # Arguments:
+        # Args:
           state: Dict. The state to restore for this object.
         """
         raise NotImplementedError
@@ -43,7 +43,7 @@ class Stateful(object):
     def save(self, fname):
         """Saves this object using `get_state`.
 
-        # Arguments:
+        # Args:
           fname: The file name to save to.
         """
         state = self.get_state()
@@ -55,7 +55,7 @@ class Stateful(object):
     def reload(self, fname):
         """Reloads this object using `set_state`.
 
-        # Arguments:
+        # Args:
           fname: The file name to restore from.
         """
         with tf.io.gfile.GFile(fname, 'r') as f:

--- a/kerastuner/engine/tuner.py
+++ b/kerastuner/engine/tuner.py
@@ -33,7 +33,7 @@ class Tuner(base_tuner.BaseTuner):
 
     May be subclassed to create new tuners.
 
-    # Arguments:
+    # Args:
         oracle: Instance of Oracle class.
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
@@ -127,7 +127,7 @@ class Tuner(base_tuner.BaseTuner):
         the input shape before building the model, adapt preprocessing layers,
         and tune other fit_args and fit_kwargs.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
               via `trial.hyperparameters`.
@@ -146,7 +146,7 @@ class Tuner(base_tuner.BaseTuner):
         This method is called during `search` to evaluate a set of
         hyperparameters.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
               via `trial.hyperparameters`.
@@ -202,7 +202,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_epoch_begin(self, trial, model, epoch, logs=None):
         """A hook called at the start of every epoch.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             epoch: The current epoch number.
@@ -213,7 +213,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_batch_begin(self, trial, model, batch, logs):
         """A hook called at the start of every batch.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             batch: The current batch number within the
@@ -225,7 +225,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_batch_end(self, trial, model, batch, logs=None):
         """A hook called at the end of every batch.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             batch: The current batch number within the
@@ -237,7 +237,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_epoch_end(self, trial, model, epoch, logs=None):
         """A hook called at the end of every epoch.
 
-        # Arguments:
+        # Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             epoch: The current epoch number.

--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -241,7 +241,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
     """BayesianOptimization tuning with Gaussian process.
 
-    # Arguments:
+    # Args:
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
             and returns a Model instance).

--- a/kerastuner/tuners/hyperband.py
+++ b/kerastuner/tuners/hyperband.py
@@ -56,7 +56,7 @@ class HyperbandOracle(oracle_module.Oracle):
             self.on_epoch_end(...)
     ```
 
-    # Arguments:
+    # Args:
         objective: String or `kerastuner.Objective`. If a string,
           the direction of the optimization (min or max) will be
           inferred.

--- a/kerastuner/tuners/randomsearch.py
+++ b/kerastuner/tuners/randomsearch.py
@@ -26,7 +26,7 @@ from ..engine import trial as trial_lib
 class RandomSearchOracle(oracle_module.Oracle):
     """Random search oracle.
 
-    # Arguments:
+    # Args:
         objective: String or `kerastuner.Objective`. If a string,
           the direction of the optimization (min or max) will be
           inferred.
@@ -87,7 +87,7 @@ class RandomSearchOracle(oracle_module.Oracle):
 class RandomSearch(multi_execution_tuner.MultiExecutionTuner):
     """Random search tuner.
 
-    # Arguments:
+    # Args:
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
             and returns a Model instance).

--- a/kerastuner/tuners/sklearn_tuner.py
+++ b/kerastuner/tuners/sklearn_tuner.py
@@ -28,7 +28,7 @@ class Sklearn(base_tuner.BaseTuner):
     Performs cross-validated hyperparameter search for Scikit-learn
     models.
 
-    # Arguments:
+    # Args:
         oracle: An instance of the `kerastuner.Oracle` class. Note that for
           this `Tuner`, the `objective` for the `Oracle` should always be set
           to `Objective('score', direction='max')`. Also, `Oracle`s that exploit
@@ -114,7 +114,7 @@ class Sklearn(base_tuner.BaseTuner):
     def search(self, X, y, sample_weight=None, groups=None):
         """Performs hyperparameter search.
 
-        Arguments:
+        Args:
           X: See docstring for `model.fit` for the `sklearn` Models being tuned.
           y: See docstring for `model.fit` for the `sklearn` Models being tuned.
           sample_weight: (Optional). See docstring for `model.fit` for the


### PR DESCRIPTION
**EDIT: Most of these changes are to the Keras format, not the Google one. Only consider merging this PR [as is] iff https://github.com/keras-team/keras-contrib/pull/550 is accepted**

I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420