### PR TITLE
Fix the trial number update issue #549  

### DIFF
--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -97,7 +97,7 @@ class Display(object):
     def __init__(self, oracle, verbose=1):
         self.verbose = verbose
         self.oracle = oracle
-        self.trial_number = 0
+        self.trial_number = len(self.oracle.trials)
         self.col_width = 18
 
         # Start time for the overall search

--- a/tests/keras_tuner/engine/tuner_correctness_test.py
+++ b/tests/keras_tuner/engine/tuner_correctness_test.py
@@ -21,6 +21,7 @@ from tensorflow import keras
 
 import keras_tuner
 from keras_tuner.engine import tuner as tuner_module
+from keras_tuner.engine import tuner_utils
 
 INPUT_DIM = 2
 NUM_CLASSES = 3
@@ -238,6 +239,28 @@ def test_overwrite_true(tmp_dir):
         overwrite=True,
     )
     assert len(new_tuner.oracle.trials) == 0
+    
+def test_correct_display_trial_number(tmp_dir):
+    tuner = keras_tuner.tuners.RandomSearch(
+        hypermodel=build_model,
+        objective="val_accuracy",
+        max_trials=2,
+        directory=tmp_dir,
+    )
+    tuner.search(
+        TRAIN_INPUTS, TRAIN_TARGETS, validation_data=(VAL_INPUTS, VAL_TARGETS)
+    )
+    new_tuner = keras_tuner.tuners.RandomSearch(
+        hypermodel=build_model,
+        objective="val_accuracy",
+        max_trials=6,
+        directory=tmp_dir,
+        overwrite=False,
+    )
+    new_tuner.search(
+        TRAIN_INPUTS, TRAIN_TARGETS, validation_data=(VAL_INPUTS, VAL_TARGETS)
+    )
+    assert len(new_tuner.oracle.trials) == new_tuner._display.trial_number
 
 
 def test_error_on_unknown_objective_direction(tmp_dir):


### PR DESCRIPTION
The trial number is now initialized to the previous number of trials done. This the correct trail number to get logged when oracle is reloaded.