### PR TITLE
allow not providing hypermodel or objective

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -40,9 +40,10 @@ class BaseTuner(stateful.Stateful):
 
     Args:
         oracle: Instance of Oracle class.
-        hypermodel: Instance of HyperModel class
-            (or callable that takes hyperparameters
-            and returns a Model instance).
+        hypermodel: Instance of `HyperModel` class (or callable that takes
+            hyperparameters and returns a `Model` instance). It is optional
+            when `Tuner.run_trial()` is overriden and does not use
+            `self.hypermodel`.
         directory: A string, the relative path to the working directory.
         project_name: A string, the name to use as prefix for files saved by
             this Tuner.
@@ -60,7 +61,7 @@ class BaseTuner(stateful.Stateful):
     def __init__(
         self,
         oracle,
-        hypermodel,
+        hypermodel=None,
         directory=None,
         project_name=None,
         logger=None,
@@ -74,7 +75,8 @@ class BaseTuner(stateful.Stateful):
 
         if not isinstance(oracle, oracle_module.Oracle):
             raise ValueError(
-                "Expected oracle to be " "an instance of Oracle, got: %s" % (oracle,)
+                "Expected `oracle` argument to be an instance of `Oracle`. "
+                f"Received: oracle={oracle} (of type ({type(oracle)})."
             )
         self.oracle = oracle
         self.oracle._set_project_dir(
@@ -117,6 +119,9 @@ class BaseTuner(stateful.Stateful):
         generates hp values based on the not activated `conditional_scopes`
         found in the builds.
         """
+        if self.hypermodel is None:
+            return
+
         hp = self.oracle.get_space()
 
         # Lists of stacks of conditions used during `explore_space()`.

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -147,13 +147,16 @@ class DefaultHyperModel(HyperModel):
 
 def get_hypermodel(hypermodel):
     """Gets a HyperModel from a HyperModel or callable."""
+    if hypermodel is None:
+        return None
+
     if isinstance(hypermodel, HyperModel):
         return hypermodel
-    else:
-        if not callable(hypermodel):
-            raise ValueError(
-                "The `hypermodel` argument should be either "
-                "a callable with signature `build(hp)` returning a model, "
-                "or an instance of `HyperModel`."
-            )
-        return DefaultHyperModel(hypermodel)
+
+    if not callable(hypermodel):
+        raise ValueError(
+            "The `hypermodel` argument should be either "
+            "a callable with signature `build(hp)` returning a model, "
+            "or an instance of `HyperModel`."
+        )
+    return DefaultHyperModel(hypermodel)

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -38,6 +38,8 @@ class Oracle(stateful.Stateful):
     Args:
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
@@ -58,7 +60,7 @@ class Oracle(stateful.Stateful):
 
     def __init__(
         self,
-        objective,
+        objective=None,
         max_trials=None,
         hyperparameters=None,
         allow_new_entries=True,
@@ -445,6 +447,8 @@ class Oracle(stateful.Stateful):
 
 
 def _format_objective(objective):
+    if objective is None:
+        return Objective("default_objective", "min")
     if isinstance(objective, list):
         return [_format_objective(obj) for obj in objective]
     if isinstance(objective, Objective):

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -125,10 +125,12 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     Args:
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
-            been exhausted.
+            been exhausted. Defaults to 10.
         num_initial_points: Optional number of randomly generated samples as
             initial training data for Bayesian optimization. If left
             unspecified, a value of 3 times the dimensionality of the
@@ -154,8 +156,8 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
     def __init__(
         self,
-        objective,
-        max_trials,
+        objective=None,
+        max_trials=10,
         num_initial_points=None,
         alpha=1e-4,
         beta=2.6,
@@ -346,14 +348,18 @@ class BayesianOptimization(tuner_module.Tuner):
     """BayesianOptimization tuning with Gaussian process.
 
     Args:
-        hypermodel: A `HyperModel` instance (or callable that takes
-            hyperparameters and returns a Model instance).
+        hypermodel: Instance of `HyperModel` class (or callable that takes
+            hyperparameters and returns a `Model` instance). It is optional
+            when `Tuner.run_trial()` is overriden and does not use
+            `self.hypermodel`.
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
-            been exhausted.
+            been exhausted. Defaults to 10.
         num_initial_points: Optional number of randomly generated samples as
             initial training data for Bayesian optimization. If left
             unspecified, a value of 3 times the dimensionality of the
@@ -381,9 +387,9 @@ class BayesianOptimization(tuner_module.Tuner):
 
     def __init__(
         self,
-        hypermodel,
-        objective,
-        max_trials,
+        hypermodel=None,
+        objective=None,
+        max_trials=10,
         num_initial_points=2,
         alpha=1e-4,
         beta=2.6,

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -59,11 +59,13 @@ class HyperbandOracle(oracle_module.Oracle):
     Args:
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_epochs: Integer, the maximum number of epochs to train one model.
             It is recommended to set this to a value slightly higher than the
             expected epochs to convergence for your largest Model, and to use
             early stopping during training (for example, via
-            `tf.keras.callbacks.EarlyStopping`).
+            `tf.keras.callbacks.EarlyStopping`). Defaults to 100.
         factor: Integer, the reduction factor for the number of epochs
             and number of models for each bracket. Defaults to 3.
         hyperband_iterations: Integer, at least 1, the number of times to
@@ -88,8 +90,8 @@ class HyperbandOracle(oracle_module.Oracle):
 
     def __init__(
         self,
-        objective,
-        max_epochs,
+        objective=None,
+        max_epochs=100,
         factor=3,
         hyperband_iterations=1,
         seed=None,
@@ -302,15 +304,19 @@ class Hyperband(tuner_module.Tuner):
 
 
     Args:
-        hypermodel: A `HyperModel` instance (or callable that takes
-            hyperparameters and returns a Model instance).
+        hypermodel: Instance of `HyperModel` class (or callable that takes
+            hyperparameters and returns a `Model` instance). It is optional
+            when `Tuner.run_trial()` is overriden and does not use
+            `self.hypermodel`.
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_epochs: Integer, the maximum number of epochs to train one model.
             It is recommended to set this to a value slightly higher than the
             expected epochs to convergence for your largest Model, and to use
             early stopping during training (for example, via
-            `tf.keras.callbacks.EarlyStopping`).
+            `tf.keras.callbacks.EarlyStopping`). Defaults to 100.
         factor: Integer, the reduction factor for the number of epochs
             and number of models for each bracket. Defaults to 3.
         hyperband_iterations: Integer, at least 1, the number of times to
@@ -337,9 +343,9 @@ class Hyperband(tuner_module.Tuner):
 
     def __init__(
         self,
-        hypermodel,
-        objective,
-        max_epochs,
+        hypermodel=None,
+        objective=None,
+        max_epochs=100,
         factor=3,
         hyperband_iterations=1,
         seed=None,

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -26,10 +26,12 @@ class RandomSearchOracle(oracle_module.Oracle):
     Args:
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
-            been exhausted.
+            been exhausted. Defaults to 10.
         seed: Optional integer, the random seed.
         hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
@@ -46,8 +48,8 @@ class RandomSearchOracle(oracle_module.Oracle):
 
     def __init__(
         self,
-        objective,
-        max_trials,
+        objective=None,
+        max_trials=10,
         seed=None,
         hyperparameters=None,
         allow_new_entries=True,
@@ -84,14 +86,18 @@ class RandomSearch(tuner_module.Tuner):
     """Random search tuner.
 
     Args:
-        hypermodel: A `HyperModel` instance (or callable that takes
-            hyperparameters and returns a Model instance).
+        hypermodel: Instance of `HyperModel` class (or callable that takes
+            hyperparameters and returns a Model instance). It is optional when
+            `Tuner.run_trial()` is overriden and does not use
+            `self.hypermodel`.
         objective: A string or `keras_tuner.Objective` instance. If a string,
             the direction of the optimization (min or max) will be inferred.
+            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
+            returns a single float as the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
-            been exhausted.
+            been exhausted. Defaults to 10.
         seed: Optional integer, the random seed.
         hyperparameters: Optional `HyperParameters` instance. Can be used to
             override (or register in advance) hyperparameters in the search
@@ -110,9 +116,9 @@ class RandomSearch(tuner_module.Tuner):
 
     def __init__(
         self,
-        hypermodel,
-        objective,
-        max_trials,
+        hypermodel=None,
+        objective=None,
+        max_trials=10,
         seed=None,
         hyperparameters=None,
         tune_new_entries=True,

--- a/tests/keras_tuner/engine/tuner_correctness_test.py
+++ b/tests/keras_tuner/engine/tuner_correctness_test.py
@@ -247,7 +247,7 @@ def test_run_trial_return_float_list(tmp_dir):
 def test_tuner_errors(tmp_dir):
     # invalid oracle
     with pytest.raises(
-        ValueError, match="Expected oracle to be an instance of Oracle"
+        ValueError, match="Expected `oracle` argument to be an instance of `Oracle`"
     ):
         tuner_module.Tuner(
             oracle="invalid", hypermodel=build_model, directory=tmp_dir


### PR DESCRIPTION
Support not providing `hypermodel` when overriding `Tuner.run_trial()`.
Support not providing `objective` when `Tuner.run_trial()` or `HyperModel.fit()` return a float, which will be minimized.

Changed to `hypermodel=None` and `objective=None` in the signature.
Because `max_trial` is after these two args, given it a default value `max_trial=10`.
The same for `max_epochs=100` in `Hyperband`.