### PR TITLE
Revise is_active function definition

### DIFF
--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -632,13 +632,13 @@ class HyperParameters(object):
         A hyperparameter is considered active if and only if all its parent
         conditions are active, and not affected by whether the hyperparameter
         is used while building the model. The function is usually called by the
-        `Oracle` for populating new hyperparamter values and updating the trial
+        `Oracle` for populating new hyperparameter values and updating the trial
         after receiving the evaluation results.
 
         Args:
-            hp: A string or `HyperParameter` instance. If string, checks if any
-                `HyperParameter` with that name is active. If `HyperParameter`,
-                checks that this object is active.
+            hp: A string or `HyperParameter` instance. If string, checks whether
+                any hyperparameter with that name is active. If `HyperParameter`
+                instance, checks whether the object is active.
 
         Returns:
             A boolean, whether the hyperparameter is active.
@@ -662,7 +662,7 @@ class HyperParameters(object):
         return True
 
     def _exists(self, name, conditions=None):
-        """Checks for a `HyperParameter` with the same name and conditions."""
+        """Checks for a hyperparameter with the same name and conditions."""
         if conditions is None:
             conditions = self._conditions
 
@@ -674,7 +674,7 @@ class HyperParameters(object):
         return False
 
     def _retrieve(self, hp):
-        """Gets or creates a `HyperParameter`.
+        """Gets or creates a hyperparameter.
 
         Args:
             hp: A `HyperParameter` instance.
@@ -690,7 +690,7 @@ class HyperParameters(object):
         return self._register(hp)
 
     def _register(self, hyperparameter, overwrite=False):
-        """Registers a `HyperParameter` into this container.
+        """Registers a hyperparameter in this container.
 
         Args:
             hp: A `HyperParameter` instance.

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -269,7 +269,10 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
             for hp in self._nonfixed_space():
                 # For hyperparameters not present in the trial (either added after
                 # the trial or inactive in the trial), set to default value.
-                if trial_hps.is_active(hp):
+                if (
+                    trial_hps.is_active(hp)  # inactive
+                    and hp.name in trial_hps.values  # added after the trial
+                ):
                     trial_value = trial_hps.values[hp.name]
                 else:
                     trial_value = hp.default

--- a/tests/keras_tuner/engine/hyperparameters_test.py
+++ b/tests/keras_tuner/engine/hyperparameters_test.py
@@ -100,6 +100,24 @@ def test_conditional_scope():
     assert child2 == 7
 
 
+def test_is_active_with_hp_name_and_hp():
+    hp = hp_module.HyperParameters()
+    hp.Choice("choice", [1, 2, 3], default=3)
+    with hp.conditional_scope("choice", [1, 3]):
+        hp.Choice("child_choice", [4, 5, 6])
+    with hp.conditional_scope("choice", 2):
+        hp.Choice("child_choice2", [7, 8, 9])
+
+    # Custom oracle populates value for an inactive hp.
+    hp.values["child_choice2"] = 7
+
+    assert hp.is_active("child_choice")
+    assert hp.is_active(hp._hps["child_choice"][0])
+
+    assert not hp.is_active("child_choice2")
+    assert not hp.is_active(hp._hps["child_choice2"][0])
+
+
 def test_build_with_conditional_scope():
     def build_model(hp):
         model = hp.Choice("model", ["v1", "v2"])

--- a/tests/keras_tuner/tuners/bayesian_test.py
+++ b/tests/keras_tuner/tuners/bayesian_test.py
@@ -229,7 +229,7 @@ def test_hyperparameters_added(tmp_dir):
         trial.status = "COMPLETED"
         oracle.trials[trial.trial_id] = trial
 
-    # Update the space.
+    # A new trial discovered a new hp and synced to oracle.hyperparameters.
     new_hps = hp_module.HyperParameters()
     new_hps.Float("b", 3.2, 6.4, step=0.2, default=3.6)
     new_hps.Boolean("c", default=True)


### PR DESCRIPTION
Consolidate the functionality of `is_active` to checking the conditions.
Decouple it from whether the values contain the hp or not.
Otherwise, it enforces the `Oracle` to only generate values for active hps.

After this patch, the user can choose to let their custom oracle generate values for inactive values, which won't cause any problem.
It would not affect the feature of "always returning None when using a inactive hp in the build_model function" since this feature is implemented independent to the `.values` attributes, and independent to the `is_active` function.