### PR TITLE
remove sklearn from bayesian tuner

### DIFF
--- a/tests/kerastuner/tuners/bayesian_test.py
+++ b/tests/kerastuner/tuners/bayesian_test.py
@@ -35,6 +35,20 @@ def build_model(hp):
     return model
 
 
+def test_gpr_mse_is_small():
+    x_train = np.random.rand(1000, 2)
+    y_train = np.multiply(x_train, x_train).mean(axis=-1).reshape(-1, 1)
+    x_test = np.random.rand(1000, 2)
+    y_test = np.multiply(x_test, x_test).mean(axis=-1).reshape(-1, 1)
+
+    gpr = bo_module.GaussianProcessRegressor(alpha=1e-4, seed=3)
+    gpr.fit(x_train, y_train)
+    y_predict_mean, y_predict_std = gpr.predict(x_test)
+
+    assert ((y_predict_mean - y_test) ** 2).mean(axis=0) < 1e-8
+    assert y_predict_std.shape == (1000,)
+
+
 def test_bayesian_oracle(tmp_dir):
     hps = hp_module.HyperParameters()
     hps.Choice("a", [1, 2], default=1)


### PR DESCRIPTION
This is the first step for removing sklearn from dependency.
We implemented a Gaussian process regressor and a matern kernel based on Scipy.
One TODO is left in the code, select the theta value for the kernel, which was originally an optimization implemented in sklearn for Gaussian process regressor.

The next steps are:
1. try import sklearn in the sklearn tuner. (#500)
2. move sklearn to optional dependency in setup.py. (#501)
3. Remove the scipy dependency.