### PR TITLE
Make hyperparameters names visible in Display output

### DIFF
--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -142,14 +142,14 @@ class Display(object):
             print("Total elapsed time: {}".format(time_elapsed_str))
 
     def show_hyperparameter_table(self, trial):
-        template = "{{0:{0}}}|{{1:{0}}}|{{2:{0}}}".format(self.col_width)
+        template = "{{0:{0}}}|{{1:{0}}}|{{2}}".format(self.col_width)
         best_trials = self.oracle.get_best_trials()
         if len(best_trials) > 0:
             best_trial = best_trials[0]
         else:
             best_trial = None
         if trial.hyperparameters.values:
-            print(template.format("Hyperparameter", "Value", "Best Value So Far"))
+            print(template.format("Value", "Best Value So Far", "Hyperparameter"))
             for hp, value in trial.hyperparameters.values.items():
                 if best_trial:
                     best_value = best_trial.hyperparameters.values.get(hp)
@@ -157,9 +157,9 @@ class Display(object):
                     best_value = "?"
                 print(
                     template.format(
-                        self.format_value(hp),
                         self.format_value(value),
                         self.format_value(best_value),
+                        hp,
                     )
                 )
         else:


### PR DESCRIPTION
Moved Hyperparameter name to the last column and removed length description as discussed in #491

Result looks like this:
```
Search: Running Trial #1

Value             |Best Value So Far |Hyperparameter
False             |False             |structured_data_block_1/normalize
False             |True              |structured_data_block_1/dense_block_1/use_batchnorm
3                 |3                 |structured_data_block_1/dense_block_1/num_layers
512               |512               |structured_data_block_1/dense_block_1/units_0
0                 |0                 |structured_data_block_1/dense_block_1/dropout
512               |512               |structured_data_block_1/dense_block_1/units_1
0                 |0                 |classification_head_1/dropout
adam_weight_decay |adam_weight_decay |optimizer
0.001             |0.001             |learning_rate
128               |128               |structured_data_block_1/dense_block_1/units_2
```