### PR TITLE
removing references to CloudLogger in the docs

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -47,8 +47,8 @@ class BaseTuner(stateful.Stateful):
         directory: A string, the relative path to the working directory.
         project_name: A string, the name to use as prefix for files saved by
             this Tuner.
-        logger: Optional instance of `Logger` class, used for streaming data to
-            Cloud Service for monitoring.
+        logger: Optional instance of `kerastuner.Logger` class for
+            streaming logs for monitoring.
         overwrite: Boolean, defaults to `False`. If `False`, reloads an
             existing project of the same name if one is found. Otherwise,
             overwrites the project.

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -60,8 +60,8 @@ class Tuner(base_tuner.BaseTuner):
         directory: A string, the relative path to the working directory.
         project_name: A string, the name to use as prefix for files saved by
             this `Tuner`.
-        logger: Optional instance of `Logger` class, used for streaming data to
-            Cloud Service for monitoring.
+        logger: Optional instance of `kerastuner.Logger` class for
+            streaming logs for monitoring.
         tuner_id: Optional string, used as the ID of this `Tuner`.
         overwrite: Boolean, defaults to `False`. If `False`, reloads an
             existing project of the same name if one is found. Otherwise,


### PR DESCRIPTION
The `CloudLogger` is removed from the docs.
We keep the implementation of `CloudLogger` just not to break people and may use it in the future.