### PR TITLE
better error check for returned eval results

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -194,7 +194,7 @@ class BaseTuner(stateful.Stateful):
                     # Convert to dictionary before calling `update_trial()`
                     # to pass it from gRPC.
                     tuner_utils.convert_to_metrics_dict(
-                        results, self.oracle.objective
+                        results, self.oracle.objective, "Tuner.run_trial()"
                     ),
                 )
             self.on_trial_end(trial)

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from keras_tuner.engine import metrics_tracking
-from keras_tuner.engine import objective as obj_module
 
 
 class Objective:
@@ -61,6 +60,13 @@ class Objective:
         return self.name == obj.name and self.direction == obj.direction
 
 
+class DefaultObjective(Objective):
+    """Default objective to minimize if not provide by the user."""
+
+    def __init__(self):
+        super().__init__(name="default_objective", direction="min")
+
+
 class MultiObjective(Objective):
     """A container for a list of objectives.
 
@@ -96,10 +102,10 @@ class MultiObjective(Objective):
 
 def create_objective(objective):
     if objective is None:
-        return obj_module.Objective("default_objective", "min")
+        return DefaultObjective()
     if isinstance(objective, list):
         return MultiObjective([create_objective(obj) for obj in objective])
-    if isinstance(objective, obj_module.Objective):
+    if isinstance(objective, Objective):
         return objective
     if isinstance(objective, str):
         direction = metrics_tracking.infer_metric_direction(objective)
@@ -112,7 +118,7 @@ def create_objective(objective):
             )
             error_msg = error_msg.format(obj=objective)
             raise ValueError(error_msg)
-        return obj_module.Objective(name=objective, direction=direction)
+        return Objective(name=objective, direction=direction)
     else:
         raise ValueError(
             "`objective` not understood, expected str or "

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -61,7 +61,7 @@ class Objective:
 
 
 class DefaultObjective(Objective):
-    """Default objective to minimize if not provide by the user."""
+    """Default objective to minimize if not provided by the user."""
 
     def __init__(self):
         super().__init__(name="default_objective", direction="min")

--- a/keras_tuner/engine/tuner_utils_test.py
+++ b/keras_tuner/engine/tuner_utils_test.py
@@ -15,6 +15,7 @@
 import os
 
 import numpy as np
+import pytest
 from tensorflow import keras
 
 from keras_tuner.engine import objective as obj_module
@@ -79,24 +80,36 @@ def test_convert_to_metrics_with_history():
     )
 
     results = tuner_utils.convert_to_metrics_dict(
-        history, obj_module.Objective("val_loss", "min")
+        history, obj_module.Objective("val_loss", "min"), "func_name"
     )
     assert all([key in results for key in ["loss", "val_loss", "mae", "val_mae"]])
 
 
 def test_convert_to_metrics_with_float():
     assert tuner_utils.convert_to_metrics_dict(
-        0.1, obj_module.Objective("val_loss", "min")
+        0.1, obj_module.Objective("val_loss", "min"), "func_name"
     ) == {"val_loss": 0.1}
 
 
 def test_convert_to_metrics_with_dict():
-    assert tuner_utils.convert_to_metrics_dict(
-        {"loss": 0.2, "val_loss": 0.1}, obj_module.Objective("val_loss", "min")
-    ) == {"loss": 0.2, "val_loss": 0.1}
+    assert (
+        tuner_utils.convert_to_metrics_dict(
+            {"loss": 0.2, "val_loss": 0.1},
+            obj_module.Objective("val_loss", "min"),
+            "func_name",
+        )
+        == {"loss": 0.2, "val_loss": 0.1}
+    )
 
 
 def test_convert_to_metrics_with_list_of_floats():
     assert tuner_utils.convert_to_metrics_dict(
-        [0.1, 0.2], obj_module.Objective("val_loss", "min")
+        [0.1, 0.2], obj_module.Objective("val_loss", "min"), "func_name"
     ) == {"val_loss": (0.1 + 0.2) / 2}
+
+
+def test_convert_to_metrics_with_dict_without_obj_key():
+    with pytest.raises(ValueError, match="the specified objective"):
+        tuner_utils.convert_to_metrics_dict(
+            {"loss": 0.1}, obj_module.Objective("val_loss", "min"), "func_name"
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,9 @@ ignore =
     N812
     # do not use bare 'except'
     E722
+    # Escape characters check.
+    # Conflict with pytest error message regex.
+    W605
 
 exclude =
     *_pb2.py


### PR DESCRIPTION
* Support numpy float types in `HyperModel.fit()` and `Tuner.run_trial()` return values.
* Raise errors when the return value types are incorrect.
* Use `DefaultObjective` class instead of the objective name to check if a default objective is used.