### PR TITLE
load hyperband model weights from checkpoints when round > 0

### DIFF
--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -383,15 +383,10 @@ class Hyperband(tuner_module.Tuner):
             fit_kwargs["initial_epoch"] = hp.values["tuner/initial_epoch"]
         return super(Hyperband, self).run_trial(trial, *fit_args, **fit_kwargs)
 
-    def _build_model(self, hp):
-        model = super(Hyperband, self)._build_model(hp)
+    def _build_hypermodel(self, hp):
+        model = super(Hyperband, self)._build_hypermodel(hp)
         if "tuner/trial_id" in hp.values:
             trial_id = hp.values["tuner/trial_id"]
-            history_trial = self.oracle.get_trial(trial_id)
             # Load best checkpoint from this trial.
-            model.load_weights(
-                self._get_checkpoint_fname(
-                    history_trial.trial_id, history_trial.best_step
-                )
-            )
+            model.load_weights(self._get_checkpoint_fname(trial_id))
         return model


### PR DESCRIPTION
Since I had the same problem, this commit is related to the problem described in the issue:
https://github.com/keras-team/keras-tuner/issues/372

The current Hyperband tuner implements a method named. "_build_model" to define the behaviour when round_num > 0 in a bracket, and where the model should train from an initial_epoch > 0 (by loading the weights from a saved model). However, this method "_build_model" is not used in the parent class (It should be a naming problem but the method that was defined in the parent class and that is used to build the model is named "_build_hypermodel" . Therefore, the current behaviour does no take into account this logic for Hyperband tuner , and all the training are done from scratch.

Overriding the method "_build_hypermodel" in the Hyperband class with the same logic that was implemented in "_build_model" solves the issue.