### PR TITLE
Correction of subclass-tuner.md sample code

### DIFF
--- a/docs/templates/tutorials/subclass-tuner.md
+++ b/docs/templates/tutorials/subclass-tuner.md
@@ -40,7 +40,7 @@ class MyTuner(kt.Tuner):
         model = self.hypermodel.build(trial.hyperparameters)
         score = ...
         self.oracle.update_trial(trial.trial_id, {'score': score})
-        self.oracle.save_model(trial.trial_id, model)
+        self.save_model(trial.trial_id, model)
 ```
 
 ### Adding HyperParameters during preprocessing, evaluation, etc.


### PR DESCRIPTION
`self.oracle.save_model(trail.trial_id, model)` yields the error 'Oracle_class' (e.g BayesianOptimizerOracle) does not have property save_model, so the actual usage should stem from self:
`self.save_model(trail.trial_id, model)` as stated in the text description of the code.