### PR TITLE
Mitigate the issue of hanging workers after chief already quits when running keras-tuner in distributed tuning mode.

### DIFF
--- a/keras_tuner/distribute/oracle_chief.py
+++ b/keras_tuner/distribute/oracle_chief.py
@@ -85,8 +85,10 @@ def start_server(oracle):
                 time.sleep(10)
 
             print(
-                "Oracle server on chief is exiting in 10s."
+                "Oracle server on chief is exiting in 40s."
                 "The chief will go on with post-search code."
             )
+            # Wait for another 30s for all the subsequent calls from workers to come
+            time.sleep(30)
             server.stop(10)
             break


### PR DESCRIPTION
Occasionally, when user runs tuning in distributed tuning mode, the worker never quits even after the chief already quits. This commit mitigates the issue by letting the chief to wait a longer time for all the subsequent grpc calls from the workers to be processed, so that the worker won't retry the grpc call forever.

Root cause of this issue:
When the last worker is finishing the last trial, it sends end_trial to the chief and the chief then pops the tuner_id from the ongoing_trials. The chief can trigger the server.stop(10) and quits (when all trials are done) before this worker sends out the subsequent grpc calls (e.g. update_space and create_trials). Thus this worker will retry the grpc call forever because the chief already quits (UNAVAILABLE) and the grpc calls are sent with wait_for_ready=True. This race condition happens occasionally.