### PR TITLE
Fix Bayesian optimization error

### DIFF
--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -247,8 +247,9 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
             result = scipy_optimize.minimize(
                 _upper_confidence_bound, x0=x_try, bounds=bounds, method="L-BFGS-B"
             )
-            if result.fun[0] < optimal_val:
-                optimal_val = result.fun[0]
+            result_fun = result.fun if np.isscalar(result.fun) else result.fun[0]
+            if result_fun < optimal_val:
+                optimal_val = result_fun
                 optimal_x = result.x
 
         values = self._vector_to_values(optimal_x)


### PR DESCRIPTION
# Problem

Unlike documented in the [SciPy docs](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html#scipy.optimize.OptimizeResult) the `OptimizeResult.fun` property can also be a scalar (See https://github.com/fmfn/BayesianOptimization/issues/60 for an example). This can lead to the following error:
```
TypeError: 'float' object is not subscriptable
```

# Solution

Check if `result.fun` is a scalar. If it is, use the value as is else get the first element as usual.