### PR TITLE
Resolves #652 and #605: Make human readable trial_id and sync trial numbers between worker Displays

### DIFF
--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -183,7 +183,9 @@ class Oracle(stateful.Stateful):
         if tuner_id in self.ongoing_trials:
             return self.ongoing_trials[tuner_id]
 
-        trial_id = trial_lib.generate_trial_id()
+        # Make the trial_id the current number of trial, pre-padded with 0s
+        trial_id = "{{:0{}d}}".format(len(str(self.max_trials)))
+        trial_id = trial_id.format(len(self.trials))
 
         if self.max_trials and len(self.trials) >= self.max_trials:
             status = trial_lib.TrialStatus.STOPPED

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -95,7 +95,6 @@ class Display(object):
     def __init__(self, oracle, verbose=1):
         self.verbose = verbose
         self.oracle = oracle
-        self.trial_number = len(self.oracle.trials)
         self.col_width = 18
 
         # Start time for the overall search
@@ -107,7 +106,7 @@ class Display(object):
     def on_trial_begin(self, trial):
         if self.verbose >= 1:
 
-            self.trial_number += 1
+            self.trial_number = int(trial.trial_id) + 1
             print()
             print("Search: Running Trial #{}".format(self.trial_number))
             print()

--- a/keras_tuner/engine/tuner_utils_test.py
+++ b/keras_tuner/engine/tuner_utils_test.py
@@ -92,14 +92,11 @@ def test_convert_to_metrics_with_float():
 
 
 def test_convert_to_metrics_with_dict():
-    assert (
-        tuner_utils.convert_to_metrics_dict(
-            {"loss": 0.2, "val_loss": 0.1},
-            obj_module.Objective("val_loss", "min"),
-            "func_name",
-        )
-        == {"loss": 0.2, "val_loss": 0.1}
-    )
+    assert tuner_utils.convert_to_metrics_dict(
+        {"loss": 0.2, "val_loss": 0.1},
+        obj_module.Objective("val_loss", "min"),
+        "func_name",
+    ) == {"loss": 0.2, "val_loss": 0.1}
 
 
 def test_convert_to_metrics_with_list_of_floats():

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -50,7 +50,7 @@ def matern_kernel(x, y=None):
     # nu = 2.5
     dists = cdist(x, y)
     dists *= math.sqrt(5)
-    kernel_matrix = (1.0 + dists + dists ** 2 / 3.0) * np.exp(-dists)
+    kernel_matrix = (1.0 + dists + dists**2 / 3.0) * np.exp(-dists)
     return kernel_matrix
 
 
@@ -122,7 +122,7 @@ class GaussianProcessRegressor(object):
         y_var[y_var < 0] = 0.0
 
         # Undo normalize y.
-        y_var *= self._y_train_std ** 2
+        y_var *= self._y_train_std**2
         y_mean = self._y_train_std * y_mean + self._y_train_mean
 
         return y_mean.flatten(), np.sqrt(y_var)


### PR DESCRIPTION
By allowing the `Oracle` class to assign the `trial_id` based on the current size of the `trials` list, the trial_id becomes more humanly readable (re: #605). 

Moreover, the trial number is now intrinsically a part of the `trial` object, meaning that distributed worker Oracles can display the correct trial number being considered without the need of communicating directly to the chief over the socket. By leveraging the chief oracle's original distribution strategy, the worker `Display`s are kept in sync and the current trial number does not become decoupled over successive iterations (re: #652).

As an example, here is the result of running the MWE code from #652 on the current `master` branch of `keras_tuner`:
![mwe_before](https://user-images.githubusercontent.com/24885961/151683255-c6112d06-bfa0-48be-a2cb-60da7870c6d1.png)
the worker in the bottom left was run first and correctly called the first trial `Trial 1`. The worker in the bottom right was run second and correctly labelled its first trial as `Trial 3` (as the first worker had already completed 2 iterations at this point). However, the next run of the first `tuner` was also labelled Trial 3 and all Tuners finished after 6 total iterations had been completed, but judging from the output no `Trial 5` or `Trial 6` was completed (though all trials _were_ completed in actuality, as evidenced by the `ls` command run in the top terminal after all workers concluded).

In contrast, here is the result of running the same MWE code from #652 but using this updated branch of `keras_tuner`
![mwe_fixed](https://user-images.githubusercontent.com/24885961/151683344-14fb5524-7433-40e3-a6ca-e1bbd2f935b4.png)
we see each trial uniquely represented in the worker `Display`s without spurious double-counting. Also, the `trial_id` folder names are human-readable in the final `ls` command in the top terminal.

Moreover, the `trial_id` strings are padded with the appropriate number of zeros (as dictated by `max_trials`) so that trials are displayed in the correct order in a file directory for larger distributed runs.
![mwe_3](https://user-images.githubusercontent.com/24885961/151683400-15c2253b-1ae6-4a23-a3bc-1d03f2b19ba8.png)
