### PR TITLE
Improving the documentations

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -36,9 +36,9 @@ TRANSFORMS = {
 
 
 class HyperImageAugment(hypermodel.HyperModel):
-    """A image augmentation HyperModel.
+    """A image augmentation hypermodel.
 
-    The HyperImageAugment class searches for the best combination of image
+    The `HyperImageAugment` class searches for the best combination of image
     augmentation operations in Keras preprocessing layers. The input shape of
     the model should be (height, width, channels). The output of the model is
     of the same shape as the input.
@@ -88,7 +88,7 @@ class HyperImageAugment(hypermodel.HyperModel):
             determines number of layers of augment transforms are applied,
             each randomly picked from all available transform types with equal
             probability on each sample.
-        **kwargs: Additional keyword arguments that apply to all HyperModels.
+        **kwargs: Additional keyword arguments that apply to all hypermodels.
             See `keras_tuner.HyperModel`.
 
     Example:

--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -40,7 +40,7 @@ class HyperImageAugment(hypermodel.HyperModel):
 
     Only supporting augmentations available in Keras preprocessing layers currently.
 
-    Arguments:
+    Args:
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
         input_tensor: Optional Keras tensor (i.e. output of
             `layers.Input()`) to use as image input for the model.
@@ -231,7 +231,8 @@ class HyperImageAugment(hypermodel.HyperModel):
 
     def _register_transform(self, transform_name, transform_params):
         """Register a transform and format parameters for tuning the transform.
-        Arguments:
+
+        Args:
             transform_name: str, the name of the transform.
             trnasform_params: A number between [0, 1], a list of two numbers
                 between [0, 1] or None. If set to a single number x, the

--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -36,14 +36,17 @@ TRANSFORMS = {
 
 
 class HyperImageAugment(hypermodel.HyperModel):
-    """Builds HyperModel for image augmentation.
+    """A image augmentation HyperModel.
 
-    Only supporting augmentations available in Keras preprocessing layers currently.
+    The HyperImageAugment class searches for the best combination of image
+    augmentation operations in Keras preprocessing layers. The input shape of
+    the model should be (height, width, channels). The output of the model is
+    of the same shape as the input.
 
     Args:
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-        input_tensor: Optional Keras tensor (i.e. output of
-            `layers.Input()`) to use as image input for the model.
+        input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.
         rotate: A number between [0, 1], a list of two numbers between [0, 1]
             or None. Configures the search space of the factor of random
             rotation transform in the augmentation. A factor is chosen for each
@@ -85,8 +88,8 @@ class HyperImageAugment(hypermodel.HyperModel):
             determines number of layers of augment transforms are applied,
             each randomly picked from all available transform types with equal
             probability on each sample.
-        **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `keras_tuner.HyperModel`.
+        **kwargs: Additional keyword arguments that apply to all HyperModels.
+            See `keras_tuner.HyperModel`.
 
     Example:
 
@@ -233,7 +236,7 @@ class HyperImageAugment(hypermodel.HyperModel):
         """Register a transform and format parameters for tuning the transform.
 
         Args:
-            transform_name: str, the name of the transform.
+            transform_name: A string, the name of the transform.
             trnasform_params: A number between [0, 1], a list of two numbers
                 between [0, 1] or None. If set to a single number x, the
                 corresponding transform factor will be between [0, x].

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -46,23 +46,25 @@ EFFICIENTNET_IMG_SIZE = {
 
 
 class HyperEfficientNet(hypermodel.HyperModel):
-    """An EfficientNet HyperModel.
+    """An EfficientNet hypermodel.
 
-    Models built by HyperEfficientNet take images with shape (height, width,
+    Models built by `HyperEfficientNet` take images with shape (height, width,
     channels) as input. The output are one-hot encoded with the length matching
     the number of classes specified by the `classes` argument.
 
     Args:
-        input_shape: shape tuple, e.g. `(256, 256, 3)`. Input images will be
-            resized if different from the default input size of the version of
-            efficientnet base model used.  One of `input_shape` or
-            `input_tensor` must be specified.
-        input_tensor: Keras tensor to use as image input for the model.  One of
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
             `input_shape` or `input_tensor` must be specified.
-        classes: number of classes to classify images into.
-        augmentation_model: optional Model or HyperModel for image augmentation.
-        **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `keras_tuner.HyperModel`.
+        input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.  One of `input_shape` or
+            `input_tensor` must be specified.
+        classes: Optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
+        augmentation_model: Optional `Model` or `HyperModel` instance for image
+            augmentation.
+        **kwargs: Additional keyword arguments that apply to all hypermodels.
+            See `keras_tuner.HyperModel`.
     """
 
     def __init__(
@@ -78,7 +80,7 @@ class HyperEfficientNet(hypermodel.HyperModel):
         ):
             raise ValueError(
                 "Keyword augmentation_model should be "
-                "a HyperModel, a Keras Model or empty. "
+                "a `HyperModel`, a Keras `Model` or empty. "
                 "Received {}.".format(augmentation_model)
             )
 

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -52,16 +52,13 @@ class HyperEfficientNet(hypermodel.HyperModel):
     ints [0, 255]. The output data should be one-hot encoded
     with number of classes matching `classes`.
 
-    Arguments:
-        input_shape: shape tuple, e.g. `(256, 256, 3)`.
-              Input images will be resized if different from
-              the default input size of the version of
-              efficientnet base model used.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        input_tensor: Keras tensor to use as image input for the model.
-              One of `input_shape` or `input_tensor` must be
-              specified.
+    Args:
+        input_shape: shape tuple, e.g. `(256, 256, 3)`. Input images will be
+            resized if different from the default input size of the version of
+            efficientnet base model used.  One of `input_shape` or
+            `input_tensor` must be specified.
+        input_tensor: Keras tensor to use as image input for the model.  One of
+            `input_shape` or `input_tensor` must be specified.
         classes: number of classes to classify images into.
         augmentation_model: optional Model or HyperModel for image augmentation.
         **kwargs: Additional keyword arguments that apply to all

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -48,9 +48,9 @@ EFFICIENTNET_IMG_SIZE = {
 class HyperEfficientNet(hypermodel.HyperModel):
     """An EfficientNet HyperModel.
 
-    Models built by this HyperModel takes input image data in
-    ints [0, 255]. The output data should be one-hot encoded
-    with number of classes matching `classes`.
+    Models built by HyperEfficientNet take images with shape (height, width,
+    channels) as input. The output are one-hot encoded with the length matching
+    the number of classes specified by the `classes` argument.
 
     Args:
         input_shape: shape tuple, e.g. `(256, 256, 3)`. Input images will be
@@ -150,8 +150,8 @@ class HyperEfficientNet(hypermodel.HyperModel):
     def _compile(self, model, hp):
         """Compile model using hyperparameters in hp.
 
-        When subclassing the hypermodel, this may
-        be overriden to change behavior of compiling.
+        When subclassing the hypermodel, this may be overriden to change
+        behavior of compiling.
         """
         learning_rate = hp.Choice("learning_rate", [0.1, 0.01, 0.001], default=0.01)
         optimizer = tf.keras.optimizers.SGD(

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -23,9 +23,9 @@ from keras_tuner.engine import hypermodel
 
 
 class HyperResNet(hypermodel.HyperModel):
-    """A ResNet HyperModel.
+    """A ResNet hypermodel.
 
-    Models built by HyperResNet take images with shape (height, width,
+    Models built by `HyperResNet` take images with shape (height, width,
     channels) as input. The output are one-hot encoded with the length matching
     the number of classes specified by the `classes` argument.
 
@@ -40,7 +40,7 @@ class HyperResNet(hypermodel.HyperModel):
         classes: Optional number of classes to classify images into, only to be
             specified if `include_top` is True, and if no `weights` argument is
             specified.
-        **kwargs: Additional keyword arguments that apply to all HyperModels.
+        **kwargs: Additional keyword arguments that apply to all hypermodels.
             See `keras_tuner.HyperModel`.
     """
 

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -25,21 +25,19 @@ from keras_tuner.engine import hypermodel
 class HyperResNet(hypermodel.HyperModel):
     """A ResNet HyperModel.
 
-    Arguments:
-        include_top: whether to include the fully-connected
-            layer at the top of the network.
-        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        input_tensor: Optional Keras tensor (i.e. output of
-            `layers.Input()`) to use as image input for the model.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        classes: optional number of classes to classify images
-            into, only to be specified if `include_top` is True,
-            and if no `weights` argument is specified.
-        **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `keras_tuner.HyperModel`.
+    Args:
+        include_top: whether to include the fully-connected layer at the top of
+            the network.
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
+            `input_shape` or `input_tensor` must be specified.
+        input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.  One of `input_shape` or
+            `input_tensor` must be specified.
+        classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
+        **kwargs: Additional keyword arguments that apply to all HyperModels.
+            See `keras_tuner.HyperModel`.
     """
 
     def __init__(
@@ -147,7 +145,8 @@ class HyperResNet(hypermodel.HyperModel):
 
 def block1(x, filters, kernel_size=3, stride=1, conv_shortcut=True, name=None):
     """A residual block.
-    # Arguments
+
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer.
         kernel_size: default 3, kernel size of the bottleneck layer.
@@ -155,7 +154,8 @@ def block1(x, filters, kernel_size=3, stride=1, conv_shortcut=True, name=None):
         conv_shortcut: default True, use convolution shortcut if True,
             otherwise identity shortcut.
         name: string, block label.
-    # Returns
+
+    Returns:
         Output tensor for the residual block.
     """
     bn_axis = 3 if backend.image_data_format() == "channels_last" else 1
@@ -195,7 +195,7 @@ def block1(x, filters, kernel_size=3, stride=1, conv_shortcut=True, name=None):
 def stack1(x, filters, blocks, stride1=2, name=None):
     """A set of stacked residual blocks.
 
-    Arguments:
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer in a block.
         blocks: integer, blocks in the stacked blocks.
@@ -214,7 +214,7 @@ def stack1(x, filters, blocks, stride1=2, name=None):
 def block2(x, filters, kernel_size=3, stride=1, conv_shortcut=False, name=None):
     """A residual block.
 
-    Arguments:
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer.
         kernel_size: default 3, kernel size of the bottleneck layer.
@@ -265,7 +265,7 @@ def block2(x, filters, kernel_size=3, stride=1, conv_shortcut=False, name=None):
 def stack2(x, filters, blocks, stride1=2, name=None):
     """A set of stacked residual blocks.
 
-    Arguments:
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer in a block.
         blocks: integer, blocks in the stacked blocks.
@@ -287,7 +287,7 @@ def block3(
 ):
     """A residual block.
 
-    Arguments:
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer.
         kernel_size: default 3, kernel size of the bottleneck layer.
@@ -365,7 +365,7 @@ def block3(
 def stack3(x, filters, blocks, stride1=2, groups=32, name=None):
     """A set of stacked residual blocks.
 
-    Arguments:
+    Args:
         x: input tensor.
         filters: integer, filters of the bottleneck layer in a block.
         blocks: integer, blocks in the stacked blocks.

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -31,7 +31,7 @@ class HyperResNet(hypermodel.HyperModel):
 
     Args:
         include_top: Boolean, whether to include the fully-connected layer at
-        the top of the network.
+            the top of the network.
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
             `input_shape` or `input_tensor` must be specified.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -25,15 +25,19 @@ from keras_tuner.engine import hypermodel
 class HyperResNet(hypermodel.HyperModel):
     """A ResNet HyperModel.
 
+    Models built by HyperResNet take images with shape (height, width,
+    channels) as input. The output are one-hot encoded with the length matching
+    the number of classes specified by the `classes` argument.
+
     Args:
-        include_top: whether to include the fully-connected layer at the top of
-            the network.
+        include_top: Boolean, whether to include the fully-connected layer at
+        the top of the network.
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
             `input_shape` or `input_tensor` must be specified.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.  One of `input_shape` or
             `input_tensor` must be specified.
-        classes: optional number of classes to classify images into, only to be
+        classes: Optional number of classes to classify images into, only to be
             specified if `include_top` is True, and if no `weights` argument is
             specified.
         **kwargs: Additional keyword arguments that apply to all HyperModels.

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -22,15 +22,19 @@ from keras_tuner.engine import hypermodel
 class HyperXception(hypermodel.HyperModel):
     """An Xception HyperModel.
 
+    Models built by HyperXception take images with shape (height, width,
+    channels) as input. The output are one-hot encoded with the length matching
+    the number of classes specified by the `classes` argument.
+
     Args:
-        include_top: whether to include the fully-connected layer at the top of
-            the network.
+        include_top: Boolean, whether to include the fully-connected layer at
+            the top of the network.
         input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
             `input_shape` or `input_tensor` must be specified.
         input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
             to use as image input for the model.  One of `input_shape` or
             `input_tensor` must be specified.
-        classes: optional number of classes to classify images into, only to be
+        classes: Optional number of classes to classify images into, only to be
             specified if `include_top` is True, and if no `weights` argument is
             specified.
         **kwargs: Additional keyword arguments that apply to all HyperModels.

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -20,9 +20,9 @@ from keras_tuner.engine import hypermodel
 
 
 class HyperXception(hypermodel.HyperModel):
-    """An Xception HyperModel.
+    """An Xception hypermodel.
 
-    Models built by HyperXception take images with shape (height, width,
+    Models built by `HyperXception` take images with shape (height, width,
     channels) as input. The output are one-hot encoded with the length matching
     the number of classes specified by the `classes` argument.
 
@@ -37,7 +37,7 @@ class HyperXception(hypermodel.HyperModel):
         classes: Optional number of classes to classify images into, only to be
             specified if `include_top` is True, and if no `weights` argument is
             specified.
-        **kwargs: Additional keyword arguments that apply to all HyperModels.
+        **kwargs: Additional keyword arguments that apply to all hypermodels.
             See `keras_tuner.HyperModel`.
     """
 

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -22,21 +22,19 @@ from keras_tuner.engine import hypermodel
 class HyperXception(hypermodel.HyperModel):
     """An Xception HyperModel.
 
-    Arguments:
-        include_top: whether to include the fully-connected
-            layer at the top of the network.
-        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        input_tensor: Optional Keras tensor (i.e. output of
-            `layers.Input()`) to use as image input for the model.
-              One of `input_shape` or `input_tensor` must be
-              specified.
-        classes: optional number of classes to classify images
-            into, only to be specified if `include_top` is True,
-            and if no `weights` argument is specified.
-        **kwargs: Additional keyword arguments that apply to all
-            HyperModels. See `keras_tuner.HyperModel`.
+    Args:
+        include_top: whether to include the fully-connected layer at the top of
+            the network.
+        input_shape: Optional shape tuple, e.g. `(256, 256, 3)`.  One of
+            `input_shape` or `input_tensor` must be specified.
+        input_tensor: Optional Keras tensor (i.e. output of `layers.Input()`)
+            to use as image input for the model.  One of `input_shape` or
+            `input_tensor` must be specified.
+        classes: optional number of classes to classify images into, only to be
+            specified if `include_top` is True, and if no `weights` argument is
+            specified.
+        **kwargs: Additional keyword arguments that apply to all HyperModels.
+            See `keras_tuner.HyperModel`.
     """
 
     def __init__(

--- a/keras_tuner/distribute/utils.py
+++ b/keras_tuner/distribute/utils.py
@@ -23,11 +23,11 @@ import os
 def has_chief_oracle():
     """Checks for distributed tuning with a chief Oracle.
 
-    `CloudOracle` manages its own distribution and so should not set
-    "KERASTUNER_ORACLE_IP"
+    `CloudOracle` manages its own distribution so should not set
+    "KERASTUNER_ORACLE_IP".
 
     Returns:
-      bool. Whether distributed tuning with a chief Oracle should be run.
+        Boolean, whether distributed tuning with a chief Oracle should be run.
     """
     if "KERASTUNER_ORACLE_IP" in os.environ:
         if "KERASTUNER_ORACLE_PORT" not in os.environ:

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -35,9 +35,9 @@ from . import tuner_utils
 class BaseTuner(stateful.Stateful):
     """Tuner base class.
 
-    BaseTuner is the base class for all Tuners, which manages the search loop,
-    Oracle, logging, saving, etc. Tuners for non-Keras models can be created
-    by subclassing BaseTuner.
+    `BaseTuner` is the base class for all Tuners, which manages the search
+    loop, Oracle, logging, saving, etc. Tuners for non-Keras models can be
+    created by subclassing `BaseTuner`.
 
     Args:
         oracle: Instance of Oracle class.
@@ -47,7 +47,7 @@ class BaseTuner(stateful.Stateful):
         directory: A string, the relative path to the working directory.
         project_name: A string, the name to use as prefix for files saved by
             this Tuner.
-        logger: Optional instance of Logger class, used for streaming data to
+        logger: Optional instance of `Logger` class, used for streaming data to
             Cloud Service for monitoring.
         overwrite: Boolean, defaults to `False`. If `False`, reloads an
             existing project of the same name if one is found. Otherwise,

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -37,7 +37,7 @@ class BaseTuner(stateful.Stateful):
 
     May be subclassed to create new tuners, including for non-Keras models.
 
-    Arguments:
+    Args:
         oracle: Instance of Oracle class.
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
@@ -114,10 +114,10 @@ class BaseTuner(stateful.Stateful):
     def search(self, *fit_args, **fit_kwargs):
         """Performs a search for best hyperparameter configuations.
 
-        Arguments:
+        Args:
             *fit_args: Positional arguments that should be passed to
               `run_trial`, for example the training and validation data.
-            *fit_kwargs: Keyword arguments that should be passed to
+            **fit_kwargs: Keyword arguments that should be passed to
               `run_trial`, for example the training and validation data.
         """
         if "verbose" in fit_kwargs:
@@ -160,19 +160,19 @@ class BaseTuner(stateful.Stateful):
             self.save_model(trial.trial_id, model)
         ```
 
-        Arguments:
+        Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. Hyperparameters can be accessed
               via `trial.hyperparameters`.
             *fit_args: Positional arguments passed by `search`.
-            *fit_kwargs: Keyword arguments passed by `search`.
+            **fit_kwargs: Keyword arguments passed by `search`.
         """
         raise NotImplementedError
 
     def save_model(self, trial_id, model, step=0):
         """Saves a Model for a given trial.
 
-        Arguments:
+        Args:
             trial_id: The ID of the `Trial` that corresponds to this Model.
             model: The trained model.
             step: For models that report intermediate results to the `Oracle`,
@@ -184,7 +184,7 @@ class BaseTuner(stateful.Stateful):
     def load_model(self, trial):
         """Loads a Model from a given trial.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance. For models that report intermediate
               results to the `Oracle`, generally `load_model` should load the
               best reported `step` by relying of `trial.best_step`
@@ -199,7 +199,7 @@ class BaseTuner(stateful.Stateful):
     def on_trial_begin(self, trial):
         """A hook called before starting each trial.
 
-        # Arguments:
+        Args:
             trial: A `Trial` instance.
         """
         if self.logger:
@@ -209,7 +209,7 @@ class BaseTuner(stateful.Stateful):
     def on_trial_end(self, trial):
         """A hook called after each trial is run.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance.
         """
         # Send status to Logger
@@ -234,7 +234,7 @@ class BaseTuner(stateful.Stateful):
         recommended to retrain your Model on the full dataset using the best
         hyperparameters found during `search`.
 
-        Arguments:
+        Args:
             num_models (int, optional). Number of best models to return.
                 Models will be returned in sorted order. Defaults to 1.
 
@@ -258,7 +258,7 @@ class BaseTuner(stateful.Stateful):
         model = tuner.hypermodel.build(best_hp)
         ```
 
-        Arguments:
+        Args:
             num_trials: (int, optional). Number of `HyperParameters` objects to
               return. `HyperParameters` will be returned in sorted order based on
               trial performance.
@@ -271,7 +271,7 @@ class BaseTuner(stateful.Stateful):
     def search_space_summary(self, extended=False):
         """Print search space summary.
 
-        Arguments:
+        Args:
             extended: Bool, optional. Display extended summary.
                 Defaults to False.
         """
@@ -287,7 +287,7 @@ class BaseTuner(stateful.Stateful):
     def results_summary(self, num_trials=10):
         """Display tuning results summary.
 
-        Arguments:
+        Args:
             num_trials (int, optional): Number of trials to display.
                 Defaults to 10.
         """

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -249,7 +249,7 @@ class BaseTuner(stateful.Stateful):
                 Defaults to 1.
 
         Returns:
-            List of trained model instances sorted from the best to the worst.
+            List of trained models sorted from the best to the worst.
         """
         best_trials = self.oracle.get_best_trials(num_models)
         models = [self.load_model(trial) for trial in best_trials]

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -48,12 +48,12 @@ class Condition(object):
 
         Determines whether this condition is true for the current `Trial`.
 
-        # Arguments:
+        Args:
             values: Dict. The active values for this `Trial`. Keys are the
                names of the hyperparameters.
 
-        # Returns:
-            bool.
+        Returns:
+            A boolean value of whether the condition is true.
         """
         raise NotImplementedError("Must be implemented in subclasses.")
 
@@ -90,12 +90,12 @@ class Parent(Condition):
 
     Example:
 
-    ```
+    ```python
     a = Choice('model', ['linear', 'dnn'])
     b = Int('num_layers', 5, 10, conditions=[kt.conditions.Parent('a', ['dnn'])])
     ```
 
-    # Arguments:
+    Args:
         name: The name of a `HyperParameter`.
         values: Values for which the `HyperParameter` this object is
             passed to should be considered active.

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -28,18 +28,9 @@ from ..protos import keras_tuner_pb2
 class Condition(object):
     """Abstract condition for a conditional hyperparameter.
 
-    Subclasses of this object can be passed to a `HyperParameter` to
-    specify that this condition must be met in order for that hyperparameter
-    to be considered active for the `Trial`.
-
-    Example:
-
-    ```
-
-    a = Choice('model', ['linear', 'dnn'])
-    condition = kt.conditions.Parent(name='a', value=['dnn'])
-    b = Int('num_layers', 5, 10, conditions=[condition])
-    ```
+    Subclasses of this object can be passed to a `HyperParameter` to specify
+    that this condition must be met for the hyperparameter to be active for the
+    `Trial`.
     """
 
     @abc.abstractmethod
@@ -50,7 +41,7 @@ class Condition(object):
 
         Args:
             values: Dict. The active values for this `Trial`. Keys are the
-               names of the hyperparameters.
+                names of the hyperparameters.
 
         Returns:
             A boolean value of whether the condition is true.
@@ -82,23 +73,25 @@ class Condition(object):
 
 
 class Parent(Condition):
-    """Condition that checks a value is equal to one of a list of values.
+    """Condition checking a `HyperParameter`'s value is in a list of values.
 
-    This object can be passed to a `HyperParameter` to specify that this
-    condition must be met in order for that hyperparameter to be considered
-    active for the `Trial`.
+    It specifies a condition that a `HyperParameter`'s value is in a list of
+    values. It can be used as the condition to activate another
+    `HyperParameter` for the `Trial`.
 
     Example:
 
     ```python
     a = Choice('model', ['linear', 'dnn'])
-    b = Int('num_layers', 5, 10, conditions=[kt.conditions.Parent('a', ['dnn'])])
+    condition = Parent(name='model', value=['dnn'])
+    b = Int('num_layers', 5, 10, conditions=[condition])
     ```
 
     Args:
-        name: The name of a `HyperParameter`.
-        values: Values for which the `HyperParameter` this object is
-            passed to should be considered active.
+        name: A string, the name of the `HyperParameter` to use in the
+            condition.
+        values: A list of values of the `HyperParameter` to activate the
+            condition.
     """
 
     def __init__(self, name, values):

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -30,12 +30,12 @@ from .. import config as config_module
 class HyperModel(object):
     """Defines a searchable space of Models and builds Models from this space.
 
-    Arguments:
+    Args:
         name: The name of this HyperModel.
         tunable: Whether the hyperparameters defined in this hypermodel
-          should be added to search space. If `False`, either the search
-          space for these parameters must be defined in advance, or the
-          default values will be used.
+            should be added to search space. If `False`, either the search
+            space for these parameters must be defined in advance, or the
+            default values will be used.
     """
 
     def __init__(self, name=None, tunable=True):
@@ -48,7 +48,7 @@ class HyperModel(object):
     def build(self, hp):
         """Builds a model.
 
-        Arguments:
+        Args:
             hp: A `HyperParameters` instance.
 
         Returns:

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -28,14 +28,34 @@ from .. import config as config_module
 
 
 class HyperModel(object):
-    """Defines a searchable space of Models and builds Models from this space.
+    """Defines a search space of models.
+
+    A search space is a collection of models. The `build` function will build
+    one of the models from the space using the given `HyperParameters` object.
+
+    Users should subclass the `HyperModel` class to define their search spaces
+    by overriding the `.build(...)` function.
+
+    Examples:
+
+    ```python
+    class MyHyperModel(kt.HyperModel):
+        def build(self, hp):
+            model = keras.Sequential()
+            model.add(keras.layers.Dense(
+                hp.Choice('units', [8, 16, 32]),
+                activation='relu'))
+            model.add(keras.layers.Dense(1, activation='relu'))
+            model.compile(loss='mse')
+            return model
+    ```
 
     Args:
-        name: The name of this HyperModel.
-        tunable: Whether the hyperparameters defined in this hypermodel
-            should be added to search space. If `False`, either the search
-            space for these parameters must be defined in advance, or the
-            default values will be used.
+        name: Optional string, the name of this HyperModel.
+        tunable: Boolean, whether the hyperparameters defined in this
+            hypermodel should be added to search space. If `False`, either the
+            search space for these parameters must be defined in advance, or
+            the default values will be used. Defaults to True.
     """
 
     def __init__(self, name=None, tunable=True):
@@ -65,6 +85,8 @@ class HyperModel(object):
 
 
 class DefaultHyperModel(HyperModel):
+    """Produces HyperModel from a model building function."""
+
     def __init__(self, build, name=None, tunable=True):
         super(DefaultHyperModel, self).__init__(name=name)
         self.build = build

--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -70,7 +70,7 @@ def _check_int(val, arg):
 class HyperParameter(object):
     """HyperParameter base class.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         default: Default value to return for the
             parameter.
@@ -104,7 +104,7 @@ class HyperParameter(object):
 class Choice(HyperParameter):
     """Choice of one value among a predefined set of possible values.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         values: List of possible values. Values must be int, float,
             str, or bool. All values must be of the same type.
@@ -225,7 +225,7 @@ class Int(HyperParameter):
     Note that unlike Python's `range` function, `max_value` is *included* in
     the possible values this parameter can take on.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         min_value: Int. Lower limit of range (included).
         max_value: Int. Upper limit of range (included).
@@ -321,7 +321,7 @@ class Int(HyperParameter):
 class Float(HyperParameter):
     """Floating point range, can be evenly divided.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         min_value: Float. Lower bound of the range.
         max_value: Float. Upper bound of the range.
@@ -422,7 +422,7 @@ class Float(HyperParameter):
 class Boolean(HyperParameter):
     """Choice between True and False.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         default: Default value to return for the parameter.
             If unspecified, the default value will be False.
@@ -461,7 +461,7 @@ class Boolean(HyperParameter):
 class Fixed(HyperParameter):
     """Fixed, untunable value.
 
-    Arguments:
+    Args:
         name: Str. Name of parameter. Must be unique.
         value: Value to use (can be any JSON-serializable
             Python type).
@@ -529,7 +529,7 @@ class Fixed(HyperParameter):
 class HyperParameters(object):
     """Container for both a hyperparameter space, and current values.
 
-    Arguments:
+    Args:
         space: A list of HyperParameter instances.
         values: A dict mapping hyperparameter names to current values.
     """
@@ -577,10 +577,10 @@ class HyperParameters(object):
         Note that any Python code under this scope will execute
         regardless of whether the condition is met.
 
-        Arguments:
+        Args:
             parent_name: The name of the HyperParameter to condition on.
             parent_values: Values of the parent HyperParameter for which
-              HyperParameters under this scope should be considered active.
+                HyperParameters under this scope should be considered active.
         """
         parent_name = self._get_name(parent_name)  # Add name_scopes.
         if not self._exists(parent_name):
@@ -597,7 +597,7 @@ class HyperParameters(object):
     def is_active(self, hyperparameter):
         """Checks if a hyperparameter is currently active for a `Trial`.
 
-        # Arguments:
+        Args:
           hp: Str or `HyperParameter`. If str, checks if any
               `HyperParameter` with that name is active. If `HyperParameter`,
               checks that this object is active.
@@ -684,7 +684,7 @@ class HyperParameters(object):
     ):
         """Choice of one value among a predefined set of possible values.
 
-        Arguments:
+        Args:
             name: Str. Name of parameter. Must be unique.
             values: List of possible values. Values must be int, float,
                 str, or bool. All values must be of the same type.
@@ -729,7 +729,7 @@ class HyperParameters(object):
         Note that unlike Python's `range` function, `max_value` is *included* in
         the possible values this parameter can take on.
 
-        Arguments:
+        Args:
             name: Str. Name of parameter. Must be unique.
             min_value: Int. Lower limit of range (included).
             max_value: Int. Upper limit of range (included).
@@ -775,7 +775,7 @@ class HyperParameters(object):
     ):
         """Floating point range, can be evenly divided.
 
-        Arguments:
+        Args:
             name: Str. Name of parameter. Must be unique.
             min_value: Float. Lower bound of the range.
             max_value: Float. Upper bound of the range.
@@ -814,7 +814,7 @@ class HyperParameters(object):
     def Boolean(self, name, default=False, parent_name=None, parent_values=None):
         """Choice between True and False.
 
-        Arguments:
+        Args:
             name: Str. Name of parameter. Must be unique.
             default: Default value to return for the parameter.
                 If unspecified, the default value will be False.
@@ -837,7 +837,7 @@ class HyperParameters(object):
     def Fixed(self, name, value, parent_name=None, parent_values=None):
         """Fixed, untunable value.
 
-        Arguments:
+        Args:
             name: Str. Name of parameter. Must be unique.
             value: Value to use (can be any JSON-serializable
                 Python type).
@@ -886,7 +886,7 @@ class HyperParameters(object):
     def merge(self, hps, overwrite=True):
         """Merges hyperparameters into this object.
 
-        Arguments:
+        Args:
           hps: A `HyperParameters` object or list of `HyperParameter`
             objects.
           overwrite: bool. Whether existing `HyperParameter`s should

--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -68,7 +68,7 @@ def _check_int(val, arg):
 
 
 class HyperParameter(object):
-    """HyperParameter base class.
+    """Hyperparameter base class.
 
     Args:
         name: A string. the name of parameter. Must be unique for each
@@ -580,8 +580,8 @@ class HyperParameters(object):
         Note that any Python code under this scope will execute regardless of
         whether the condition is met.
 
-        This feature is for the Tuner to collect more information of the search
-        space and the current trial.  It is especially useful for model
+        This feature is for the `Tuner` to collect more information of the
+        search space and the current trial.  It is especially useful for model
         selection. If the parent `HyperParameter` is for model selection, the
         `HyperParameter`s in a model should only be active when the model
         selected, which can be implemented using `conditional_scope`.
@@ -1114,7 +1114,7 @@ def cumulative_prob_to_value(prob, hp):
             return int(value)
         return value
     else:
-        raise ValueError("Unrecognized HyperParameter type: {}".format(hp))
+        raise ValueError("Unrecognized `HyperParameter` type: {}".format(hp))
 
 
 def value_to_cumulative_prob(value, hp):
@@ -1146,7 +1146,7 @@ def value_to_cumulative_prob(value, hp):
         else:
             raise ValueError("Unrecognized sampling value: {}".format(sampling))
     else:
-        raise ValueError("Unrecognized HyperParameter type: {}".format(hp))
+        raise ValueError("Unrecognized `HyperParameter` type: {}".format(hp))
 
 
 def _sampling_from_proto(sampling):

--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -71,11 +71,11 @@ class HyperParameter(object):
     """HyperParameter base class.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        default: Default value to return for the
-            parameter.
-        conditions: A list of `Condition`s for this object to be
-            considered active.
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        default: The default value to return for the parameter.
+        conditions: A list of `Condition`s for this object to be considered
+            active.
     """
 
     def __init__(self, name, default=None, conditions=None):
@@ -105,13 +105,14 @@ class Choice(HyperParameter):
     """Choice of one value among a predefined set of possible values.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        values: List of possible values. Values must be int, float,
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        values: A list of possible values. Values must be int, float,
             str, or bool. All values must be of the same type.
-        ordered: Whether the values passed should be considered to
-            have an ordering. This defaults to `True` for float/int
-            values. Must be `False` for any other values.
-        default: Default value to return for the parameter.
+        ordered: Optional boolean, whether the values passed should be
+            considered to have an ordering. Defaults to `True` for float/int
+            values.  Must be `False` for any other values.
+        default: Optional default value to return for the parameter.
             If unspecified, the default value will be:
             - None if None is one of the choices in `values`
             - The first entry in `values` otherwise.
@@ -226,18 +227,18 @@ class Int(HyperParameter):
     the possible values this parameter can take on.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        min_value: Int. Lower limit of range (included).
-        max_value: Int. Upper limit of range (included).
-        step: Int. Step of range.
-        sampling: Optional. One of "linear", "log",
-            "reverse_log". Acts as a hint for an initial prior
-            probability distribution for how this value should
-            be sampled, e.g. "log" will assign equal
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        min_value: Integer, the lower limit of range, inclusive.
+        max_value: Integer, the upper limit of range, inclusive.
+        step: Integer, the distance between two consecutive samples in the
+            range. Defaults to 1.
+        sampling: Optional string. One of "linear", "log", "reverse_log". Acts
+            as a hint for an initial prior probability distribution for how
+            this value should be sampled, e.g. "log" will assign equal
             probabilities to each order of magnitude range.
-        default: Default value to return for the parameter.
-            If unspecified, the default value will be
-            `min_value`.
+        default: Integer, default value to return for the parameter. If
+            unspecified, the default value will be `min_value`.
     """
 
     def __init__(
@@ -322,21 +323,20 @@ class Float(HyperParameter):
     """Floating point range, can be evenly divided.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        min_value: Float. Lower bound of the range.
-        max_value: Float. Upper bound of the range.
-        step: Optional. Float, e.g. 0.1.
-            smallest meaningful distance between two values.
-            Whether step should be specified is Oracle dependent,
-            since some Oracles can infer an optimal step automatically.
-        sampling: Optional. One of "linear", "log",
-            "reverse_log". Acts as a hint for an initial prior
-            probability distribution for how this value should
-            be sampled, e.g. "log" will assign equal
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        min_value: Float, the lower bound of the range.
+        max_value: Float, the upper bound of the range.
+        step: Optional float, e.g. 0.1, the smallest meaningful distance
+            between two values. Whether step should be specified is Oracle
+            dependent, since some Oracles can infer an optimal step
+            automatically.
+        sampling: Optional string. One of "linear", "log", "reverse_log". Acts
+            as a hint for an initial prior probability distribution for how
+            this value should be sampled, e.g. "log" will assign equal
             probabilities to each order of magnitude range.
-        default: Default value to return for the parameter.
-            If unspecified, the default value will be
-            `min_value`.
+        default: Float, the default value to return for the parameter. If
+            unspecified, the default value will be `min_value`.
     """
 
     def __init__(
@@ -423,8 +423,9 @@ class Boolean(HyperParameter):
     """Choice between True and False.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        default: Default value to return for the parameter.
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        default: Boolean, the default value to return for the parameter.
             If unspecified, the default value will be False.
     """
 
@@ -462,9 +463,9 @@ class Fixed(HyperParameter):
     """Fixed, untunable value.
 
     Args:
-        name: Str. Name of parameter. Must be unique.
-        value: Value to use (can be any JSON-serializable
-            Python type).
+        name: A string. the name of parameter. Must be unique for each
+            `HyperParameter` instance in the search space.
+        value: The value to use (can be any JSON-serializable Python type).
     """
 
     def __init__(self, name, value, **kwargs):
@@ -529,8 +530,10 @@ class Fixed(HyperParameter):
 class HyperParameters(object):
     """Container for both a hyperparameter space, and current values.
 
-    Args:
-        space: A list of HyperParameter instances.
+    A `HyperParameters` instance can be pass to `HyperModel.build(hp)` as an
+    argument to build a model.
+
+    Attributes:
         values: A dict mapping hyperparameter names to current values.
     """
 
@@ -566,21 +569,50 @@ class HyperParameters(object):
     def conditional_scope(self, parent_name, parent_values):
         """Opens a scope to create conditional HyperParameters.
 
-        All HyperParameters created under this scope will only be active
-        when the parent HyperParameter specified by `parent_name` is
-        equal to one of the values passed in `parent_values`.
+        All `HyperParameter`s created under this scope will only be active when
+        the parent `HyperParameter` specified by `parent_name` is equal to one
+        of the values passed in `parent_values`.
 
-        When the condition is not met, creating a HyperParameter under
-        this scope will register the HyperParameter, but will return
-        `None` rather than a concrete value.
+        When the condition is not met, creating a `HyperParameter` under this
+        scope will register the `HyperParameter`, but will return `None` rather
+        than a concrete value.
 
-        Note that any Python code under this scope will execute
-        regardless of whether the condition is met.
+        Note that any Python code under this scope will execute regardless of
+        whether the condition is met.
+
+        This feature is for the Tuner to collect more information of the search
+        space and the current trial.  It is especially useful for model
+        selection. If the parent `HyperParameter` is for model selection, the
+        `HyperParameter`s in a model should only be active when the model
+        selected, which can be implemented using `conditional_scope`.
+
+        Examples:
+
+        ```python
+        def MyHyperModel(HyperModel):
+            def build(self, hp):
+                model = Sequential()
+                model.add(Input(shape=(32, 32, 3)))
+                model_type = hp.Choice("model_type", ["mlp", "cnn"])
+                if model_type == "mlp":
+                    with hp.conditional_scope("model_type", ["mlp"]):
+                        model.add(Flatten())
+                        model.add(Dense(32, activation='relu'))
+                if model_type == "cnn":
+                    with hp.conditional_scope("model_type", ["cnn"]):
+                        model.add(Conv2D(64, 3, activation='relu'))
+                        model.add(GlobalAveragePooling2D())
+                model.add(Dense(10, activation='softmax'))
+                return model
+        ```
 
         Args:
-            parent_name: The name of the HyperParameter to condition on.
-            parent_values: Values of the parent HyperParameter for which
-                HyperParameters under this scope should be considered active.
+            parent_name: A string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: A list of the values of the parent `HyperParameter`
+                to use as the condition to activate the current
+                `HyperParameter`.
         """
         parent_name = self._get_name(parent_name)  # Add name_scopes.
         if not self._exists(parent_name):
@@ -598,9 +630,11 @@ class HyperParameters(object):
         """Checks if a hyperparameter is currently active for a `Trial`.
 
         Args:
-          hp: Str or `HyperParameter`. If str, checks if any
-              `HyperParameter` with that name is active. If `HyperParameter`,
-              checks that this object is active.
+            hp: A string or `HyperParameter` instance. If string, checks if any
+                `HyperParameter` with that name is active. If `HyperParameter`,
+                checks that this object is active.
+        Returns:
+            A boolean, whether the hyperparameter is active.
         """
         hp = hyperparameter
         if isinstance(hp, six.string_types):
@@ -685,20 +719,23 @@ class HyperParameters(object):
         """Choice of one value among a predefined set of possible values.
 
         Args:
-            name: Str. Name of parameter. Must be unique.
-            values: List of possible values. Values must be int, float,
+            name: A string. the name of parameter. Must be unique for each
+                `HyperParameter` instance in the search space.
+            values: A list of possible values. Values must be int, float,
                 str, or bool. All values must be of the same type.
-            ordered: Whether the values passed should be considered to
-                have an ordering. This defaults to `True` for float/int
-                values. Must be `False` for any other values.
-            default: Default value to return for the parameter.
+            ordered: Optional boolean, whether the values passed should be
+                considered to have an ordering. Defaults to `True` for float/int
+                values.  Must be `False` for any other values.
+            default: Optional default value to return for the parameter.
                 If unspecified, the default value will be:
                 - None if None is one of the choices in `values`
                 - The first entry in `values` otherwise.
-            parent_name: (Optional) String. Specifies that this hyperparameter is
-              conditional. The name of the this hyperparameter's parent.
-            parent_values: (Optional) List. The values of the parent hyperparameter
-              for which this hyperparameter should be considered active.
+            parent_name: Optional string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: Optional list of the values of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
 
         Returns:
             The current value of this hyperparameter.
@@ -730,22 +767,24 @@ class HyperParameters(object):
         the possible values this parameter can take on.
 
         Args:
-            name: Str. Name of parameter. Must be unique.
-            min_value: Int. Lower limit of range (included).
-            max_value: Int. Upper limit of range (included).
-            step: Int. Step of range.
-            sampling: Optional. One of "linear", "log",
-                "reverse_log". Acts as a hint for an initial prior
-                probability distribution for how this value should
-                be sampled, e.g. "log" will assign equal
+            name: A string. the name of parameter. Must be unique for each
+                `HyperParameter` instance in the search space.
+            min_value: Integer, the lower limit of range, inclusive.
+            max_value: Integer, the upper limit of range, inclusive.
+            step: Integer, the distance between two consecutive samples in the
+                range. Defaults to 1.
+            sampling: Optional string. One of "linear", "log", "reverse_log". Acts
+                as a hint for an initial prior probability distribution for how
+                this value should be sampled, e.g. "log" will assign equal
                 probabilities to each order of magnitude range.
-            default: Default value to return for the parameter.
-                If unspecified, the default value will be
-                `min_value`.
-            parent_name: (Optional) String. Specifies that this hyperparameter is
-              conditional. The name of the this hyperparameter's parent.
-            parent_values: (Optional) List. The values of the parent hyperparameter
-              for which this hyperparameter should be considered active.
+            default: Integer, default value to return for the parameter. If
+                unspecified, the default value will be `min_value`.
+            parent_name: Optional string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: Optional list of the values of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
 
         Returns:
             The current value of this hyperparameter.
@@ -776,25 +815,26 @@ class HyperParameters(object):
         """Floating point range, can be evenly divided.
 
         Args:
-            name: Str. Name of parameter. Must be unique.
-            min_value: Float. Lower bound of the range.
-            max_value: Float. Upper bound of the range.
-            step: Optional. Float, e.g. 0.1.
-                smallest meaningful distance between two values.
-                Whether step should be specified is Oracle dependent,
-                since some Oracles can infer an optimal step automatically.
-            sampling: Optional. One of "linear", "log",
-                "reverse_log". Acts as a hint for an initial prior
-                probability distribution for how this value should
-                be sampled, e.g. "log" will assign equal
+            name: A string. the name of parameter. Must be unique for each
+                `HyperParameter` instance in the search space.
+            min_value: Float, the lower bound of the range.
+            max_value: Float, the upper bound of the range.
+            step: Optional float, e.g. 0.1, the smallest meaningful distance
+                between two values. Whether step should be specified is Oracle
+                dependent, since some Oracles can infer an optimal step
+                automatically.
+            sampling: Optional string. One of "linear", "log", "reverse_log". Acts
+                as a hint for an initial prior probability distribution for how
+                this value should be sampled, e.g. "log" will assign equal
                 probabilities to each order of magnitude range.
-            default: Default value to return for the parameter.
-                If unspecified, the default value will be
-                `min_value`.
-            parent_name: (Optional) String. Specifies that this hyperparameter is
-              conditional. The name of the this hyperparameter's parent.
-            parent_values: (Optional) List. The values of the parent hyperparameter
-              for which this hyperparameter should be considered active.
+            default: Float, the default value to return for the parameter. If
+                unspecified, the default value will be `min_value`.
+            parent_name: Optional string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: Optional list of the values of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
 
         Returns:
             The current value of this hyperparameter.
@@ -815,13 +855,16 @@ class HyperParameters(object):
         """Choice between True and False.
 
         Args:
-            name: Str. Name of parameter. Must be unique.
-            default: Default value to return for the parameter.
+            name: A string. the name of parameter. Must be unique for each
+                `HyperParameter` instance in the search space.
+            default: Boolean, the default value to return for the parameter.
                 If unspecified, the default value will be False.
-            parent_name: (Optional) String. Specifies that this hyperparameter is
-              conditional. The name of the this hyperparameter's parent.
-            parent_values: (Optional) List. The values of the parent hyperparameter
-              for which this hyperparameter should be considered active.
+            parent_name: Optional string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: Optional list of the values of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
 
         Returns:
             The current value of this hyperparameter.
@@ -838,13 +881,15 @@ class HyperParameters(object):
         """Fixed, untunable value.
 
         Args:
-            name: Str. Name of parameter. Must be unique.
-            value: Value to use (can be any JSON-serializable
-                Python type).
-            parent_name: (Optional) String. Specifies that this hyperparameter is
-              conditional. The name of the this hyperparameter's parent.
-            parent_values: (Optional) List. The values of the parent hyperparameter
-              for which this hyperparameter should be considered active.
+            name: A string. the name of parameter. Must be unique for each
+                `HyperParameter` instance in the search space.
+            value: The value to use (can be any JSON-serializable Python type).
+            parent_name: Optional string, specifying the name of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
+            parent_values: Optional list of the values of the parent
+                `HyperParameter` to use as the condition to activate the
+                current `HyperParameter`.
 
         Returns:
             The current value of this hyperparameter.
@@ -887,11 +932,10 @@ class HyperParameters(object):
         """Merges hyperparameters into this object.
 
         Args:
-          hps: A `HyperParameters` object or list of `HyperParameter`
-            objects.
-          overwrite: bool. Whether existing `HyperParameter`s should
-            be overridden by those in `hps` with the same name and
-            conditions.
+            hps: A `HyperParameters` object or list of `HyperParameter`
+                objects.
+            overwrite: bool. Whether existing `HyperParameter`s should be
+                overridden by those in `hps` with the same name and conditions.
         """
         if isinstance(hps, HyperParameters):
             hps = hps.space

--- a/keras_tuner/engine/multi_execution_tuner.py
+++ b/keras_tuner/engine/multi_execution_tuner.py
@@ -31,15 +31,15 @@ from . import tuner_utils
 
 
 class MultiExecutionTuner(tuner_module.Tuner):
-    """A Tuner class that averages multiple runs of the process.
+    """A `Tuner` class that averages multiple runs of the process.
 
     Args:
         oracle: An Oracle instance.
         hypermodel: A `HyperModel` instance (or callable that takes
-            hyperparameters and returns a Model instance).
+            hyperparameters and returns a `Model` instance).
         executions_per_trial: Integer, the number of executions (training a
             model from scratch, starting from a new initialization) to run per
-            trial (model configuration).  Model metrics may vary greatly
+            trial (model configuration). Model metrics may vary greatly
             depending on random initialization, hence it is often a good idea
             to run several executions per trial in order to evaluate the
             performance of a given set of hyperparameter values.

--- a/keras_tuner/engine/multi_execution_tuner.py
+++ b/keras_tuner/engine/multi_execution_tuner.py
@@ -34,19 +34,15 @@ class MultiExecutionTuner(tuner_module.Tuner):
     """A Tuner class that averages multiple runs of the process.
 
     Args:
-        oracle: Instance of Oracle class.
-        hypermodel: Instance of HyperModel class
-            (or callable that takes hyperparameters
-            and returns a Model instance).
-        executions_per_trial: Int. Number of executions
-            (training a model from scratch,
-            starting from a new initialization)
-            to run per trial (model configuration).
-            Model metrics may vary greatly depending
-            on random initialization, hence it is
-            often a good idea to run several executions
-            per trial in order to evaluate the performance
-            of a given set of hyperparameter values.
+        oracle: An Oracle instance.
+        hypermodel: A `HyperModel` instance (or callable that takes
+            hyperparameters and returns a Model instance).
+        executions_per_trial: Integer, the number of executions (training a
+            model from scratch, starting from a new initialization) to run per
+            trial (model configuration).  Model metrics may vary greatly
+            depending on random initialization, hence it is often a good idea
+            to run several executions per trial in order to evaluate the
+            performance of a given set of hyperparameter values.
         **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
             Please see the docstring for `Tuner`.
     """

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -39,22 +39,23 @@ class Oracle(stateful.Stateful):
     """Implements a hyperparameter optimization algorithm.
 
     Args:
-        objective: String. Name of model metric to minimize
-            or maximize, e.g. "val_accuracy".
-        max_trials: The maximum number of hyperparameter
-            combinations to try.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparamters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
+        max_trials: Integer, the total number of trials (model configurations)
+            to test at most. Note that the oracle may interrupt the search
+            before `max_trial` models have been tested if the search space has
+            been exhausted.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
         seed: Int. Random seed.
     """
 
@@ -130,7 +131,7 @@ class Oracle(stateful.Stateful):
         values.
 
         Args:
-          `trial_id`: The id for this Trial.
+            trial_id: A string, the ID for this Trial.
 
         Returns:
             A dictionary with keys "values" and "status", where "values" is
@@ -168,7 +169,7 @@ class Oracle(stateful.Stateful):
         by `Tuner.run_trial`.
 
         Args:
-            tuner_id: A ID that identifies the `Tuner` requesting a
+            tuner_id: A string, the ID that identifies the `Tuner` requesting a
                 `Trial`. `Tuners` that should run the same trial (for instance,
                 when running a multi-worker model) should have the same ID.
 
@@ -209,12 +210,11 @@ class Oracle(stateful.Stateful):
         """Used by a worker to report the status of a trial.
 
         Args:
-            trial_id: A previously seen trial id.
-            metrics: Dict of float. The current value of this
-                trial's metrics.
-            step: (Optional) Float. Used to report intermediate results. The
-                current value in a timeseries representing the state of the
-                trial. This is the value that `metrics` will be associated with.
+            trial_id: A string, a previously seen trial id.
+            metrics: Dict of float. The current value of this trial's metrics.
+            step: Optional float, reporting intermediate results. The current
+                value in a timeseries representing the state of the trial. This
+                is the value that `metrics` will be associated with.
 
         Returns:
             Trial object. Trial.status will be set to "STOPPED" if the Trial
@@ -237,10 +237,9 @@ class Oracle(stateful.Stateful):
         """Record the measured objective for a set of parameter values.
 
         Args:
-            trial_id: String. Unique id for this trial.
-            status: String, one of "COMPLETED", "INVALID". A status of
-                "INVALID" means a trial has crashed or been deemed
-                infeasible.
+            trial_id: A string, the unique ID for this trial.
+            status: A string, one of "COMPLETED", "INVALID". A status of
+                "INVALID" means a trial has crashed or been deemed infeasible.
         """
         trial = None
         for tuner_id, ongoing_trial in self.ongoing_trials.items():

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -45,7 +45,7 @@ class Oracle(stateful.Stateful):
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
             been exhausted.
-        hyperparameters: Optional HyperParameters instance. Can be used to
+        hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
             space.
         tune_new_entries: Boolean, whether hyperparameter entries that are
@@ -238,8 +238,9 @@ class Oracle(stateful.Stateful):
 
         Args:
             trial_id: A string, the unique ID for this trial.
-            status: A string, one of "COMPLETED", "INVALID". A status of
-                "INVALID" means a trial has crashed or been deemed infeasible.
+            status: A string, one of `"COMPLETED"`, `"INVALID"`. A status of
+                `"INVALID"` means a trial has crashed or been deemed
+                infeasible.
         """
         trial = None
         for tuner_id, ongoing_trial in self.ongoing_trials.items():
@@ -267,7 +268,7 @@ class Oracle(stateful.Stateful):
         Already recorded parameters get ignored.
 
         Args:
-            hyperparameters: An updated HyperParameters object.
+            hyperparameters: An updated `HyperParameters` object.
         """
         hps = hyperparameters.space
         new_hps = []

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -38,7 +38,7 @@ Objective = collections.namedtuple("Objective", "name direction")
 class Oracle(stateful.Stateful):
     """Implements a hyperparameter optimization algorithm.
 
-    Arguments:
+    Args:
         objective: String. Name of model metric to minimize
             or maximize, e.g. "val_accuracy".
         max_trials: The maximum number of hyperparameter
@@ -167,14 +167,14 @@ class Oracle(stateful.Stateful):
         A `Trial` corresponds to a unique set of hyperparameters to be run
         by `Tuner.run_trial`.
 
-        Arguments:
-          tuner_id: A ID that identifies the `Tuner` requesting a
-          `Trial`. `Tuners` that should run the same trial (for instance,
-           when running a multi-worker model) should have the same ID.
+        Args:
+            tuner_id: A ID that identifies the `Tuner` requesting a
+                `Trial`. `Tuners` that should run the same trial (for instance,
+                when running a multi-worker model) should have the same ID.
 
         Returns:
-          A `Trial` object containing a set of hyperparameter values to run
-          in a `Tuner`.
+            A `Trial` object containing a set of hyperparameter values to run
+            in a `Tuner`.
         """
         # Allow for multi-worker DistributionStrategy within a Trial.
         if tuner_id in self.ongoing_trials:
@@ -208,7 +208,7 @@ class Oracle(stateful.Stateful):
     def update_trial(self, trial_id, metrics, step=0):
         """Used by a worker to report the status of a trial.
 
-        Arguments:
+        Args:
             trial_id: A previously seen trial id.
             metrics: Dict of float. The current value of this
                 trial's metrics.
@@ -236,7 +236,7 @@ class Oracle(stateful.Stateful):
     def end_trial(self, trial_id, status="COMPLETED"):
         """Record the measured objective for a set of parameter values.
 
-        Arguments:
+        Args:
             trial_id: String. Unique id for this trial.
             status: String, one of "COMPLETED", "INVALID". A status of
                 "INVALID" means a trial has crashed or been deemed
@@ -267,7 +267,7 @@ class Oracle(stateful.Stateful):
 
         Already recorded parameters get ignored.
 
-        Arguments:
+        Args:
             hyperparameters: An updated HyperParameters object.
         """
         hps = hyperparameters.space

--- a/keras_tuner/engine/stateful.py
+++ b/keras_tuner/engine/stateful.py
@@ -35,7 +35,7 @@ class Stateful(object):
 
         This method is called during `reload`.
 
-        Arguments:
+        Args:
             state: Dict. The state to restore for this object.
         """
         raise NotImplementedError
@@ -43,7 +43,7 @@ class Stateful(object):
     def save(self, fname):
         """Saves this object using `get_state`.
 
-        Arguments:
+        Args:
             fname: The file name to save to.
         """
         state = self.get_state()
@@ -55,7 +55,7 @@ class Stateful(object):
     def reload(self, fname):
         """Reloads this object using `set_state`.
 
-        Arguments:
+        Args:
             fname: The file name to restore from.
         """
         with tf.io.gfile.GFile(fname, "r") as f:

--- a/keras_tuner/engine/stateful.py
+++ b/keras_tuner/engine/stateful.py
@@ -23,10 +23,15 @@ import tensorflow as tf
 
 
 class Stateful(object):
+    """The base class for saving and restoring the state."""
+
     def get_state(self):
         """Returns the current state of this object.
 
         This method is called during `save`.
+
+        Returns:
+            A dictionary of serializable objects as the state.
         """
         raise NotImplementedError
 
@@ -36,7 +41,7 @@ class Stateful(object):
         This method is called during `reload`.
 
         Args:
-            state: Dict. The state to restore for this object.
+            state: A dictionary of serialized objects as the state to restore.
         """
         raise NotImplementedError
 
@@ -44,7 +49,7 @@ class Stateful(object):
         """Saves this object using `get_state`.
 
         Args:
-            fname: The file name to save to.
+            fname: A string, the file name to save to.
         """
         state = self.get_state()
         state_json = json.dumps(state)
@@ -56,7 +61,7 @@ class Stateful(object):
         """Reloads this object using `set_state`.
 
         Args:
-            fname: The file name to restore from.
+            fname: A string, the file name to restore from.
         """
         with tf.io.gfile.GFile(fname, "r") as f:
             state_data = f.read()

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -33,7 +33,7 @@ class Tuner(base_tuner.BaseTuner):
 
     May be subclassed to create new tuners.
 
-    Arguments:
+    Args:
         oracle: Instance of Oracle class.
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
@@ -134,7 +134,7 @@ class Tuner(base_tuner.BaseTuner):
         the input shape before building the model, adapt preprocessing layers,
         and tune other fit_args and fit_kwargs.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
               via `trial.hyperparameters`.
@@ -153,12 +153,12 @@ class Tuner(base_tuner.BaseTuner):
         This method is called during `search` to evaluate a set of
         hyperparameters.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance that contains the information
               needed to run this trial. `Hyperparameters` can be accessed
               via `trial.hyperparameters`.
             *fit_args: Positional arguments passed by `search`.
-            *fit_kwargs: Keyword arguments passed by `search`.
+            **fit_kwargs: Keyword arguments passed by `search`.
         """
         # Handle any callbacks passed to `fit`.
         copied_fit_kwargs = copy.copy(fit_kwargs)
@@ -210,7 +210,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_epoch_begin(self, trial, model, epoch, logs=None):
         """A hook called at the start of every epoch.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             epoch: The current epoch number.
@@ -221,7 +221,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_batch_begin(self, trial, model, batch, logs):
         """A hook called at the start of every batch.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             batch: The current batch number within the
@@ -233,7 +233,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_batch_end(self, trial, model, batch, logs=None):
         """A hook called at the end of every batch.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             batch: The current batch number within the
@@ -245,7 +245,7 @@ class Tuner(base_tuner.BaseTuner):
     def on_epoch_end(self, trial, model, epoch, logs=None):
         """A hook called at the end of every epoch.
 
-        Arguments:
+        Args:
             trial: A `Trial` instance.
             model: A Keras `Model`.
             epoch: The current epoch number.
@@ -269,7 +269,7 @@ class Tuner(base_tuner.BaseTuner):
         recommended to retrain your Model on the full dataset using the best
         hyperparameters found during `search`.
 
-        Arguments:
+        Args:
             num_models (int, optional): Number of best models to return.
                 Models will be returned in sorted order. Defaults to 1.
 

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -31,7 +31,7 @@ from . import tuner_utils
 class Tuner(base_tuner.BaseTuner):
     """Tuner class for Keras models.
 
-    This is the base Tuner class for all tuners for Keras models. It manages
+    This is the base `Tuner` class for all tuners for Keras models. It manages
     the building, training, evaluation and saving of the Keras models. New
     tuners can be created by subclassing the class.
 
@@ -41,7 +41,7 @@ class Tuner(base_tuner.BaseTuner):
             hyperparameters and returns a Model instance).
         max_model_size: Integer, maximum number of scalars in the parameters of
             a model. Models larger than this are rejected.
-        optimizer: Optional Optimizer instance.  May be used to override the
+        optimizer: Optional `Optimizer` instance.  May be used to override the
             `optimizer` argument in the `compile` step for the models. If the
             hypermodel does not compile the models it generates, then this
             argument must be specified.
@@ -59,10 +59,10 @@ class Tuner(base_tuner.BaseTuner):
             supported.
         directory: A string, the relative path to the working directory.
         project_name: A string, the name to use as prefix for files saved by
-            this Tuner.
-        logger: Optional instance of Logger class, used for streaming data to
+            this `Tuner`.
+        logger: Optional instance of `Logger` class, used for streaming data to
             Cloud Service for monitoring.
-        tuner_id: Optional string, used as the ID of this Tuner.
+        tuner_id: Optional string, used as the ID of this `Tuner`.
         overwrite: Boolean, defaults to `False`. If `False`, reloads an
             existing project of the same name if one is found. Otherwise,
             overwrites the project.

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -44,10 +44,10 @@ class GaussianProcessRegressor(object):
     """A Gaussian process regressor.
 
     Args:
-        alpha: Float. Value added to the diagonal of the kernel matrix
-            during fitting. It represents the expected amount of noise
-            in the observed performances in Bayesian optimization.
-        seed: Int. Random seed.
+        alpha: Float, the value added to the diagonal of the kernel matrix
+            during fitting. It represents the expected amount of noise in the
+            observed performances in Bayesian optimization.
+        seed: Optional int, the random seed.
     """
 
     def __init__(self, alpha, seed=None):
@@ -123,36 +123,33 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     https://www.cse.wustl.edu/~garnett/cse515t/spring_2015/files/lecture_notes/12.pdf).
 
     Args:
-        objective: String or `keras_tuner.Objective`. If a string,
-          the direction of the optimization (min or max) will be
-          inferred.
-        max_trials: Int. Total number of trials
-            (model configurations) to test at most.
-            Note that the oracle may interrupt the search
-            before `max_trial` models have been tested if the search space has been
-            exhausted.
-        num_initial_points: (Optional) Int. The number of randomly generated samples
-            as initial training data for Bayesian optimization. If not specified,
-            a value of 3 times the dimensionality of the hyperparameter space is
-            used.
-        alpha: Float. Value added to the diagonal of the kernel matrix
-            during fitting. It represents the expected amount of noise
-            in the observed performances in Bayesian optimization.
-        beta: Float. The balancing factor of exploration and exploitation.
-            The larger it is, the more explorative it is.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparameters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        objective: A string or `keras_tuner.Objective` instance. If a string, the
+            direction of the optimization (min or max) will be inferred.
+        max_trials: Integer, the total number of trials (model configurations)
+            to test at most. Note that the oracle may interrupt the search
+            before `max_trial` models have been tested if the search space has
+            been exhausted.
+        num_initial_points: Optional number of randomly generated samples as
+            initial training data for Bayesian optimization. If left
+            unspecified, a value of 3 times the dimensionality of the
+            hyperparameter space is used.
+        alpha: Float, the value added to the diagonal of the kernel matrix
+            during fitting. It represents the expected amount of noise in the
+            observed performances in Bayesian optimization. Defaults to 1e-4.
+        beta: Float, the balancing factor of exploration and exploitation. The
+            larger it is, the more explorative it is. Defaults to 2.6.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
     """
 
     def __init__(
@@ -346,37 +343,37 @@ class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
     """BayesianOptimization tuning with Gaussian process.
 
     Args:
-        hypermodel: Instance of HyperModel class
-            (or callable that takes hyperparameters
-            and returns a Model instance).
-        objective: String. Name of model metric to minimize
-            or maximize, e.g. "val_accuracy".
-        max_trials: Int. Total number of trials
-            (model configurations) to test at most.
-            Note that the oracle may interrupt the search
+        hypermodel: Instance of HyperModel class (or callable that takes
+            hyperparameters and returns a Model instance).
+        objective: A string or `keras_tuner.Objective` instance. If a string, the
+            direction of the optimization (min or max) will be inferred.
+        max_trials: Integer, the total number of trials (model configurations)
+            to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
             been exhausted.
-        num_initial_points: Int. The number of randomly generated samples as initial
-            training data for Bayesian optimization.
-        alpha: Float or array-like. Value added to the diagonal of
-            the kernel matrix during fitting.
-        beta: Float. The balancing factor of exploration and exploitation.
-            The larger it is, the more explorative it is.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparamters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
-        **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
-            Please see the docstring for `Tuner`.
+        num_initial_points: Optional number of randomly generated samples as
+            initial training data for Bayesian optimization. If left
+            unspecified, a value of 3 times the dimensionality of the
+            hyperparameter space is used.
+        alpha: Float, the value added to the diagonal of the kernel matrix
+            during fitting. It represents the expected amount of noise in the
+            observed performances in Bayesian optimization. Defaults to 1e-4.
+        beta: Float, the balancing factor of exploration and exploitation. The
+            larger it is, the more explorative it is. Defaults to 2.6.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
+        **kwargs: Keyword arguments relevant to all `Tuner` subclasses. Please
+            see the docstring for `Tuner`.
     """
 
     def __init__(

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -139,7 +139,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         beta: Float, the balancing factor of exploration and exploitation. The
             larger it is, the more explorative it is. Defaults to 2.6.
         seed: Optional integer, the random seed.
-        hyperparameters: Optional HyperParameters instance. Can be used to
+        hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
             space.
         tune_new_entries: Boolean, whether hyperparameter entries that are
@@ -361,7 +361,7 @@ class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
         beta: Float, the balancing factor of exploration and exploitation. The
             larger it is, the more explorative it is. Defaults to 2.6.
         seed: Optional integer, the random seed.
-        hyperparameters: Optional HyperParameters instance. Can be used to
+        hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
             space.
         tune_new_entries: Boolean, whether hyperparameter entries that are

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -123,8 +123,8 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     https://www.cse.wustl.edu/~garnett/cse515t/spring_2015/files/lecture_notes/12.pdf).
 
     Args:
-        objective: A string or `keras_tuner.Objective` instance. If a string, the
-            direction of the optimization (min or max) will be inferred.
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
@@ -343,10 +343,10 @@ class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
     """BayesianOptimization tuning with Gaussian process.
 
     Args:
-        hypermodel: Instance of HyperModel class (or callable that takes
+        hypermodel: A `HyperModel` instance (or callable that takes
             hyperparameters and returns a Model instance).
-        objective: A string or `keras_tuner.Objective` instance. If a string, the
-            direction of the optimization (min or max) will be inferred.
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -43,7 +43,7 @@ def matern_kernel(x, y=None):
 class GaussianProcessRegressor(object):
     """A Gaussian process regressor.
 
-    Arguments:
+    Args:
         alpha: Float. Value added to the diagonal of the kernel matrix
             during fitting. It represents the expected amount of noise
             in the observed performances in Bayesian optimization.
@@ -62,7 +62,7 @@ class GaussianProcessRegressor(object):
     def fit(self, x, y):
         """Fit the Gaussian process regressor.
 
-        Arguments:
+        Args:
             x: np.ndarray with shape (samples, features).
             y: np.ndarray with shape (samples,).
         """
@@ -85,7 +85,7 @@ class GaussianProcessRegressor(object):
     def predict(self, x):
         """Predict the mean and standard deviation of the target.
 
-        Arguments:
+        Args:
             x: np.ndarray with shape (samples, features).
 
         Returns:
@@ -122,7 +122,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     be found [here](
     https://www.cse.wustl.edu/~garnett/cse515t/spring_2015/files/lecture_notes/12.pdf).
 
-    Arguments:
+    Args:
         objective: String or `keras_tuner.Objective`. If a string,
           the direction of the optimization (min or max) will be
           inferred.
@@ -345,7 +345,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
     """BayesianOptimization tuning with Gaussian process.
 
-    Arguments:
+    Args:
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
             and returns a Model instance).

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -56,7 +56,7 @@ class HyperbandOracle(oracle_module.Oracle):
             self.on_epoch_end(...)
     ```
 
-    Arguments:
+    Args:
         objective: String or `keras_tuner.Objective`. If a string,
           the direction of the optimization (min or max) will be
           inferred.
@@ -301,7 +301,7 @@ class Hyperband(multi_execution_tuner.MultiExecutionTuner):
             http://jmlr.org/papers/v18/16-558.html).
 
 
-    # Arguments
+    Args:
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
             and returns a Model instance).

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -35,7 +35,7 @@ class HyperbandOracle(oracle_module.Oracle):
     These hyperparameters will be set during the "successive halving" portion
     of the Hyperband algorithm.
 
-    Example:
+    Examples:
 
     ```python
     def run_trial(self, trial, *args, **kwargs):
@@ -57,33 +57,33 @@ class HyperbandOracle(oracle_module.Oracle):
     ```
 
     Args:
-        objective: String or `keras_tuner.Objective`. If a string,
-          the direction of the optimization (min or max) will be
-          inferred.
-        max_epochs: Int. The maximum number of epochs to train one model. It is
-          recommended to set this to a value slightly higher than the expected epochs
-          to convergence for your largest Model, and to use early stopping during
-          training (for example, via `tf.keras.callbacks.EarlyStopping`).
-        factor: Int. Reduction factor for the number of epochs
-            and number of models for each bracket.
-        hyperband_iterations: Int >= 1. The number of times to iterate over the full
-          Hyperband algorithm. One iteration will run approximately
-          `max_epochs * (math.log(max_epochs, factor) ** 2)` cumulative epochs
-          across all trials. It is recommended to set this to as high a value
-          as is within your resource budget.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparameters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
+        max_epochs: Integer, the maximum number of epochs to train one model.
+            It is recommended to set this to a value slightly higher than the
+            expected epochs to convergence for your largest Model, and to use
+            early stopping during training (for example, via
+            `tf.keras.callbacks.EarlyStopping`).
+        factor: Integer, the reduction factor for the number of epochs
+            and number of models for each bracket. Defaults to 3.
+        hyperband_iterations: Integer, at least 1, the number of times to
+            iterate over the full Hyperband algorithm. One iteration will run
+            approximately `max_epochs * (math.log(max_epochs, factor) ** 2)`
+            cumulative epochs across all trials. It is recommended to set this
+            to as high a value as is within your resource budget. Defaults to
+            1.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
     """
 
     def __init__(
@@ -302,35 +302,35 @@ class Hyperband(multi_execution_tuner.MultiExecutionTuner):
 
 
     Args:
-        hypermodel: Instance of HyperModel class
-            (or callable that takes hyperparameters
-            and returns a Model instance).
-        objective: String. Name of model metric to minimize
-            or maximize, e.g. "val_accuracy".
-        max_epochs: Int. The maximum number of epochs to train one model. It is
-          recommended to set this to a value slightly higher than the expected time
-          to convergence for your largest Model, and to use early stopping during
-          training (for example, via `tf.keras.callbacks.EarlyStopping`).
-        factor: Int. Reduction factor for the number of epochs
-            and number of models for each bracket.
-        hyperband_iterations: Int >= 1. The number of times to iterate over the full
-          Hyperband algorithm. One iteration will run approximately
-          `max_epochs * (math.log(max_epochs, factor) ** 2)` cumulative epochs
-          across all trials. It is recommended to set this to as high a value
-          as is within your resource budget.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparamters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        hypermodel: A `HyperModel` instance (or callable that takes
+            hyperparameters and returns a Model instance).
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
+        max_epochs: Integer, the maximum number of epochs to train one model.
+            It is recommended to set this to a value slightly higher than the
+            expected epochs to convergence for your largest Model, and to use
+            early stopping during training (for example, via
+            `tf.keras.callbacks.EarlyStopping`).
+        factor: Integer, the reduction factor for the number of epochs
+            and number of models for each bracket. Defaults to 3.
+        hyperband_iterations: Integer, at least 1, the number of times to
+            iterate over the full Hyperband algorithm. One iteration will run
+            approximately `max_epochs * (math.log(max_epochs, factor) ** 2)`
+            cumulative epochs across all trials. It is recommended to set this
+            to as high a value as is within your resource budget. Defaults to
+            1.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
         **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
             Please see the docstring for `Tuner`.
     """

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -34,7 +34,7 @@ class RandomSearchOracle(oracle_module.Oracle):
             before `max_trial` models have been tested if the search space has
             been exhausted.
         seed: Optional integer, the random seed.
-        hyperparameters: Optional HyperParameters instance. Can be used to
+        hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
             space.
         tune_new_entries: Boolean, whether hyperparameter entries that are
@@ -96,7 +96,7 @@ class RandomSearch(multi_execution_tuner.MultiExecutionTuner):
             before `max_trial` models have been tested if the search space has
             been exhausted.
         seed: Optional integer, the random seed.
-        hyperparameters: Optional HyperParameters instance. Can be used to
+        hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
             space.
         tune_new_entries: Boolean, whether hyperparameter entries that are

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -26,7 +26,7 @@ from ..engine import trial as trial_lib
 class RandomSearchOracle(oracle_module.Oracle):
     """Random search oracle.
 
-    Arguments:
+    Args:
         objective: String or `keras_tuner.Objective`. If a string,
           the direction of the optimization (min or max) will be
           inferred.
@@ -70,7 +70,7 @@ class RandomSearchOracle(oracle_module.Oracle):
     def populate_space(self, _):
         """Fill the hyperparameter space with values.
 
-        Arguments:
+        Args:
           `trial_id`: The id for this Trial.
 
         Returns:
@@ -88,7 +88,7 @@ class RandomSearchOracle(oracle_module.Oracle):
 class RandomSearch(multi_execution_tuner.MultiExecutionTuner):
     """Random search tuner.
 
-    Arguments:
+    Args:
         hypermodel: Instance of HyperModel class
             (or callable that takes hyperparameters
             and returns a Model instance).

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -27,26 +27,24 @@ class RandomSearchOracle(oracle_module.Oracle):
     """Random search oracle.
 
     Args:
-        objective: String or `keras_tuner.Objective`. If a string,
-          the direction of the optimization (min or max) will be
-          inferred.
-        max_trials: Int. Total number of trials
-            (model configurations) to test at most.
-            Note that the oracle may interrupt the search
-            before `max_trial` models have been tested.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparameters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
+        max_trials: Integer, the total number of trials (model configurations)
+            to test at most. Note that the oracle may interrupt the search
+            before `max_trial` models have been tested if the search space has
+            been exhausted.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
     """
 
     def __init__(
@@ -67,11 +65,11 @@ class RandomSearchOracle(oracle_module.Oracle):
             seed=seed,
         )
 
-    def populate_space(self, _):
+    def populate_space(self, trial_id):
         """Fill the hyperparameter space with values.
 
         Args:
-          `trial_id`: The id for this Trial.
+            trial_id: A string, the ID for this Trial.
 
         Returns:
             A dictionary with keys "values" and "status", where "values" is
@@ -89,28 +87,26 @@ class RandomSearch(multi_execution_tuner.MultiExecutionTuner):
     """Random search tuner.
 
     Args:
-        hypermodel: Instance of HyperModel class
-            (or callable that takes hyperparameters
-            and returns a Model instance).
-        objective: String. Name of model metric to minimize
-            or maximize, e.g. "val_accuracy".
-        max_trials: Int. Total number of trials
-            (model configurations) to test at most.
-            Note that the oracle may interrupt the search
-            before `max_trial` models have been tested.
-        seed: Int. Random seed.
-        hyperparameters: HyperParameters class instance.
-            Can be used to override (or register in advance)
-            hyperparamters in the search space.
-        tune_new_entries: Whether hyperparameter entries
-            that are requested by the hypermodel
-            but that were not specified in `hyperparameters`
-            should be added to the search space, or not.
-            If not, then the default value for these parameters
-            will be used.
-        allow_new_entries: Whether the hypermodel is allowed
-            to request hyperparameter entries not listed in
-            `hyperparameters`.
+        hypermodel: A `HyperModel` instance (or callable that takes
+            hyperparameters and returns a Model instance).
+        objective: A string or `keras_tuner.Objective` instance. If a string,
+            the direction of the optimization (min or max) will be inferred.
+        max_trials: Integer, the total number of trials (model configurations)
+            to test at most. Note that the oracle may interrupt the search
+            before `max_trial` models have been tested if the search space has
+            been exhausted.
+        seed: Optional integer, the random seed.
+        hyperparameters: Optional HyperParameters instance. Can be used to
+            override (or register in advance) hyperparameters in the search
+            space.
+        tune_new_entries: Boolean, whether hyperparameter entries that are
+            requested by the hypermodel but that were not specified in
+            `hyperparameters` should be added to the search space, or not. If
+            not, then the default value for these parameters will be used.
+            Defaults to True.
+        allow_new_entries: Boolean, whether the hypermodel is allowed to
+            request hyperparameter entries not listed in `hyperparameters`.
+            Defaults to True.
         **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
             Please see the docstring for `Tuner`.
     """

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -34,27 +34,6 @@ class SklearnTuner(base_tuner.BaseTuner):
     Performs cross-validated hyperparameter search for Scikit-learn
     models.
 
-    Arguments:
-        oracle: An instance of the `keras_tuner.Oracle` class. Note that for
-          this `Tuner`, the `objective` for the `Oracle` should always be set
-          to `Objective('score', direction='max')`. Also, `Oracle`s that exploit
-          Neural-Network-specific training (e.g. `Hyperband`) should not be
-          used with this `Tuner`.
-        hypermodel: Instance of `HyperModel` class (or callable that takes a
-          `Hyperparameters` object and returns a Model instance).
-        scoring: An sklearn `scoring` function. For more information, see
-          `sklearn.metrics.make_scorer`. If not provided, the Model's default
-          scoring will be used via `model.score`. Note that if you are searching
-          across different Model families, the default scoring for these Models
-          will often be different. In this case you should supply `scoring` here
-          in order to make sure your Models are being scored on the same metric.
-        metrics: Additional `sklearn.metrics` functions to monitor during search.
-          Note that these metrics do not affect the search process.
-        cv: An `sklearn.model_selection` Splitter class. Used to
-          determine how samples are split up into groups for cross-validation.
-        **kwargs: Keyword arguments relevant to all `Tuner` subclasses. Please
-          see the docstring for `Tuner`.
-
     Example:
 
     ```python
@@ -77,7 +56,7 @@ class SklearnTuner(base_tuner.BaseTuner):
       return model
 
     tuner = kt.tuners.SklearnTuner(
-        oracle=kt.oracles.BayesianOptimization(
+        oracle=kt.oracles.BayesianOptimizationOracle(
             objective=kt.Objective('score', 'max'),
             max_trials=10),
         hypermodel=build_model,
@@ -94,6 +73,27 @@ class SklearnTuner(base_tuner.BaseTuner):
 
     best_model = tuner.get_best_models(num_models=1)[0]
     ```
+
+    Args:
+        oracle: An instance of the `keras_tuner.Oracle` class. Note that for
+          this `Tuner`, the `objective` for the `Oracle` should always be set
+          to `Objective('score', direction='max')`. Also, `Oracle`s that exploit
+          Neural-Network-specific training (e.g. `Hyperband`) should not be
+          used with this `Tuner`.
+        hypermodel: Instance of `HyperModel` class (or callable that takes a
+          `Hyperparameters` object and returns a Model instance).
+        scoring: An sklearn `scoring` function. For more information, see
+          `sklearn.metrics.make_scorer`. If not provided, the Model's default
+          scoring will be used via `model.score`. Note that if you are searching
+          across different Model families, the default scoring for these Models
+          will often be different. In this case you should supply `scoring` here
+          in order to make sure your Models are being scored on the same metric.
+        metrics: Additional `sklearn.metrics` functions to monitor during search.
+          Note that these metrics do not affect the search process.
+        cv: An `sklearn.model_selection` Splitter class. Used to
+          determine how samples are split up into groups for cross-validation.
+        **kwargs: Keyword arguments relevant to all `Tuner` subclasses. Please
+          see the docstring for `Tuner`.
     """
 
     def __init__(
@@ -121,7 +121,7 @@ class SklearnTuner(base_tuner.BaseTuner):
     def search(self, X, y, sample_weight=None, groups=None):
         """Performs hyperparameter search.
 
-        Arguments:
+        Args:
             X: See docstring for `model.fit` for the `sklearn` Models being tuned.
             y: See docstring for `model.fit` for the `sklearn` Models being tuned.
             sample_weight: (Optional). See docstring for `model.fit` for the

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -31,10 +31,9 @@ from ..engine import base_tuner
 class SklearnTuner(base_tuner.BaseTuner):
     """Tuner for Scikit-learn Models.
 
-    Performs cross-validated hyperparameter search for Scikit-learn
-    models.
+    Performs cross-validated hyperparameter search for Scikit-learn models.
 
-    Example:
+    Examples:
 
     ```python
     import keras_tuner as kt
@@ -75,25 +74,27 @@ class SklearnTuner(base_tuner.BaseTuner):
     ```
 
     Args:
-        oracle: An instance of the `keras_tuner.Oracle` class. Note that for
-          this `Tuner`, the `objective` for the `Oracle` should always be set
-          to `Objective('score', direction='max')`. Also, `Oracle`s that exploit
-          Neural-Network-specific training (e.g. `Hyperband`) should not be
-          used with this `Tuner`.
-        hypermodel: Instance of `HyperModel` class (or callable that takes a
-          `Hyperparameters` object and returns a Model instance).
+        oracle: A `keras_tuner.Oracle` instance. Note that for this `Tuner`,
+            the `objective` for the `Oracle` should always be set to
+            `Objective('score', direction='max')`. Also, `Oracle`s that exploit
+            Neural-Network-specific training (e.g. `Hyperband`) should not be
+            used with this `Tuner`.
+        hypermodel: A `HyperModel` instance (or callable that takes
+            hyperparameters and returns a Model instance).
         scoring: An sklearn `scoring` function. For more information, see
-          `sklearn.metrics.make_scorer`. If not provided, the Model's default
-          scoring will be used via `model.score`. Note that if you are searching
-          across different Model families, the default scoring for these Models
-          will often be different. In this case you should supply `scoring` here
-          in order to make sure your Models are being scored on the same metric.
+            `sklearn.metrics.make_scorer`. If not provided, the Model's default
+            scoring will be used via `model.score`. Note that if you are
+            searching across different Model families, the default scoring for
+            these Models will often be different. In this case you should
+            supply `scoring` here in order to make sure your Models are being
+            scored on the same metric.
         metrics: Additional `sklearn.metrics` functions to monitor during search.
-          Note that these metrics do not affect the search process.
+            Note that these metrics do not affect the search process.
         cv: An `sklearn.model_selection` Splitter class. Used to
-          determine how samples are split up into groups for cross-validation.
+            determine how samples are split up into groups for
+            cross-validation.
         **kwargs: Keyword arguments relevant to all `Tuner` subclasses. Please
-          see the docstring for `Tuner`.
+            see the docstring for `Tuner`.
     """
 
     def __init__(
@@ -124,11 +125,11 @@ class SklearnTuner(base_tuner.BaseTuner):
         Args:
             X: See docstring for `model.fit` for the `sklearn` Models being tuned.
             y: See docstring for `model.fit` for the `sklearn` Models being tuned.
-            sample_weight: (Optional). See docstring for `model.fit` for the
-            `sklearn` Models being tuned.
-            groups: (Optional). Required for `sklearn.model_selection` Splitter
-            classes that split based on group labels (For example, see
-            `sklearn.model_selection.GroupKFold`).
+            sample_weight: Optional. See docstring for `model.fit` for the
+                `sklearn` Models being tuned.
+            groups: Optional. Required for `sklearn.model_selection` Splitter
+                classes that split based on group labels (For example, see
+                `sklearn.model_selection.GroupKFold`).
         """
         # Only overridden for the docstring.
         return super().search(X, y, sample_weight=sample_weight, groups=groups)


### PR DESCRIPTION
resolves #537 

- [x] `keras_tuner/__init__.py`
- [x] `keras_tuner/applications/__init__.py`
- [x] `keras_tuner/applications/augment.py`
- [x] `keras_tuner/applications/efficientnet.py`
- [x] `keras_tuner/applications/resnet.py`
- [x] `keras_tuner/applications/xception.py`
- [x] `keras_tuner/config.py`
- [x] `keras_tuner/distribute/__init__.py`
- [x] `keras_tuner/distribute/oracle_chief.py`
- [x] `keras_tuner/distribute/oracle_client.py`
- [x] `keras_tuner/distribute/utils.py`
- [x] `keras_tuner/engine/__init__.py`
- [x] `keras_tuner/engine/base_tuner.py`
- [x] `keras_tuner/engine/conditions.py`
- [x] `keras_tuner/engine/hypermodel.py`
- [x] `keras_tuner/engine/hyperparameters.py`
- [x] `keras_tuner/engine/logger.py`
- [x] `keras_tuner/engine/metrics_tracking.py`
- [x] `keras_tuner/engine/multi_execution_tuner.py`
- [x] `keras_tuner/engine/oracle.py`
- [x] `keras_tuner/engine/stateful.py`
- [x] `keras_tuner/engine/trial.py`
- [x] `keras_tuner/engine/tuner.py`
- [x] `keras_tuner/engine/tuner_utils.py`
- [x] `keras_tuner/oracles/__init__.py`
- [x] `keras_tuner/protos/__init__.py`
- [x] `keras_tuner/protos/keras_tuner_pb2.py`
- [x] `keras_tuner/protos/keras_tuner_pb2_grpc.py`
- [x] `keras_tuner/protos/service_pb2.py`
- [x] `keras_tuner/protos/service_pb2_grpc.py`
- [x] `keras_tuner/tuners/__init__.py`
- [x] `keras_tuner/tuners/bayesian.py`
- [x] `keras_tuner/tuners/hyperband.py`
- [x] `keras_tuner/tuners/randomsearch.py`
- [x] `keras_tuner/tuners/sklearn_tuner.py`
- [x] `keras_tuner/utils.py`