### PR TITLE
Support multi-objective

### DIFF
--- a/keras_tuner/__init__.py
+++ b/keras_tuner/__init__.py
@@ -21,7 +21,7 @@ from keras_tuner.engine.hyperparameters import HyperParameter
 from keras_tuner.engine.hyperparameters import HyperParameters
 from keras_tuner.engine.logger import CloudLogger
 from keras_tuner.engine.logger import Logger
-from keras_tuner.engine.oracle import Objective
+from keras_tuner.engine.objective import Objective
 from keras_tuner.engine.oracle import Oracle
 from keras_tuner.engine.tuner import Tuner
 from keras_tuner.tuners import BayesianOptimization

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -191,6 +191,8 @@ class BaseTuner(stateful.Stateful):
             else:
                 self.oracle.update_trial(
                     trial.trial_id,
+                    # Convert to dictionary before calling `update_trial()`
+                    # to pass it from gRPC.
                     tuner_utils.convert_to_metrics_dict(
                         results, self.oracle.objective
                     ),

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The KerasTuner Authors
+# Copyright 2022 The KerasTuner Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@ from keras_tuner.engine import metrics_tracking
 from keras_tuner.engine import objective as obj_module
 
 
-class Objective(object):
+class Objective:
     """The objective for optimization during tuning.
 
     Args:
         name: String. The name of the objective.
-        direction: String. The value should be "min" or "max" indicating the
-            objective value should be minimized or maximized.
+        direction: String. The value should be "min" or "max" indicating
+            whether the objective value should be minimized or maximized.
     """
 
     def __init__(self, name, direction):
@@ -34,7 +34,7 @@ class Objective(object):
 
         Args:
             logs: A dictionary with the metric names as the keys and the metric
-                values as the values, which is the same format as the `logs`
+                values as the values, which is in the same format as the `logs`
                 argument for `Callback.on_epoch_end()`.
 
         Returns:

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -1,0 +1,110 @@
+# Copyright 2019 The KerasTuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from keras_tuner.engine import metrics_tracking
+from keras_tuner.engine import objective as obj_module
+
+
+class Objective(object):
+    """The objective for optimization during tuning.
+
+    Args:
+        name: String. The name of the objective.
+        direction: String. The value should be "min" or "max" indicating the
+            objective value should be minimized or maximized.
+    """
+
+    def __init__(self, name, direction):
+        self.name = name
+        self.direction = direction
+
+    def get_value(self, logs):
+        """Get the objective value from the metrics logs.
+
+        Args:
+            logs: A dictionary with the metric names as the keys and the metric
+                values as the values, which is the same format as the `logs`
+                argument for `Callback.on_epoch_end()`.
+
+        Returns:
+            The objective value.
+        """
+        return logs[self.name]
+
+    def better_than(self, a, b):
+        """Whether the first objective value is better than the second.
+
+        Args:
+            a: A float, an objective value to compare.
+            b: A float, another objective value to compare.
+
+        Returns:
+            Boolean, whether the first objective value is better than the
+            second.
+        """
+        return (a > b and self.direction == "max") or (
+            a < b and self.direction == "min"
+        )
+
+
+class MultiObjective(Objective):
+    """A container for a list of objectives.
+
+    Args:
+        objectives: A list of `Objective`s.
+    """
+
+    def __init__(self, objectives):
+        super().__init__(name="multi_objective", direction="min")
+        self.objectives = objectives
+        self.name_to_direction = {
+            objective.name: objective.direction for objective in self.objectives
+        }
+
+    def get_value(self, logs):
+        obj_value = 0
+        for metric_name, metric_value in logs.items():
+            if metric_name not in self.name_to_direction:
+                continue
+            if self.name_to_direction[metric_name] == "min":
+                obj_value += metric_value
+            else:
+                obj_value -= metric_value
+        return obj_value
+
+
+def create_objective(objective):
+    if objective is None:
+        return obj_module.Objective("default_objective", "min")
+    if isinstance(objective, list):
+        return MultiObjective([create_objective(obj) for obj in objective])
+    if isinstance(objective, obj_module.Objective):
+        return objective
+    if isinstance(objective, str):
+        direction = metrics_tracking.infer_metric_direction(objective)
+        if direction is None:
+            error_msg = (
+                'Could not infer optimization direction ("min" or "max") '
+                'for unknown metric "{obj}". Please specify the objective  as'
+                "a `keras_tuner.Objective`, for example `keras_tuner.Objective("
+                '"{obj}", direction="min")`.'
+            )
+            error_msg = error_msg.format(obj=objective)
+            raise ValueError(error_msg)
+        return obj_module.Objective(name=objective, direction=direction)
+    else:
+        raise ValueError(
+            "`objective` not understood, expected str or "
+            "`Objective` object, found: {}".format(objective)
+        )

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -137,10 +137,14 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
     https://www.cse.wustl.edu/~garnett/cse515t/spring_2015/files/lecture_notes/12.pdf).
 
     Args:
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
@@ -366,10 +370,14 @@ class BayesianOptimization(tuner_module.Tuner):
             hyperparameters and returns a `Model` instance). It is optional
             when `Tuner.run_trial()` is overriden and does not use
             `self.hypermodel`.
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -57,10 +57,14 @@ class HyperbandOracle(oracle_module.Oracle):
     ```
 
     Args:
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_epochs: Integer, the maximum number of epochs to train one model.
             It is recommended to set this to a value slightly higher than the
             expected epochs to convergence for your largest Model, and to use
@@ -308,10 +312,14 @@ class Hyperband(tuner_module.Tuner):
             hyperparameters and returns a `Model` instance). It is optional
             when `Tuner.run_trial()` is overriden and does not use
             `self.hypermodel`.
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_epochs: Integer, the maximum number of epochs to train one model.
             It is recommended to set this to a value slightly higher than the
             expected epochs to convergence for your largest Model, and to use

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -24,10 +24,14 @@ class RandomSearchOracle(oracle_module.Oracle):
     """Random search oracle.
 
     Args:
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has
@@ -90,10 +94,14 @@ class RandomSearch(tuner_module.Tuner):
             hyperparameters and returns a Model instance). It is optional when
             `Tuner.run_trial()` is overriden and does not use
             `self.hypermodel`.
-        objective: A string or `keras_tuner.Objective` instance. If a string,
-            the direction of the optimization (min or max) will be inferred.
-            It is optional when `Tuner.run_trial()` or `HyperModel.fit()`
-            returns a single float as the objective to minimize.
+        objective: A string, `keras_tuner.Objective` instance, or a list of
+            `keras_tuner.Objective`s and strings. If a string, the direction of
+            the optimization (min or max) will be inferred. If a list of
+            `keras_tuner.Objective`, we will minimize the sum of all the
+            objectives to minimize subtracting the sum of all the objectives to
+            maximize. The `objective` argument is optional when
+            `Tuner.run_trial()` or `HyperModel.fit()` returns a single float as
+            the objective to minimize.
         max_trials: Integer, the total number of trials (model configurations)
             to test at most. Note that the oracle may interrupt the search
             before `max_trial` models have been tested if the search space has

--- a/tests/unit_tests/engine/objective_test.py
+++ b/tests/unit_tests/engine/objective_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The KerasTuner Authors
+# Copyright 2022 The KerasTuner Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_tests/engine/objective_test.py
+++ b/tests/unit_tests/engine/objective_test.py
@@ -1,0 +1,69 @@
+# Copyright 2019 The KerasTuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import keras_tuner
+from keras_tuner.engine import objective
+
+
+def test_create_objective_with_str():
+    obj = objective.create_objective("accuracy")
+    assert obj.name == "accuracy" and obj.direction == "max"
+
+
+def test_create_objective_with_objective():
+    obj = objective.create_objective("accuracy")
+    obj = objective.create_objective(keras_tuner.Objective("score", "min"))
+    assert obj.name == "score" and obj.direction == "min"
+
+
+def test_create_objective_with_multi_objective():
+    obj = objective.create_objective(
+        [keras_tuner.Objective("score", "max"), keras_tuner.Objective("loss", "min")]
+    )
+    assert isinstance(obj, objective.MultiObjective)
+    assert obj.objectives[0].name == "score" and obj.objectives[0].direction == "max"
+    assert obj.objectives[1].name == "loss" and obj.objectives[1].direction == "min"
+
+
+def test_create_objective_with_multi_str():
+    obj = objective.create_objective(["accuracy", "loss"])
+    assert isinstance(obj, objective.MultiObjective)
+    assert (
+        obj.objectives[0].name == "accuracy" and obj.objectives[0].direction == "max"
+    )
+    assert obj.objectives[1].name == "loss" and obj.objectives[1].direction == "min"
+
+
+def test_objective_better_than_max():
+    obj = objective.create_objective("accuracy")
+    assert obj.better_than(1, 0)
+    assert not obj.better_than(0, 1)
+    assert not obj.better_than(0, 0)
+
+
+def test_objective_better_than_min():
+    obj = objective.create_objective("loss")
+    assert obj.better_than(0, 1)
+    assert not obj.better_than(1, 0)
+    assert not obj.better_than(0, 0)
+
+
+def test_objective_get_value():
+    obj = objective.create_objective("loss")
+    assert obj.get_value({"accuracy": 3.0, "loss": 2.0}) == 2.0
+
+
+def test_multi_objective_get_value():
+    obj = objective.create_objective(["accuracy", "loss"])
+    assert obj.get_value({"accuracy": 3.0, "loss": 2.0}) == -1.0

--- a/tests/unit_tests/engine/tuner_utils_test.py
+++ b/tests/unit_tests/engine/tuner_utils_test.py
@@ -1,0 +1,102 @@
+# Copyright 2019 The KerasTuner Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import numpy as np
+from tensorflow import keras
+
+from keras_tuner.engine import objective as obj_module
+from keras_tuner.engine import tuner_utils
+
+
+def test_save_best_epoch_with_single_objective(tmp_path):
+    objective = obj_module.create_objective("val_loss")
+    filepath = os.path.join(tmp_path, "saved_weights")
+    callback = tuner_utils.SaveBestEpoch(objective, filepath)
+
+    model = keras.Sequential([keras.layers.Dense(1)])
+    model.compile(loss="mse")
+    val_x = np.random.rand(10, 10)
+    val_y = np.random.rand(10, 10)
+    history = model.fit(
+        x=np.random.rand(10, 10),
+        y=np.random.rand(10, 1),
+        validation_data=(val_x, val_y),
+        epochs=10,
+        callbacks=[callback],
+    )
+
+    model.load_weights(filepath)
+
+    assert min(history.history["val_loss"]) == model.evaluate(val_x, val_y)
+
+
+def test_save_best_epoch_with_multi_objective(tmp_path):
+    objective = obj_module.create_objective(["val_loss", "val_mae"])
+    filepath = os.path.join(tmp_path, "saved_weights")
+    callback = tuner_utils.SaveBestEpoch(objective, filepath)
+
+    model = keras.Sequential([keras.layers.Dense(1)])
+    model.compile(loss="mse", metrics=["mae"])
+    val_x = np.random.rand(10, 10)
+    val_y = np.random.rand(10, 10)
+    history = model.fit(
+        x=np.random.rand(10, 10),
+        y=np.random.rand(10, 1),
+        validation_data=(val_x, val_y),
+        epochs=10,
+        callbacks=[callback],
+    )
+
+    model.load_weights(filepath)
+
+    assert min(history.history["val_loss"]) + min(history.history["val_mae"]) == sum(
+        model.evaluate(val_x, val_y)
+    )
+
+
+def test_convert_to_metrics_with_history():
+    model = keras.Sequential([keras.layers.Dense(1)])
+    model.compile(loss="mse", metrics=["mae"])
+    val_x = np.random.rand(10, 10)
+    val_y = np.random.rand(10, 10)
+    history = model.fit(
+        x=np.random.rand(10, 10),
+        y=np.random.rand(10, 1),
+        validation_data=(val_x, val_y),
+    )
+
+    results = tuner_utils.convert_to_metrics_dict(
+        history, obj_module.Objective("val_loss", "min")
+    )
+    assert all([key in results for key in ["loss", "val_loss", "mae", "val_mae"]])
+
+
+def test_convert_to_metrics_with_float():
+    assert tuner_utils.convert_to_metrics_dict(
+        0.1, obj_module.Objective("val_loss", "min")
+    ) == {"val_loss": 0.1}
+
+
+def test_convert_to_metrics_with_dict():
+    assert tuner_utils.convert_to_metrics_dict(
+        {"loss": 0.2, "val_loss": 0.1}, obj_module.Objective("val_loss", "min")
+    ) == {"loss": 0.2, "val_loss": 0.1}
+
+
+def test_convert_to_metrics_with_list_of_floats():
+    assert tuner_utils.convert_to_metrics_dict(
+        [0.1, 0.2], obj_module.Objective("val_loss", "min")
+    ) == {"val_loss": (0.1 + 0.2) / 2}

--- a/tests/unit_tests/engine/tuner_utils_test.py
+++ b/tests/unit_tests/engine/tuner_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The KerasTuner Authors
+# Copyright 2022 The KerasTuner Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_tests/legacy_import_test.py
+++ b/tests/unit_tests/legacy_import_test.py
@@ -35,7 +35,7 @@ def test_kerastuner_same_as_keras_tuner():
         from kerastuner.engine.metrics_tracking import (  # noqa: F401
             MetricObservation,
         )
-        from kerastuner.engine.oracle import Objective  # noqa: F401
+        from kerastuner import Objective  # noqa: F401
         from kerastuner.engine.oracle import Oracle  # noqa: F401
         from kerastuner.engine.tuner import Tuner  # noqa: F401
         from kerastuner.engine.stateful import Stateful  # noqa: F401


### PR DESCRIPTION
Resolves #556 

Support `objective` as a list of `Objective`s.

There are two approaches to implement it:

1. Create a custom metric to run all the metrics in the multi-objective. However, it slows down the evaluation since each metric is evaluated twice. Moreover, we need to handle the update of different types of metrics, including functions and subclasses. We would also need to get the metric class or function if the user provide a string.
2. Create a custom callback to collect the metric values and saves the model at its best value. Because the objective is not one of the metrics, we cannot use the built-in `ModelCheckPoint` callback. This one is much more straight-forward to implement. It also allows advanced objective like FLOPs or model size in the future.