### PR TITLE
bug fix: override compile args when loading model

### DIFF
--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -155,7 +155,9 @@ class Tuner(base_tuner.BaseTuner):
 
     def _build_hypermodel(self, hp):
         with maybe_distribute(self.distribution_strategy):
-            return self.hypermodel.build(hp)
+            model = self.hypermodel.build(hp)
+            self._override_compile_args(model)
+            return model
 
     def _try_build(self, hp):
         for i in range(MAX_FAIL_STREAK + 1):
@@ -229,7 +231,6 @@ class Tuner(base_tuner.BaseTuner):
         """
         hp = trial.hyperparameters
         model = self._try_build(hp)
-        self._override_compile_args(model)
         return self.hypermodel.fit(hp, model, *args, **kwargs)
 
     def run_trial(self, trial, *args, **kwargs):
@@ -319,7 +320,7 @@ class Tuner(base_tuner.BaseTuner):
         return histories
 
     def load_model(self, trial):
-        model = self._build_hypermodel(trial.hyperparameters)
+        model = self._try_build(trial.hyperparameters)
         # Reload best checkpoint. The Oracle scores the Trial and also
         # indicates at what epoch the best value of the objective was
         # obtained.

--- a/tests/keras_tuner/engine/tuner_workflows_test.py
+++ b/tests/keras_tuner/engine/tuner_workflows_test.py
@@ -281,7 +281,7 @@ def test_override_compile(tmp_dir):
         def fit(self, hp, model, *args, **kwargs):
             history = super().fit(hp, model, *args, **kwargs)
             assert model.optimizer.__class__.__name__ == "RMSprop"
-            assert model.loss == "sparse_categorical_crossentropy"
+            assert model.loss == "mse"
             assert len(model.metrics) >= 2
             assert model.metrics[-2]._fn.__name__ == "mean_squared_error"
             assert model.metrics[-1]._fn.__name__ == "sparse_categorical_accuracy"
@@ -293,14 +293,14 @@ def test_override_compile(tmp_dir):
         max_trials=2,
         executions_per_trial=1,
         metrics=["mse", "accuracy"],
-        loss="sparse_categorical_crossentropy",
+        loss="mse",
         optimizer="rmsprop",
         directory=tmp_dir,
     )
 
     assert tuner.oracle.objective.name == "val_mse"
     assert tuner.optimizer == "rmsprop"
-    assert tuner.loss == "sparse_categorical_crossentropy"
+    assert tuner.loss == "mse"
     assert tuner.metrics == ["mse", "accuracy"]
 
     tuner.search_space_summary()
@@ -311,7 +311,8 @@ def test_override_compile(tmp_dir):
         validation_data=(VAL_INPUTS, VAL_TARGETS),
     )
     tuner.results_summary()
-    tuner.hypermodel.build(tuner.oracle.hyperparameters)
+    model = tuner.get_best_models()[0]
+    assert model.loss == "mse"
 
 
 def test_static_space(tmp_dir):


### PR DESCRIPTION
The bug:

When loading the best model, the `loss`, `optimizer` and `metrics` passed to the tuner are not used. It loads the compile args used in the hypermodel.

Fix:

Minor refactor. Whenever trying to build the model in `Tuner`, just call `_try_build()`, which will build and override the compile args.