### PR TITLE
Record best epoch info with update_trial

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -193,13 +193,18 @@ class BaseTuner(stateful.Stateful):
                     stacklevel=2,
                 )
             else:
+                tuner_utils.validate_trial_results(
+                    results, self.oracle.objective, "Tuner.run_trial()"
+                ),
                 self.oracle.update_trial(
                     trial.trial_id,
                     # Convert to dictionary before calling `update_trial()`
                     # to pass it from gRPC.
                     tuner_utils.convert_to_metrics_dict(
-                        results, self.oracle.objective, "Tuner.run_trial()"
+                        results,
+                        self.oracle.objective,
                     ),
+                    step=tuner_utils.get_best_step(results, self.oracle.objective),
                 )
             self.on_trial_end(trial)
         self.on_search_end()

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -41,7 +41,7 @@ class Trial(stateful.Stateful):
 
         self.metrics = metrics_tracking.MetricsTracker()
         self.score = None
-        self.best_step = None
+        self.best_step = 0
         self.status = status
 
     def summary(self):

--- a/keras_tuner/engine/trial_test.py
+++ b/keras_tuner/engine/trial_test.py
@@ -34,7 +34,7 @@ def test_trial_proto():
     assert new_trial.hyperparameters.get("a") == 3
     assert new_trial.trial_id == "trial1"
     assert new_trial.score is None
-    assert new_trial.best_step is None
+    assert new_trial.best_step == 0
 
     trial.score = -10
     trial.best_step = 3

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -220,9 +220,10 @@ class Tuner(base_tuner.BaseTuner):
         hp = trial.hyperparameters
         model = self._try_build(hp)
         results = self.hypermodel.fit(hp, model, *args, **kwargs)
-        return tuner_utils.convert_to_metrics_dict(
+        tuner_utils.validate_trial_results(
             results, self.oracle.objective, "HyperModel.fit()"
         )
+        return results
 
     def run_trial(self, trial, *args, **kwargs):
         """Evaluates a set of hyperparameter values.
@@ -338,6 +339,15 @@ class Tuner(base_tuner.BaseTuner):
         pass
 
     def on_epoch_end(self, trial, model, epoch, logs=None):
+        """Called at the end of an epoch.
+
+        Args:
+            trial: A `Trial` instance.
+            model: A Keras `Model`.
+            epoch: The current epoch number.
+            logs: Dict. Metrics for this epoch. This should include
+              the value of the objective for this epoch.
+        """
         # Intermediate results are not passed to the Oracle, and
         # checkpointing is handled via a `SaveBestEpoch` callback.
         pass


### PR DESCRIPTION
With #602, a bug is introduced that the `MetricHistory` no longer tracks the best epoch information,
which is due to the merging of `MultiExecutionTuner` and `Tuner` class.
`MultiExecutionTuner` does not use `Tuner.on_epoch_end()` to call `Oracle.update_trial()` for every epoch, while `Tuner` does.
After merging, we use the `MultiExecutionTuner` behavior for `Tuner`, which only call `Oracle.update_trial()` once after the training is finished,
which is much easier to manage and enabled more workflows for the user, while the user can always overide the `Tuner` class to use `.on_epoch_end()` to report the per epoch info.

As we only report once after the training, the epoch number is no longer preserved in the `MetricHistory`, which is managed by the `Oracle`. (The best epoch is still saved with a callback, but don't know which epoch number it is.)
This breaks an AutoKeras workflow. If the user do not specify the number of epochs when using AutoKeras, it would use early stopping.
If the user does not provide the validation data, it would first spilt a validation set from the training data when searching for best hyperparameters,
and merge it back for a final training with the original training set.
How many epochs the final training use is decided by which epoch has the best metric value on the validation data for that specific trial, which uses the best hyperparameters during the search.
That is why we need to record the best epoch for each trial.

There are 2 ways to do it.
One is to override `on_epoch_end` to report every epoch, just like before.
Another way is the proposed way, just to check the `History` object to find out the best epoch number.
The first solution would destroy the simplicity of only reporting once to the `Oracle`.
So picked the second solution, which is more elegant.
However, it requires to add a function to find out the best epochs, which is `tuner_utils.get_best_step()`.

