### PR TITLE
Unnecessary explicit object inheritance.

### DIFF
--- a/kerastuner/distribute/oracle_client.py
+++ b/kerastuner/distribute/oracle_client.py
@@ -23,7 +23,7 @@ from ..protos import service_pb2
 from ..protos import service_pb2_grpc
 
 
-class OracleClient(object):
+class OracleClient:
     """Wraps an `Oracle` on a worker to send requests to the chief."""
 
     def __init__(self, oracle):

--- a/kerastuner/engine/conditions.py
+++ b/kerastuner/engine/conditions.py
@@ -25,7 +25,7 @@ from ..protos import kerastuner_pb2
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Condition(object):
+class Condition:
     """Abstract condition for a conditional hyperparameter.
 
     Subclasses of this object can be passed to a `HyperParameter` to

--- a/kerastuner/engine/hypermodel.py
+++ b/kerastuner/engine/hypermodel.py
@@ -27,7 +27,7 @@ from tensorflow import keras
 from .. import config as config_module
 
 
-class HyperModel(object):
+class HyperModel:
     """Defines a searchable space of Models and builds Models from this space.
 
     # Attributes:

--- a/kerastuner/engine/hyperparameters.py
+++ b/kerastuner/engine/hyperparameters.py
@@ -67,7 +67,7 @@ def _check_int(val, arg):
     return int_val
 
 
-class HyperParameter(object):
+class HyperParameter:
     """HyperParameter base class.
 
     # Arguments:
@@ -531,7 +531,7 @@ class Fixed(HyperParameter):
         )
 
 
-class HyperParameters(object):
+class HyperParameters:
     """Container for both a hyperparameter space, and current values.
 
     # Attributes:

--- a/kerastuner/engine/logger.py
+++ b/kerastuner/engine/logger.py
@@ -16,7 +16,7 @@ AUTH_ERROR = 3
 UPLOAD_ERROR = 4
 
 
-class Logger(object):
+class Logger:
     def register_tuner(self, tuner_state):
         """Informs the logger that a new search is starting."""
         raise NotImplementedError

--- a/kerastuner/engine/metrics_tracking.py
+++ b/kerastuner/engine/metrics_tracking.py
@@ -23,7 +23,7 @@ from tensorflow import keras
 from ..protos import kerastuner_pb2
 
 
-class MetricObservation(object):
+class MetricObservation:
     def __init__(self, value, step):
         if not isinstance(value, list):
             value = [value]
@@ -61,7 +61,7 @@ class MetricObservation(object):
         return cls(value=list(proto.value), step=proto.step)
 
 
-class MetricHistory(object):
+class MetricHistory:
     def __init__(self, direction="min"):
         if direction not in {"min", "max"}:
             raise ValueError(
@@ -152,7 +152,7 @@ class MetricHistory(object):
         return instance
 
 
-class MetricsTracker(object):
+class MetricsTracker:
     def __init__(self, metrics=None):
         # str -> MetricHistory
         self.metrics = {}

--- a/kerastuner/engine/stateful.py
+++ b/kerastuner/engine/stateful.py
@@ -22,7 +22,7 @@ import json
 import tensorflow as tf
 
 
-class Stateful(object):
+class Stateful:
     def get_state(self):
         """Returns the current state of this object.
 

--- a/kerastuner/engine/tuner_utils.py
+++ b/kerastuner/engine/tuner_utils.py
@@ -30,7 +30,7 @@ from .. import utils
 from . import hyperparameters as hp_module
 
 
-class TunerStats(object):
+class TunerStats:
     """Track tuner statistics."""
 
     def __init__(self):
@@ -93,7 +93,7 @@ class TunerCallback(keras.callbacks.Callback):
 
 
 # TODO: Add more extensive display.
-class Display(object):
+class Display:
     def __init__(self, oracle, verbose=1):
         self.verbose = verbose
         self.oracle = oracle

--- a/kerastuner/protos/service_pb2_grpc.py
+++ b/kerastuner/protos/service_pb2_grpc.py
@@ -4,7 +4,7 @@ import grpc
 from kerastuner.protos import service_pb2 as kerastuner_dot_protos_dot_service__pb2
 
 
-class OracleStub(object):
+class OracleStub:
   # missing associated documentation comment in .proto file
   pass
 
@@ -51,7 +51,7 @@ class OracleStub(object):
         )
 
 
-class OracleServicer(object):
+class OracleServicer:
   # missing associated documentation comment in .proto file
   pass
 

--- a/kerastuner/tuners/bayesian.py
+++ b/kerastuner/tuners/bayesian.py
@@ -39,7 +39,7 @@ def matern_kernel(x, y=None):
     return kernel_matrix
 
 
-class GaussianProcessRegressor(object):
+class GaussianProcessRegressor:
     """A Gaussian process regressor.
 
     # Arguments


### PR DESCRIPTION
Minor stylistic fix. As all classes implicitly
inherit from object in Python 3, explicit inheritance
from object is no longer necessary.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>