### PR TITLE
Explore the search space when initializing the Tuner based on conditions

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -115,7 +115,7 @@ class BaseTuner(stateful.Stateful):
         training data.
         """
         hp = self.oracle.get_space()
-        self.hypermodel.build(hp)
+        hp.explore_space(self.hypermodel)
         self.oracle.update_space(hp)
 
     def search(self, *fit_args, **fit_kwargs):

--- a/tests/keras_tuner/engine/tuner_correctness_test.py
+++ b/tests/keras_tuner/engine/tuner_correctness_test.py
@@ -406,20 +406,23 @@ def test_init_build_all_hps_in_all_conditions(tmp_dir):
     class ConditionalHyperModel(MockHyperModel):
         def build(self, hp):
             model_type = hp.Choice("model_type", ["cnn", "mlp"])
-            with hp.conditional_scope("model_type", [model_type]):
+            with hp.conditional_scope("model_type", ["cnn"]):
                 if model_type == "cnn":
                     sub_cnn = hp.Choice("sub_cnn", ["a", "b"])
-                    with hp.conditional_scope("sub_cnn", [sub_cnn]):
+                    with hp.conditional_scope("sub_cnn", ["a"]):
                         if sub_cnn == "a":
                             hp.Int("n_filters_a", 2, 4)
-                        else:
+                    with hp.conditional_scope("sub_cnn", ["b"]):
+                        if sub_cnn == "b":
                             hp.Int("n_filters_b", 6, 8)
-                else:
+            with hp.conditional_scope("model_type", ["mlp"]):
+                if model_type == "mlp":
                     sub_mlp = hp.Choice("sub_mlp", ["a", "b"])
-                    with hp.conditional_scope("sub_mlp", [sub_mlp]):
+                    with hp.conditional_scope("sub_mlp", ["a"]):
                         if sub_mlp == "a":
                             hp.Int("n_units_a", 2, 4)
-                        else:
+                    with hp.conditional_scope("sub_mlp", ["b"]):
+                        if sub_mlp == "b":
                             hp.Int("n_units_b", 6, 8)
             more_block = hp.Boolean("more_block", default=False)
             with hp.conditional_scope("more_block", [True]):
@@ -428,7 +431,7 @@ def test_init_build_all_hps_in_all_conditions(tmp_dir):
             return super().build(hp)
 
     def name_in_hp(name, hp):
-        return any(["model_type" == single_hp.name for single_hp in hp.space])
+        return any([name == single_hp.name for single_hp in hp.space])
 
     class MyTuner(tuner_module.Tuner):
         def _populate_initial_space(self):


### PR DESCRIPTION
At initialization of the Tuner, it would build the search space multiple times to activate each condition so that it can fetch all the hyperparamters in the search space.

However, it requires the user to define the search space using `conditional scope` as follows.
```py
    class ConditionalHyperModel(MockHyperModel):
        def build(self, hp):
            model_type = hp.Choice("model_type", ["cnn", "mlp"])
            with hp.conditional_scope("model_type", ["cnn"]):
                if model_type == "cnn":
                    sub_cnn = hp.Choice("sub_cnn", ["a", "b"])
                    with hp.conditional_scope("sub_cnn", ["a"]):
                        if sub_cnn == "a":
                            hp.Int("n_filters_a", 2, 4)
                    with hp.conditional_scope("sub_cnn", ["b"]):
                        if sub_cnn == "b":
                            hp.Int("n_filters_b", 6, 8)
            with hp.conditional_scope("model_type", ["mlp"]):
                if model_type == "mlp":
                    sub_mlp = hp.Choice("sub_mlp", ["a", "b"])
                    with hp.conditional_scope("sub_mlp", ["a"]):
                        if sub_mlp == "a":
                            hp.Int("n_units_a", 2, 4)
                    with hp.conditional_scope("sub_mlp", ["b"]):
                        if sub_mlp == "b":
                            hp.Int("n_units_b", 6, 8)
            more_block = hp.Boolean("more_block", default=False)
            with hp.conditional_scope("more_block", [True]):
                if more_block:
                    hp.Int("new_block_hp", 1, 3)
```
resolves #498 