### PR TITLE
Resolves #609: Support for sklearn functions without sample_weight

### DIFF
--- a/keras_tuner/engine/tuner_utils_test.py
+++ b/keras_tuner/engine/tuner_utils_test.py
@@ -92,14 +92,11 @@ def test_convert_to_metrics_with_float():
 
 
 def test_convert_to_metrics_with_dict():
-    assert (
-        tuner_utils.convert_to_metrics_dict(
-            {"loss": 0.2, "val_loss": 0.1},
-            obj_module.Objective("val_loss", "min"),
-            "func_name",
-        )
-        == {"loss": 0.2, "val_loss": 0.1}
-    )
+    assert tuner_utils.convert_to_metrics_dict(
+        {"loss": 0.2, "val_loss": 0.1},
+        obj_module.Objective("val_loss", "min"),
+        "func_name",
+    ) == {"loss": 0.2, "val_loss": 0.1}
 
 
 def test_convert_to_metrics_with_list_of_floats():

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -50,7 +50,7 @@ def matern_kernel(x, y=None):
     # nu = 2.5
     dists = cdist(x, y)
     dists *= math.sqrt(5)
-    kernel_matrix = (1.0 + dists + dists ** 2 / 3.0) * np.exp(-dists)
+    kernel_matrix = (1.0 + dists + dists**2 / 3.0) * np.exp(-dists)
     return kernel_matrix
 
 
@@ -122,7 +122,7 @@ class GaussianProcessRegressor(object):
         y_var[y_var < 0] = 0.0
 
         # Undo normalize y.
-        y_var *= self._y_train_std ** 2
+        y_var *= self._y_train_std**2
         y_mean = self._y_train_std * y_mean + self._y_train_mean
 
         return y_mean.flatten(), np.sqrt(y_var)

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -16,6 +16,7 @@ import collections
 import os
 import pickle
 import warnings
+import inspect
 
 import numpy as np
 import tensorflow as tf
@@ -166,7 +167,9 @@ class SklearnTuner(base_tuner.BaseTuner):
             )
 
             model = self.hypermodel.build(trial.hyperparameters)
-            if isinstance(model, sklearn.pipeline.Pipeline):
+            
+            supports_sw = 'sample_weight' in inspect.getfullargspec(model.fit).args
+            if isinstance(model, sklearn.pipeline.Pipeline) or not supports_sw:
                 model.fit(X_train, y_train)
             else:
                 model.fit(X_train, y_train, sample_weight=sample_weight_train)

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -167,8 +167,8 @@ class SklearnTuner(base_tuner.BaseTuner):
             )
 
             model = self.hypermodel.build(trial.hyperparameters)
-            
-            supports_sw = 'sample_weight' in inspect.getfullargspec(model.fit).args
+
+            supports_sw = "sample_weight" in inspect.getfullargspec(model.fit).args
             if isinstance(model, sklearn.pipeline.Pipeline) or not supports_sw:
                 model.fit(X_train, y_train)
             else:

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 """Tuner for Scikit-learn Models."""
 import collections
+import inspect
 import os
 import pickle
 import warnings
-import inspect
 
 import numpy as np
 import tensorflow as tf

--- a/keras_tuner/tuners/sklearn_tuner_test.py
+++ b/keras_tuner/tuners/sklearn_tuner_test.py
@@ -21,8 +21,8 @@ from sklearn import ensemble
 from sklearn import linear_model
 from sklearn import metrics
 from sklearn import model_selection
-from sklearn import pipeline
 from sklearn import neighbors
+from sklearn import pipeline
 
 import keras_tuner as kt
 

--- a/keras_tuner/tuners/sklearn_tuner_test.py
+++ b/keras_tuner/tuners/sklearn_tuner_test.py
@@ -45,7 +45,9 @@ def build_model(hp):
             k = hp.Int("n_neighbors", 1, 30, default=5)
             model = neighbors.KNeighborsClassifier(
                 n_neighbors=k,
-                weights=hp.Choice("weights", ["uniform", "distance"], default="uniform")
+                weights=hp.Choice(
+                    "weights", ["uniform", "distance"], default="uniform"
+                ),
             )
     else:
         raise ValueError("Unrecognized model_type")
@@ -73,7 +75,9 @@ def build_pipeline(hp):
             k = hp.Int("n_neighbors", 1, 30, default=5)
             model = neighbors.KNeighborsClassifier(
                 n_neighbors=k,
-                weights=hp.Choice("weights", ["uniform", "distance"], default="uniform")
+                weights=hp.Choice(
+                    "weights", ["uniform", "distance"], default="uniform"
+                ),
             )
     else:
         raise ValueError("Unrecognized model_type")

--- a/keras_tuner/tuners/sklearn_tuner_test.py
+++ b/keras_tuner/tuners/sklearn_tuner_test.py
@@ -22,12 +22,13 @@ from sklearn import linear_model
 from sklearn import metrics
 from sklearn import model_selection
 from sklearn import pipeline
+from sklearn import neighbors
 
 import keras_tuner as kt
 
 
 def build_model(hp):
-    model_type = hp.Choice("model_type", ["random_forest", "ridge"])
+    model_type = hp.Choice("model_type", ["random_forest", "ridge", "knn"])
     if model_type == "random_forest":
         with hp.conditional_scope("model_type", "random_forest"):
             model = ensemble.RandomForestClassifier(
@@ -38,6 +39,13 @@ def build_model(hp):
         with hp.conditional_scope("model_type", "ridge"):
             model = linear_model.RidgeClassifier(
                 alpha=hp.Float("alpha", 1e-3, 1, sampling="log")
+            )
+    elif model_type == "knn":
+        with hp.conditional_scope("model_type", "knn"):
+            k = hp.Int("n_neighbors", 1, 30, default=5)
+            model = neighbors.KNeighborsClassifier(
+                n_neighbors=k,
+                weights=hp.Choice("weights", ["uniform", "distance"], default="uniform")
             )
     else:
         raise ValueError("Unrecognized model_type")
@@ -48,7 +56,7 @@ def build_pipeline(hp):
     n_components = hp.Choice("n_components", [2, 5, 10], default=5)
     pca = decomposition.PCA(n_components=n_components)
 
-    model_type = hp.Choice("model_type", ["random_forest", "ridge"])
+    model_type = hp.Choice("model_type", ["random_forest", "ridge", "knn"])
     if model_type == "random_forest":
         with hp.conditional_scope("model_type", "random_forest"):
             model = ensemble.RandomForestClassifier(
@@ -59,6 +67,13 @@ def build_pipeline(hp):
         with hp.conditional_scope("model_type", "ridge"):
             model = linear_model.RidgeClassifier(
                 alpha=hp.Float("alpha", 1e-3, 1, sampling="log")
+            )
+    elif model_type == "knn":
+        with hp.conditional_scope("model_type", "knn"):
+            k = hp.Int("n_neighbors", 1, 30, default=5)
+            model = neighbors.KNeighborsClassifier(
+                n_neighbors=k,
+                weights=hp.Choice("weights", ["uniform", "distance"], default="uniform")
             )
     else:
         raise ValueError("Unrecognized model_type")


### PR DESCRIPTION
The code uses the inspect library to check if `sample_weight` is a part of the model's fit signature. This allows the `sklearn_tuner` to be used with the many models in the `sklearn` library without a `sample_weight` keyword-argument.