### PR TITLE
Change MultiExecutionTuner to Tuner

### DIFF
--- a/keras_tuner/engine/multi_execution_tuner.py
+++ b/keras_tuner/engine/multi_execution_tuner.py
@@ -12,115 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"Tuner that runs multiple executions per Trial."
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import collections
-import copy
-import os
-
-import numpy as np
-from tensorboard.plugins.hparams import api as hparams_api
-from tensorflow import keras
-
-from . import tuner as tuner_module
-from . import tuner_utils
+from keras_tuner.engine import tuner as tuner_module
 
 
 class MultiExecutionTuner(tuner_module.Tuner):
-    """A `Tuner` class that averages multiple runs of the process.
+    """Keep this class for backward compatibility.
 
-    Args:
-        oracle: An Oracle instance.
-        hypermodel: A `HyperModel` instance (or callable that takes
-            hyperparameters and returns a `Model` instance).
-        executions_per_trial: Integer, the number of executions (training a
-            model from scratch, starting from a new initialization) to run per
-            trial (model configuration). Model metrics may vary greatly
-            depending on random initialization, hence it is often a good idea
-            to run several executions per trial in order to evaluate the
-            performance of a given set of hyperparameter values.
-        **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
-            Please see the docstring for `Tuner`.
+    Currently, the Tuner class behavoir is the same as the old
+    MultiExecutionTuner.
     """
-
-    def __init__(self, oracle, hypermodel, executions_per_trial=1, **kwargs):
-        super(MultiExecutionTuner, self).__init__(oracle, hypermodel, **kwargs)
-        if isinstance(oracle.objective, list):
-            raise ValueError(
-                "Multi-objective is not supported, found: {}".format(
-                    oracle.objective
-                )
-            )
-        self.executions_per_trial = executions_per_trial
-        # This is the `step` that will be reported to the Oracle at the end
-        # of the Trial. Since intermediate results are not used, this is set
-        # to 0.
-        self._reported_step = 0
-
-    def on_epoch_end(self, trial, model, epoch, logs=None):
-        # Intermediate results are not passed to the Oracle, and
-        # checkpointing is handled via a `ModelCheckpoint` callback.
-        pass
-
-    def run_trial(self, trial, *fit_args, **fit_kwargs):
-        model_checkpoint = keras.callbacks.ModelCheckpoint(
-            filepath=self._get_checkpoint_fname(trial.trial_id, self._reported_step),
-            monitor=self.oracle.objective.name,
-            mode=self.oracle.objective.direction,
-            save_best_only=True,
-            save_weights_only=True,
-        )
-        original_callbacks = fit_kwargs.pop("callbacks", [])
-
-        # Run the training process multiple times.
-        metrics = collections.defaultdict(list)
-        for execution in range(self.executions_per_trial):
-            copied_fit_kwargs = copy.copy(fit_kwargs)
-            callbacks = self._deepcopy_callbacks(original_callbacks)
-            self._configure_tensorboard_dir(callbacks, trial, execution)
-            callbacks.append(tuner_utils.TunerCallback(self, trial))
-            # Only checkpoint the best epoch across all executions.
-            callbacks.append(model_checkpoint)
-            copied_fit_kwargs["callbacks"] = callbacks
-
-            history = self._build_and_fit_model(trial, fit_args, copied_fit_kwargs)
-            for metric, epoch_values in history.history.items():
-                if self.oracle.objective.direction == "min":
-                    best_value = np.min(epoch_values)
-                else:
-                    best_value = np.max(epoch_values)
-                metrics[metric].append(best_value)
-
-        # Average the results across executions and send to the Oracle.
-        averaged_metrics = {}
-        for metric, execution_values in metrics.items():
-            averaged_metrics[metric] = np.mean(execution_values)
-        self.oracle.update_trial(
-            trial.trial_id, metrics=averaged_metrics, step=self._reported_step
-        )
-
-    def _configure_tensorboard_dir(self, callbacks, trial, execution=0):
-        for callback in callbacks:
-            if callback.__class__.__name__ == "TensorBoard":
-                # Patch TensorBoard log_dir and add HParams KerasCallback
-                logdir = self._get_tensorboard_dir(
-                    callback.log_dir, trial.trial_id, execution
-                )
-                callback.log_dir = logdir
-                hparams = tuner_utils.convert_hyperparams_to_hparams(
-                    trial.hyperparameters
-                )
-                callbacks.append(
-                    hparams_api.KerasCallback(
-                        writer=logdir, hparams=hparams, trial_id=trial.trial_id
-                    )
-                )
-
-    def _get_tensorboard_dir(self, logdir, trial_id, execution):
-        return os.path.join(
-            str(logdir), str(trial_id), "execution{}".format(execution)
-        )

--- a/keras_tuner/engine/single_execution_tuner.py
+++ b/keras_tuner/engine/single_execution_tuner.py
@@ -1,0 +1,126 @@
+# Copyright 2019 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import os
+
+from tensorboard.plugins.hparams import api as hparams_api
+
+from keras_tuner.engine import tuner as tuner_module
+from keras_tuner.engine import tuner_utils
+
+
+class SingleExecutionTuner(tuner_module.Tuner):
+    """A `Tuner` class running each model once and reporting every epoch.
+
+    Args:
+        oracle: An Oracle instance.
+        hypermodel: A `HyperModel` instance (or callable that takes
+            hyperparameters and returns a `Model` instance).
+        **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
+            Please see the docstring for `Tuner`.
+    """
+
+    def __init__(self, oracle, hypermodel, **kwargs):
+        if "executions_per_trial" in kwargs:
+            raise ValueError(
+                "executions_per_trial is not supported " "in SingleExecutionTuner."
+            )
+        super().__init__(oracle, hypermodel, **kwargs)
+
+    def run_trial(self, trial, *fit_args, **fit_kwargs):
+        """Evaluates a set of hyperparameter values.
+
+        This method is called multiple times during `search` to build and
+        evaluate the models with different hyperparameters.
+
+        The method is responsible for reporting metrics related to the `Trial`
+        to the `Oracle` via `self.oracle.update_trial`.
+
+        Args:
+            trial: A `Trial` instance that contains the information needed to
+                run this trial. `Hyperparameters` can be accessed via
+                `trial.hyperparameters`.
+            *fit_args: Positional arguments passed by `search`.
+            **fit_kwargs: Keyword arguments passed by `search`.
+        """
+        # Handle any callbacks passed to `fit`.
+        copied_fit_kwargs = copy.copy(fit_kwargs)
+        callbacks = fit_kwargs.pop("callbacks", [])
+        callbacks = self._deepcopy_callbacks(callbacks)
+        self._configure_tensorboard_dir(callbacks, trial)
+        # `TunerCallback` calls:
+        # - `Tuner.on_epoch_begin`
+        # - `Tuner.on_batch_begin`
+        # - `Tuner.on_batch_end`
+        # - `Tuner.on_epoch_end`
+        # These methods report results to the `Oracle` and save the trained Model. If
+        # you are subclassing `Tuner` to write a custom training loop, you should
+        # make calls to these methods within `run_trial`.
+        callbacks.append(tuner_utils.TunerCallback(self, trial))
+        copied_fit_kwargs["callbacks"] = callbacks
+
+        self._build_and_fit_model(trial, fit_args, copied_fit_kwargs)
+
+    def save_model(self, trial_id, model, step=0):
+        epoch = step
+        self._checkpoint_model(model, trial_id, epoch)
+        # TODO: save the top epoch checkpoints instead of last ones.
+        epoch_to_delete = epoch - self._save_n_checkpoints
+        best_epoch = 0
+        if epoch > 0:
+            # TODO: `get_best_models` would load the `best_step` checkpoint after
+            # training. It would break if oracle picks a different `best_step` than
+            # `metrics.get_best_step` since it might be deleted due to it was
+            # not the `best_epoch` during the training.
+            best_epoch = self.oracle.get_trial(trial_id).metrics.get_best_step(
+                self.oracle.objective.name
+            )
+        if epoch > self._save_n_checkpoints and epoch_to_delete != best_epoch:
+            self._delete_checkpoint(trial_id, epoch_to_delete)
+
+    def on_epoch_end(self, trial, model, epoch, logs=None):
+        """Called at the end of an epoch.
+
+        Args:
+            trial: A `Trial` instance.
+            model: A Keras `Model`.
+            epoch: The current epoch number.
+            logs: Dict. Metrics for this epoch. This should include
+              the value of the objective for this epoch.
+        """
+        self.save_model(trial.trial_id, model, step=epoch)
+        # Report intermediate metrics to the `Oracle`.
+        status = self.oracle.update_trial(trial.trial_id, metrics=logs, step=epoch)
+        trial.status = status
+        if trial.status == "STOPPED":
+            model.stop_training = True
+
+    def _configure_tensorboard_dir(self, callbacks, trial):
+        for callback in callbacks:
+            if callback.__class__.__name__ == "TensorBoard":
+                # Patch TensorBoard log_dir and add HParams KerasCallback
+                logdir = self._get_tensorboard_dir(callback.log_dir, trial.trial_id)
+                callback.log_dir = logdir
+                hparams = tuner_utils.convert_hyperparams_to_hparams(
+                    trial.hyperparameters
+                )
+                callbacks.append(
+                    hparams_api.KerasCallback(
+                        writer=logdir, hparams=hparams, trial_id=trial.trial_id
+                    )
+                )
+
+    def _get_tensorboard_dir(self, logdir, trial_id):
+        return os.path.join(str(logdir), str(trial_id))

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -5,10 +5,10 @@ import numpy as np
 import tensorflow as tf
 from scipy import optimize as scipy_optimize
 
-from ..engine import hyperparameters as hp_module
-from ..engine import multi_execution_tuner
-from ..engine import oracle as oracle_module
-from ..engine import trial as trial_lib
+from keras_tuner.engine import hyperparameters as hp_module
+from keras_tuner.engine import oracle as oracle_module
+from keras_tuner.engine import trial as trial_module
+from keras_tuner.engine import tuner as tuner_module
 
 
 def cdist(x, y=None):
@@ -232,13 +232,13 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                 optimal_x = result.x
 
         values = self._vector_to_values(optimal_x)
-        return {"status": trial_lib.TrialStatus.RUNNING, "values": values}
+        return {"status": trial_module.TrialStatus.RUNNING, "values": values}
 
     def _random_populate_space(self):
         values = self._random_values()
         if values is None:
-            return {"status": trial_lib.TrialStatus.STOPPED, "values": None}
-        return {"status": trial_lib.TrialStatus.RUNNING, "values": values}
+            return {"status": trial_module.TrialStatus.STOPPED, "values": None}
+        return {"status": trial_module.TrialStatus.RUNNING, "values": values}
 
     def get_state(self):
         state = super(BayesianOptimizationOracle, self).get_state()
@@ -342,7 +342,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         return np.array(bounds)
 
 
-class BayesianOptimization(multi_execution_tuner.MultiExecutionTuner):
+class BayesianOptimization(tuner_module.Tuner):
     """BayesianOptimization tuning with Gaussian process.
 
     Args:

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -14,8 +14,8 @@
 import math
 import random
 
-from ..engine import multi_execution_tuner
-from ..engine import oracle as oracle_module
+from keras_tuner.engine import oracle as oracle_module
+from keras_tuner.engine import tuner as tuner_module
 
 
 class HyperbandOracle(oracle_module.Oracle):
@@ -290,7 +290,7 @@ class HyperbandOracle(oracle_module.Oracle):
         self._current_iteration = state["current_iteration"]
 
 
-class Hyperband(multi_execution_tuner.MultiExecutionTuner):
+class Hyperband(tuner_module.Tuner):
     """Variation of HyperBand algorithm.
 
     Reference:

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from ..engine import multi_execution_tuner
-from ..engine import oracle as oracle_module
-from ..engine import trial as trial_lib
+from keras_tuner.engine import oracle as oracle_module
+from keras_tuner.engine import trial as trial_module
+from keras_tuner.engine import tuner as tuner_module
 
 
 class RandomSearchOracle(oracle_module.Oracle):
@@ -79,11 +79,11 @@ class RandomSearchOracle(oracle_module.Oracle):
         """
         values = self._random_values()
         if values is None:
-            return {"status": trial_lib.TrialStatus.STOPPED, "values": None}
-        return {"status": trial_lib.TrialStatus.RUNNING, "values": values}
+            return {"status": trial_module.TrialStatus.STOPPED, "values": None}
+        return {"status": trial_module.TrialStatus.RUNNING, "values": values}
 
 
-class RandomSearch(multi_execution_tuner.MultiExecutionTuner):
+class RandomSearch(tuner_module.Tuner):
     """Random search tuner.
 
     Args:

--- a/tests/keras_tuner/engine/single_execution_tuner_test.py
+++ b/tests/keras_tuner/engine/single_execution_tuner_test.py
@@ -1,0 +1,143 @@
+# Copyright 2019 The Keras Tuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from tensorflow import keras
+
+import keras_tuner
+from keras_tuner.engine import single_execution_tuner
+
+INPUT_DIM = 2
+NUM_CLASSES = 3
+NUM_SAMPLES = 64
+TRAIN_INPUTS = np.random.random(size=(NUM_SAMPLES, INPUT_DIM))
+TRAIN_TARGETS = np.random.randint(0, NUM_CLASSES, size=(NUM_SAMPLES, 1))
+VAL_INPUTS = np.random.random(size=(NUM_SAMPLES, INPUT_DIM))
+VAL_TARGETS = np.random.randint(0, NUM_CLASSES, size=(NUM_SAMPLES, 1))
+
+
+@pytest.fixture(scope="function")
+def tmp_dir(tmpdir_factory):
+    return tmpdir_factory.mktemp("integration_test", numbered=True)
+
+
+def build_model(hp):
+    model = keras.Sequential(
+        [
+            keras.layers.Dense(
+                hp.Int("units", 100, 1000, 100),
+                input_shape=(INPUT_DIM,),
+                activation="relu",
+            ),
+            keras.layers.Dense(NUM_CLASSES, activation="softmax"),
+        ]
+    )
+    model.compile("rmsprop", "sparse_categorical_crossentropy", metrics=["accuracy"])
+    return model
+
+
+def test_update_trial(tmp_dir):
+    class MyOracle(keras_tuner.Oracle):
+        def populate_space(self, _):
+            values = {p.name: p.random_sample() for p in self.hyperparameters.space}
+            return {"values": values, "status": "RUNNING"}
+
+        def update_trial(self, trial_id, metrics, step=0):
+            if step == 3:
+                trial = self.trials[trial_id]
+                trial.status = "STOPPED"
+                return trial.status
+            return super(MyOracle, self).update_trial(trial_id, metrics, step)
+
+    my_oracle = MyOracle(objective="val_accuracy", max_trials=2)
+    tuner = single_execution_tuner.SingleExecutionTuner(
+        oracle=my_oracle, hypermodel=build_model, directory=tmp_dir
+    )
+    tuner.search(
+        x=TRAIN_INPUTS,
+        y=TRAIN_TARGETS,
+        epochs=5,
+        validation_data=(VAL_INPUTS, VAL_TARGETS),
+    )
+
+    assert len(my_oracle.trials) == 2
+
+    for trial in my_oracle.trials.values():
+        # Test that early stopping worked.
+        assert len(trial.metrics.get_history("val_accuracy")) == 3
+
+
+def test_checkpoint_removal(tmp_dir):
+    def build_model(hp):
+        model = keras.Sequential(
+            [keras.layers.Dense(hp.Int("size", 5, 10)), keras.layers.Dense(1)]
+        )
+        model.compile("sgd", "mse", metrics=["accuracy"])
+        return model
+
+    tuner = single_execution_tuner.SingleExecutionTuner(
+        oracle=keras_tuner.tuners.randomsearch.RandomSearchOracle(
+            objective="val_accuracy", max_trials=1, seed=1337
+        ),
+        hypermodel=build_model,
+        directory=tmp_dir,
+    )
+    x, y = np.ones((1, 5)), np.ones((1, 1))
+    tuner.search(x, y, validation_data=(x, y), epochs=21)
+    trial = list(tuner.oracle.trials.values())[0]
+    trial_id = trial.trial_id
+    assert tf.io.gfile.exists(tuner._get_checkpoint_fname(trial_id, 20))
+    assert not tf.io.gfile.exists(tuner._get_checkpoint_fname(trial_id, 10))
+
+
+def save_model_setup_tuner(tmp_dir):
+    class MyTuner(single_execution_tuner.SingleExecutionTuner):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.was_called = False
+
+        def _delete_checkpoint(self, trial_id, epoch):
+            self.was_called = True
+
+        def _checkpoint_model(self, model, trial_id, epoch):
+            pass
+
+    class MyOracle(keras_tuner.engine.oracle.Oracle):
+        def get_trial(self, trial_id):
+            trial = unittest.mock.Mock()
+            trial.metrics = unittest.mock.Mock()
+            trial.metrics.get_best_step.return_value = 5
+            return trial
+
+    return MyTuner(
+        oracle=MyOracle(objective="val_accuracy"),
+        hypermodel=build_model,
+        directory=tmp_dir,
+    )
+
+
+def test_save_model_delete_not_called(tmp_dir):
+    tuner = save_model_setup_tuner(tmp_dir)
+    tuner.save_model("a", None, step=15)
+    assert not tuner.was_called
+
+
+def test_save_model_delete_called(tmp_dir):
+    tuner = save_model_setup_tuner(tmp_dir)
+    tuner.save_model("a", None, step=16)
+    assert tuner.was_called

--- a/tests/keras_tuner/engine/tuner_workflows_test.py
+++ b/tests/keras_tuner/engine/tuner_workflows_test.py
@@ -554,37 +554,6 @@ def test_subclass_model_loading(tmp_dir):
     assert best_model_score == best_trial_score
 
 
-def test_update_trial(tmp_dir):
-    class MyOracle(keras_tuner.Oracle):
-        def populate_space(self, _):
-            values = {p.name: p.random_sample() for p in self.hyperparameters.space}
-            return {"values": values, "status": "RUNNING"}
-
-        def update_trial(self, trial_id, metrics, step=0):
-            if step == 3:
-                trial = self.trials[trial_id]
-                trial.status = "STOPPED"
-                return trial.status
-            return super(MyOracle, self).update_trial(trial_id, metrics, step)
-
-    my_oracle = MyOracle(objective="val_accuracy", max_trials=2)
-    tuner = keras_tuner.Tuner(
-        oracle=my_oracle, hypermodel=build_model, directory=tmp_dir
-    )
-    tuner.search(
-        x=TRAIN_INPUTS,
-        y=TRAIN_TARGETS,
-        epochs=5,
-        validation_data=(VAL_INPUTS, VAL_TARGETS),
-    )
-
-    assert len(my_oracle.trials) == 2
-
-    for trial in my_oracle.trials.values():
-        # Test that early stopping worked.
-        assert len(trial.metrics.get_history("val_accuracy")) == 3
-
-
 def test_objective_formats():
     obj = keras_tuner.engine.oracle._format_objective("accuracy")
     assert obj == keras_tuner.Objective("accuracy", "max")

--- a/tests/keras_tuner/tuners/randomsearch_test.py
+++ b/tests/keras_tuner/tuners/randomsearch_test.py
@@ -16,7 +16,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from keras_tuner.engine import multi_execution_tuner
+from keras_tuner.engine import tuner as tuner_module
 from keras_tuner.tuners import randomsearch
 
 
@@ -47,7 +47,7 @@ def test_update_space(tmp_dir):
                 result["values"]["layers"] = 2
             return result
 
-    tuner = multi_execution_tuner.MultiExecutionTuner(
+    tuner = tuner_module.Tuner(
         oracle=MyRandomSearch(objective="accuracy", max_trials=1),
         hypermodel=build_model,
         directory=tmp_dir,


### PR DESCRIPTION
The original `Tuner` class is for single execution per trial and reporting every epoch to the oracle.
The `MultiExecutionTuner` runs multiple executions per trial and reports to the oracle only once per trial.
All built-in tuners are `MultiExecutionTuner` subclasses.

Users thought the code in `Tuner` defines the behavior of the subclass tuners.
However, the functions are actually overridden by `MultiExecutionTuner` and results in different behaviors, which confuses the user.
The single execution feature in the `Tuner` class is for internal use only, and not called in the OSS code at all.

To resolve the confusion, we swapped the two classes.
Changed `MultiExecutionTuner` to `Tuner`, and the original `Tuner` to `SingleExecutionTuner`.
Now `SingleExecutionTuner` is a subclass of the `Tuner`.
It will be removed in the OSS and move to internal in the future.

We kept the `MultiExecutionTuner` class for backward compatibility.