### PR TITLE
Ensure hallucination checks if the Gaussian regressor has been fit be…

### DIFF
--- a/keras_tuner/engine/tuner_utils_test.py
+++ b/keras_tuner/engine/tuner_utils_test.py
@@ -92,14 +92,11 @@ def test_convert_to_metrics_with_float():
 
 
 def test_convert_to_metrics_with_dict():
-    assert (
-        tuner_utils.convert_to_metrics_dict(
-            {"loss": 0.2, "val_loss": 0.1},
-            obj_module.Objective("val_loss", "min"),
-            "func_name",
-        )
-        == {"loss": 0.2, "val_loss": 0.1}
-    )
+    assert tuner_utils.convert_to_metrics_dict(
+        {"loss": 0.2, "val_loss": 0.1},
+        obj_module.Objective("val_loss", "min"),
+        "func_name",
+    ) == {"loss": 0.2, "val_loss": 0.1}
 
 
 def test_convert_to_metrics_with_list_of_floats():

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -301,8 +301,9 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                 prob = hp_module.value_to_cumulative_prob(trial_value, hp)
                 vector.append(prob)
 
-            if trial in ongoing_trials:
-                # "Hallucinate" the results of ongoing trials. This ensures that
+            if trial in ongoing_trials and hasattr(self.gpr, "_x_train"):
+                # Check if self.gpr has had a .fit called at least once and then
+                # "hallucinate" the results of ongoing trials. This ensures that
                 # repeat trials are not selected when running distributed.
                 x_h = np.array(vector).reshape((1, -1))
                 y_h_mean, y_h_std = self.gpr.predict(x_h)

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -50,7 +50,7 @@ def matern_kernel(x, y=None):
     # nu = 2.5
     dists = cdist(x, y)
     dists *= math.sqrt(5)
-    kernel_matrix = (1.0 + dists + dists ** 2 / 3.0) * np.exp(-dists)
+    kernel_matrix = (1.0 + dists + dists**2 / 3.0) * np.exp(-dists)
     return kernel_matrix
 
 
@@ -122,7 +122,7 @@ class GaussianProcessRegressor(object):
         y_var[y_var < 0] = 0.0
 
         # Undo normalize y.
-        y_var *= self._y_train_std ** 2
+        y_var *= self._y_train_std**2
         y_mean = self._y_train_std * y_mean + self._y_train_mean
 
         return y_mean.flatten(), np.sqrt(y_var)


### PR DESCRIPTION
…fore calling predict in the Bayesian oracle.

Previously the oracle would attempt to call the predict method of the Gaussian regressor without checking if the regressor has been fit yet. In distributed runs, this could lead to a cryptic error about _x_train if the Bayesian oracle attempted to hallucinate on a trial recently initialized by a different worker process.

`raise _InactiveRpcError(state) grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with: status = StatusCode.UNKNOWN details = "Exception calling application: 'GaussianProcessRegressor' object has no attribute '_x_train'" debug_error_string = "{"created":"@1643154861.118197004","description":"Error received from peer ipv4:127.0.0.1:8000","file":"src/core/lib/surface/call.cc","file_line":1074,"grpc_message":"Exception calling application: 'GaussianProcessRegressor' object has no attribute '_x_train'","grpc_status":2}"`

This error is especially common when hyperparameter optimizing with a long-running, training loop. Now, the Bayesian oracle ensures that the Gaussian regressor has been previously fit before it attempts to use that regressor to predict for "hallucinations".