### PR TITLE
add --profile=black to isort

### DIFF
--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,4 +1,4 @@
-isort --sl .
+isort --sl --profile=black .
 black --line-length 85 .
 
 for i in $(find keras_tuner -name '*.py') # or whatever other pattern...

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,4 +1,4 @@
-isort --sl -c .
+isort --sl --profile=black -c .
 if ! [ $? -eq 0 ]
 then
   echo "Please run \"sh shell/format.sh\" to format the code."


### PR DESCRIPTION
This causes isort to respect the rules of black.  Without this,
if you have any long paths isort will wrap them as follows:

from my_long_path_import_something.something import (
  Symbol
)

while black does:

from my_long_path_import_something.something import (
  Symbol
)