### PR TITLE
Argument for the 'fit' method verbosity.

### DIFF
--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -143,6 +143,9 @@ class Tuner(base_tuner.BaseTuner):
         Returns:
             The fit history.
         """
+        if "keras_verbose" in fit_kwargs:
+            fit_kwargs["verbose"] = fit_kwargs.pop("keras_verbose", 1)
+
         model = self.hypermodel.build(trial.hyperparameters)
         return model.fit(*fit_args, **fit_kwargs)
 

--- a/tests/keras_tuner/engine/tuner_correctness_test.py
+++ b/tests/keras_tuner/engine/tuner_correctness_test.py
@@ -354,6 +354,7 @@ def test_build_and_fit_model_in_tuner(tmp_dir):
         TRAIN_INPUTS,
         TRAIN_TARGETS,
         validation_data=(VAL_INPUTS, VAL_TARGETS),
+        keras_verbose=1,
     )
 
     assert tuner.was_called


### PR DESCRIPTION
Right now we have to set logging verbosity for both keras and keras tuner in one place.
That can make output a bit messy if we want to see the trial results and hyperparameters,
as it also displays the progress and stats of the tuned keras model.
Even on default '1' this is at least a line per epoch [1]

This patch will give allow for setting verbosity of the keras training output with a new key word argument.
If the argument isn't set, the behavior will remain the same.

Resolves: #569 

[1] https://keras.rstudio.com/reference/fit.html

Commit msg: 
-----------------
kwargs are queried for the 'keras_verbose' parameter
setting verbosity for the 'fit' method of the instantiated
model tested by the tuner.

Default logging level set to 1. As specified in
Keras documentation of the 'fit' method.

Signed-off-by: Jiri Podivin <jpodivin@gmail.com>