### PR TITLE
Adopt safe model and trial saving practices in the multi-worker setting

### DIFF
--- a/keras_tuner/distribute/utils.py
+++ b/keras_tuner/distribute/utils.py
@@ -47,3 +47,133 @@ def is_chief_oracle():
     if has_chief_oracle():
         return "chief" in os.environ["KERASTUNER_TUNER_ID"]
     return False
+
+
+# Below is forked from Keras:
+# https://github.com/keras-team/keras/blob/master/keras/distribute/distributed_file_utils.py
+"""Utilities that help manage directory path in distributed settings.
+
+In multi-worker training, the need to write a file to distributed file
+location often requires only one copy done by one worker despite many workers
+that are involved in training. The option to only perform saving by chief is
+not feasible for a couple of reasons: 1) Chief and workers may each contain
+a client that runs the same piece of code and it's preferred not to make
+any distinction between the code run by chief and other workers, and 2)
+saving of model or model's related information may require SyncOnRead
+variables to be read, which needs the cooperation of all workers to perform
+all-reduce.
+
+This set of utility is used so that only one copy is written to the needed
+directory, by supplying a temporary write directory path for workers that don't
+need to save, and removing the temporary directory once file writing is done.
+
+Example usage:
+```
+# Before using a directory to write file to.
+self.log_write_dir = write_dirpath(self.log_dir, get_distribution_strategy())
+# Now `self.log_write_dir` can be safely used to write file to.
+
+...
+
+# After the file is written to the directory.
+remove_temp_dirpath(self.log_dir, get_distribution_strategy())
+
+```
+
+Experimental. API is subject to change.
+"""
+
+def _get_base_dirpath(strategy):
+    task_id = strategy.extended._task_id    # pylint: disable=protected-access
+    return 'workertemp_' + str(task_id)
+
+
+def _is_temp_dir(dirpath, strategy):
+    return dirpath.endswith(_get_base_dirpath(strategy))
+
+
+def _get_temp_dir(dirpath, strategy):
+    if _is_temp_dir(dirpath, strategy):
+        temp_dir = dirpath
+    else:
+        temp_dir = os.path.join(dirpath, _get_base_dirpath(strategy))
+    tf.io.gfile.makedirs(temp_dir)
+    return temp_dir
+
+
+def write_dirpath(dirpath, strategy):
+    """Returns the writing dir that should be used to save file distributedly.
+
+    `dirpath` would be created if it doesn't exist.
+
+    Args:
+        dirpath: Original dirpath that would be used without distribution.
+        strategy: The tf.distribute strategy object currently used.
+
+    Returns:
+        The writing dir path that should be used to save with distribution.
+    """
+    if strategy is None:
+        # Infer strategy if not given.
+        strategy = tf.distribute.get_strategy()
+    if strategy is None:
+        # If strategy is still not available, this is not in distributed training.
+        # Fallback to original dirpath.
+        return dirpath
+    if not strategy.extended._in_multi_worker_mode():    # pylint: disable=protected-access
+        return dirpath
+    if strategy.extended.should_checkpoint:
+        return dirpath
+    # If this worker is not chief and hence should not save file, save it to a
+    # temporary directory to be removed later.
+    return _get_temp_dir(dirpath, strategy)
+
+
+def remove_temp_dirpath(dirpath, strategy):
+    """Removes the temp path after writing is finished.
+
+    Args:
+        dirpath: Original dirpath that would be used without distribution.
+        strategy: The tf.distribute strategy object currently used.
+    """
+    if strategy is None:
+        # Infer strategy if not given.
+        strategy = tf.distribute.get_strategy()
+    if strategy is None:
+        # If strategy is still not available, this is not in distributed training.
+        # Fallback to no-op.
+        return
+    # TODO(anjalisridhar): Consider removing the check for multi worker mode since
+    # it is redundant when used with the should_checkpoint property.
+    if (strategy.extended._in_multi_worker_mode() and    # pylint: disable=protected-access
+            not strategy.extended.should_checkpoint):
+        # If this worker is not chief and hence should not save file, remove
+        # the temporary directory.
+        tf.io.gfile.rmtree(_get_temp_dir(dirpath, strategy))
+
+
+def write_filepath(filepath, strategy):
+    """Returns the writing file path to be used to save file distributedly.
+
+    Directory to contain `filepath` would be created if it doesn't exist.
+
+    Args:
+        filepath: Original filepath that would be used without distribution.
+        strategy: The tf.distribute strategy object currently used.
+
+    Returns:
+        The writing filepath that should be used to save file with distribution.
+    """
+    dirpath = os.path.dirname(filepath)
+    base = os.path.basename(filepath)
+    return os.path.join(write_dirpath(dirpath, strategy), base)
+
+
+def remove_temp_dir_with_filepath(filepath, strategy):
+    """Removes the temp path for file after writing is finished.
+
+    Args:
+        filepath: Original filepath that would be used without distribution.
+        strategy: The tf.distribute strategy object currently used.
+    """
+    remove_temp_dirpath(os.path.dirname(filepath), strategy)

--- a/keras_tuner/distribute/utils.py
+++ b/keras_tuner/distribute/utils.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Distribution utilities."""
 
-
 import os
+
+import tensorflow as tf
 
 
 def has_chief_oracle():
@@ -83,9 +84,10 @@ remove_temp_dirpath(self.log_dir, get_distribution_strategy())
 Experimental. API is subject to change.
 """
 
+
 def _get_base_dirpath(strategy):
-    task_id = strategy.extended._task_id    # pylint: disable=protected-access
-    return 'workertemp_' + str(task_id)
+    task_id = strategy.extended._task_id  # pylint: disable=protected-access
+    return "workertemp_" + str(task_id)
 
 
 def _is_temp_dir(dirpath, strategy):
@@ -120,7 +122,9 @@ def write_dirpath(dirpath, strategy):
         # If strategy is still not available, this is not in distributed training.
         # Fallback to original dirpath.
         return dirpath
-    if not strategy.extended._in_multi_worker_mode():    # pylint: disable=protected-access
+    if (
+        not strategy.extended._in_multi_worker_mode()
+    ):  # pylint: disable=protected-access
         return dirpath
     if strategy.extended.should_checkpoint:
         return dirpath
@@ -133,7 +137,8 @@ def remove_temp_dirpath(dirpath, strategy):
     """Removes the temp path after writing is finished.
 
     Args:
-        dirpath: Original dirpath that would be used without distribution.
+        dirpath: Original dirpath that would be used without distribution, or
+            the temporary dirpath used with distribution.
         strategy: The tf.distribute strategy object currently used.
     """
     if strategy is None:
@@ -145,8 +150,10 @@ def remove_temp_dirpath(dirpath, strategy):
         return
     # TODO(anjalisridhar): Consider removing the check for multi worker mode since
     # it is redundant when used with the should_checkpoint property.
-    if (strategy.extended._in_multi_worker_mode() and    # pylint: disable=protected-access
-            not strategy.extended.should_checkpoint):
+    if (
+        strategy.extended._in_multi_worker_mode()
+        and not strategy.extended.should_checkpoint
+    ):
         # If this worker is not chief and hence should not save file, remove
         # the temporary directory.
         tf.io.gfile.rmtree(_get_temp_dir(dirpath, strategy))
@@ -173,7 +180,8 @@ def remove_temp_dir_with_filepath(filepath, strategy):
     """Removes the temp path for file after writing is finished.
 
     Args:
-        filepath: Original filepath that would be used without distribution.
+        filepath: Original filepath that would be used without distribution, or
+            the temporary filepath used with distribution.
         strategy: The tf.distribute strategy object currently used.
     """
     remove_temp_dirpath(os.path.dirname(filepath), strategy)

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -114,7 +114,7 @@ class Oracle(stateful.Stateful):
         self.project_name = None
 
         # In multi-worker mode, only the chief of each cluster should report
-        # results.
+        # results and save trials.
         self.multi_worker = False
         self.should_report = True
 
@@ -233,6 +233,8 @@ class Oracle(stateful.Stateful):
                 )
                 trial.metrics.register(metric_name, direction=direction)
             trial.metrics.update(metric_name, metric_value, step=step)
+        if self.should_report:
+            self._save_trial(trial)
         self._save_trial(trial)
         # To signal early stopping, set Trial.status to "STOPPED".
         return trial.status

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -235,7 +235,6 @@ class Oracle(stateful.Stateful):
             trial.metrics.update(metric_name, metric_value, step=step)
         if self.should_report:
             self._save_trial(trial)
-        self._save_trial(trial)
         # To signal early stopping, set Trial.status to "STOPPED".
         return trial.status
 

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -24,6 +24,7 @@ from tensorboard.plugins.hparams import api as hparams_api
 from tensorflow import keras
 
 from keras_tuner import utils
+from keras_tuner.distribute import utils as ds_utils
 from keras_tuner.engine import hyperparameters as hp_module
 from keras_tuner.engine import objective as obj_module
 
@@ -191,6 +192,10 @@ class SaveBestEpoch(keras.callbacks.Callback):
             self.best_value = float("inf")
 
     def on_epoch_end(self, epoch, logs=None):
+        # Create temporary saved model directories on non-chief workers, to 
+        # avoid file contention.
+        self.filepath = ds_utils.write_filepath(self.filepath,
+                                                self.model.distribute_strategy)
         if not self.objective.has_value(logs):
             # Save on every epoch if metric value is not in the logs. Either no
             # objective is specified, or objective is computed and returned
@@ -201,6 +206,10 @@ class SaveBestEpoch(keras.callbacks.Callback):
         if self.objective.better_than(current_value, self.best_value):
             self.best_value = current_value
             self.model.save_weights(self.filepath)
+            # Remove temporary saved model files from non-chief workers.
+            ds_utils.remove_temp_dir_with_filepath(
+                self.filepath, self.model.distribute_strategy
+            )
 
 
 def average_metrics_dicts(metrics_dicts):


### PR DESCRIPTION
Based on the [reference guide](https://www.tensorflow.org/tutorials/distribute/multi_worker_with_keras#model_saving_and_loading) for saving models when training with multiple workers.