### PR TITLE
Add f-string format with flynt

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -259,9 +259,7 @@ class HyperImageAugment(hypermodel.HyperModel):
             transform_factor_max = transform_params[1]
             if len(transform_params) > 2:
                 raise ValueError(
-                    "Length of keyword argument {} must not exceed 2.".format(
-                        transform_name
-                    )
+                    f"Length of keyword argument {transform_name} must not exceed 2."
                 )
         except TypeError:
             transform_factor_min = 0

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -135,9 +135,7 @@ class HyperEfficientNet(hypermodel.HyperModel):
             x = augmentation_model(x)
 
         # Select one of pre-trained EfficientNet as feature extractor
-        version = hp.Choice(
-            "version", ["B{}".format(i) for i in range(8)], default="B0"
-        )
+        version = hp.Choice("version", [f"B{i}" for i in range(8)], default="B0")
         img_size = EFFICIENTNET_IMG_SIZE[version]
 
         x = preprocessing.Resizing(img_size, img_size, interpolation="bilinear")(x)

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -47,7 +47,7 @@ class HyperXception(hypermodel.HyperModel):
         input_shape=None,
         input_tensor=None,
         classes=None,
-        **kwargs
+        **kwargs,
     ):
         super(HyperXception, self).__init__(**kwargs)
         if include_top and classes is None:
@@ -150,7 +150,7 @@ def sep_conv(x, num_filters, kernel_size=(3, 3), activation="relu"):
         x = layers.BatchNormalization()(x)
         x = layers.Activation("relu")(x)
     else:
-        ValueError("Unknown activation function: %s" % (activation,))
+        ValueError(f"Unknown activation function: {activation}")
     return x
 
 
@@ -200,7 +200,7 @@ def conv(x, num_filters, kernel_size=(3, 3), activation="relu", strides=(2, 2)):
         x = layers.BatchNormalization()(x)
         x = layers.Activation("relu")(x)
     else:
-        msg = "Unknown activation function: %s" % activation
+        msg = f"Unknown activation function: {activation}"
         ValueError(msg)
     return x
 
@@ -222,6 +222,6 @@ def dense(x, dims, activation="relu", batchnorm=True, dropout_rate=0):
         if dropout_rate:
             x = layers.Dropout(dropout_rate)(x)
     else:
-        msg = "Unknown activation function: %s" % activation
+        msg = f"Unknown activation function: {activation}"
         ValueError(msg)
     return x

--- a/keras_tuner/distribute/oracle_chief.py
+++ b/keras_tuner/distribute/oracle_chief.py
@@ -74,7 +74,7 @@ def start_server(oracle):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     oracle_servicer = OracleServicer(oracle)
     service_pb2_grpc.add_OracleServicer_to_server(oracle_servicer, server)
-    server.add_insecure_port("{}:{}".format(ip_addr, port))
+    server.add_insecure_port(f"{ip_addr}:{port}")
     server.start()
     while True:
         # The server does not block otherwise.

--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -31,7 +31,7 @@ class OracleClient(object):
 
         ip_addr = os.environ["KERASTUNER_ORACLE_IP"]
         port = os.environ["KERASTUNER_ORACLE_PORT"]
-        channel = grpc.insecure_channel("{}:{}".format(ip_addr, port))
+        channel = grpc.insecure_channel(f"{ip_addr}:{port}")
         self.stub = service_pb2_grpc.OracleStub(channel)
         self.tuner_id = os.environ["KERASTUNER_TUNER_ID"]
 
@@ -50,9 +50,7 @@ class OracleClient(object):
         }
         if name in whitelisted_attrs:
             return getattr(self._oracle, name)
-        raise AttributeError(
-            '`OracleClient` object has no attribute "{}"'.format(name)
-        )
+        raise AttributeError(f'`OracleClient` object has no attribute "{name}"')
 
     def get_space(self):
         response = self.stub.GetSpace(

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -103,9 +103,7 @@ class BaseTuner(stateful.Stateful):
         self._populate_initial_space()
 
         if not overwrite and tf.io.gfile.exists(self._get_tuner_fname()):
-            tf.get_logger().info(
-                "Reloading Tuner from {}".format(self._get_tuner_fname())
-            )
+            tf.get_logger().info(f"Reloading Tuner from {self._get_tuner_fname()}")
             self.reload()
 
     def _populate_initial_space(self):
@@ -329,11 +327,11 @@ class BaseTuner(stateful.Stateful):
         """
         print("Search space summary")
         hp = self.oracle.get_space()
-        print("Default search space size: %d" % len(hp.space))
+        print(f"Default search space size: {len(hp.space)}")
         for p in hp.space:
             config = p.get_config()
             name = config.pop("name")
-            print("%s (%s)" % (name, p.__class__.__name__))
+            print(f"{name} ({p.__class__.__name__})")
             print(config)
 
     def results_summary(self, num_trials=10):
@@ -346,9 +344,9 @@ class BaseTuner(stateful.Stateful):
             num_trials: Optional number of trials to display. Defaults to 10.
         """
         print("Results summary")
-        print("Results in %s" % self.project_dir)
+        print(f"Results in {self.project_dir}")
         print("Showing %d best trials" % num_trials)
-        print("{}".format(self.oracle.objective))
+        print(f"{self.oracle.objective}")
 
         best_trials = self.oracle.get_best_trials(num_trials)
         for trial in best_trials:

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -66,7 +66,7 @@ class Condition(object):
             values = parent.values
             values = [getattr(v, v.WhichOneof("kind")) for v in values]
             return Parent(name=name, values=values)
-        raise ValueError("Unrecognized condition of type: {}".format(kind))
+        raise ValueError(f"Unrecognized condition of type: {kind}")
 
 
 class Parent(Condition):

--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -252,7 +252,7 @@ class Int(HyperParameter):
         step=1,
         sampling=None,
         default=None,
-        **kwargs
+        **kwargs,
     ):
         super(Int, self).__init__(name=name, default=default, **kwargs)
         self.max_value = _check_int(max_value, arg="max_value")
@@ -350,7 +350,7 @@ class Float(HyperParameter):
         step=None,
         sampling=None,
         default=None,
-        **kwargs
+        **kwargs,
     ):
         super(Float, self).__init__(name=name, default=default, **kwargs)
         self.max_value = float(max_value)
@@ -436,12 +436,11 @@ class Boolean(HyperParameter):
         super(Boolean, self).__init__(name=name, default=default, **kwargs)
         if default not in {True, False}:
             raise ValueError(
-                "`default` must be a Python boolean. "
-                "You passed: default=%s" % (default,)
+                f"`default` must be a Python boolean. You passed: default={default}"
             )
 
     def __repr__(self):
-        return 'Boolean(name: "{}", default: {})'.format(self.name, self.default)
+        return f'Boolean(name: "{self.name}", default: {self.default})'
 
     def random_sample(self, seed=None):
         random_state = random.Random(seed)
@@ -489,7 +488,7 @@ class Fixed(HyperParameter):
         self.value = value
 
     def __repr__(self):
-        return "Fixed(name: {}, value: {})".format(self.name, self.value)
+        return f"Fixed(name: {self.name}, value: {self.value})"
 
     def random_sample(self, seed=None):
         return self.value
@@ -736,9 +735,9 @@ class HyperParameters(object):
         if name in self.values:
             return self.values[name]  # Only active values are added here.
         elif name in self._hps:
-            raise ValueError("{} is currently inactive.".format(name))
+            raise ValueError(f"{name} is currently inactive.")
         else:
-            raise KeyError("{} does not exist.".format(name))
+            raise KeyError(f"{name} does not exist.")
 
     def __getitem__(self, name):
         return self.get(name)
@@ -1044,7 +1043,7 @@ class HyperParameters(object):
             elif isinstance(hp, Boolean):
                 boolean_space.append(hp.to_proto())
             else:
-                raise ValueError("Unrecognized HP type: {}".format(hp))
+                raise ValueError(f"Unrecognized HP type: {hp}")
 
         values = {}
         for name, value in self.values.items():
@@ -1057,7 +1056,7 @@ class HyperParameters(object):
             elif isinstance(value, bool):
                 val = keras_tuner_pb2.Value(boolean_value=value)
             else:
-                raise ValueError("Unrecognized value type: {}".format(value))
+                raise ValueError(f"Unrecognized value type: {value}")
             values[name] = val
 
         return keras_tuner_pb2.HyperParameters(
@@ -1156,7 +1155,7 @@ def cumulative_prob_to_value(prob, hp):
                 - hp.min_value * math.pow(hp.max_value / hp.min_value, 1 - prob)
             )
         else:
-            raise ValueError("Unrecognized sampling value: {}".format(sampling))
+            raise ValueError(f"Unrecognized sampling value: {sampling}")
 
         if hp.step is not None:
             values = np.arange(hp.min_value, hp.max_value + 1e-7, step=hp.step)
@@ -1167,7 +1166,7 @@ def cumulative_prob_to_value(prob, hp):
             return int(value)
         return value
     else:
-        raise ValueError("Unrecognized `HyperParameter` type: {}".format(hp))
+        raise ValueError(f"Unrecognized `HyperParameter` type: {hp}")
 
 
 def value_to_cumulative_prob(value, hp):
@@ -1199,9 +1198,9 @@ def value_to_cumulative_prob(value, hp):
                 (hp.max_value + hp.min_value - value) / hp.min_value
             ) / math.log(hp.max_value / hp.min_value)
         else:
-            raise ValueError("Unrecognized sampling value: {}".format(sampling))
+            raise ValueError(f"Unrecognized sampling value: {sampling}")
     else:
-        raise ValueError("Unrecognized `HyperParameter` type: {}".format(hp))
+        raise ValueError(f"Unrecognized `HyperParameter` type: {hp}")
 
 
 def _sampling_from_proto(sampling):
@@ -1213,7 +1212,7 @@ def _sampling_from_proto(sampling):
         return "log"
     if sampling == keras_tuner_pb2.Sampling.REVERSE_LOG:
         return "reverse_log"
-    raise ValueError("Unrecognized sampling: {}".format(sampling))
+    raise ValueError(f"Unrecognized sampling: {sampling}")
 
 
 def _sampling_to_proto(sampling):
@@ -1225,7 +1224,7 @@ def _sampling_to_proto(sampling):
         return keras_tuner_pb2.Sampling.LOG
     if sampling == "reverse_log":
         return keras_tuner_pb2.Sampling.REVERSE_LOG
-    raise ValueError("Unrecognized sampling: {}".format(sampling))
+    raise ValueError(f"Unrecognized sampling: {sampling}")
 
 
 def _to_list(values):

--- a/keras_tuner/engine/logger.py
+++ b/keras_tuner/engine/logger.py
@@ -56,14 +56,14 @@ def send_to_backend(url, data, key):
     try:
         response_json = response.json()
     except json.decoder.JSONDecodeError:
-        print("Cloud service down -- data not uploaded: %s" % response.text)
+        print(f"Cloud service down -- data not uploaded: {response.text}")
         return CONNECT_ERROR
 
     if response_json["status"] == "Unauthorized":
         print("Invalid backend API key.")
         return AUTH_ERROR
     else:
-        print("Warning! Cloud service upload failed: %s" % response.text)
+        print(f"Warning! Cloud service upload failed: {response.text}")
         return UPLOAD_ERROR
 
 

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -61,7 +61,7 @@ class MetricObservation(object):
         return other.value == self.value and other.step == self.step
 
     def __repr__(self):
-        return "MetricObservation(value={}, step={})".format(self.value, self.step)
+        return f"MetricObservation(value={self.value}, step={self.step})"
 
     def to_proto(self):
         return keras_tuner_pb2.MetricObservation(value=self.value, step=self.step)
@@ -196,7 +196,7 @@ class MetricsTracker(object):
 
     def register(self, name, direction=None):
         if self.exists(name):
-            raise ValueError("Metric already exists: %s" % (name,))
+            raise ValueError(f"Metric already exists: {name}")
         if direction is None:
             direction = infer_metric_direction(name)
         if direction is None:
@@ -283,7 +283,7 @@ class MetricsTracker(object):
 
     def _assert_exists(self, name):
         if name not in self.metrics:
-            raise ValueError("Unknown metric: %s" % (name,))
+            raise ValueError(f"Unknown metric: {name}")
 
 
 _MAX_METRICS = (

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -184,7 +184,7 @@ class Oracle(stateful.Stateful):
             return self.ongoing_trials[tuner_id]
 
         # Make the trial_id the current number of trial, pre-padded with 0s
-        trial_id = "{{:0{}d}}".format(len(str(self.max_trials)))
+        trial_id = f"{{:0{len(str(self.max_trials))}d}}"
         trial_id = trial_id.format(len(self.trials))
 
         if self.max_trials and len(self.trials) >= self.max_trials:
@@ -254,7 +254,7 @@ class Oracle(stateful.Stateful):
                 break
 
         if not trial:
-            raise ValueError("Ongoing trial with id: {} not found.".format(trial_id))
+            raise ValueError(f"Ongoing trial with id: {trial_id} not found.")
 
         trial.status = status
         if status == trial_lib.TrialStatus.COMPLETED:
@@ -283,8 +283,7 @@ class Oracle(stateful.Stateful):
 
         if new_hps and not self.allow_new_entries:
             raise RuntimeError(
-                "`allow_new_entries` is `False`, but found "
-                "new entries {}".format(new_hps)
+                f"`allow_new_entries` is `False`, but found new entries {new_hps}"
             )
         if not self.tune_new_entries:
             # New entries should always use the default value.
@@ -351,9 +350,7 @@ class Oracle(stateful.Stateful):
         self._project_name = project_name
         if not overwrite and tf.io.gfile.exists(self._get_oracle_fname()):
             tf.get_logger().info(
-                "Reloading Oracle from existing project {}".format(
-                    self._get_oracle_fname()
-                )
+                f"Reloading Oracle from existing project {self._get_oracle_fname()}"
             )
             self.reload()
 

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -52,7 +52,7 @@ class Trial(stateful.Stateful):
         self.display_hyperparameters()
 
         if self.score is not None:
-            print("Score: {}".format(self.score))
+            print(f"Score: {self.score}")
 
     def display_hyperparameters(self):
         if self.hyperparameters.values:
@@ -142,7 +142,7 @@ def _convert_trial_status_to_proto(status):
     elif status == TrialStatus.COMPLETED:
         return ts.COMPLETED
     else:
-        raise ValueError("Unknown status {}".format(status))
+        raise ValueError(f"Unknown status {status}")
 
 
 def _convert_trial_status_to_str(status):
@@ -160,4 +160,4 @@ def _convert_trial_status_to_str(status):
     elif status == ts.COMPLETED:
         return TrialStatus.COMPLETED
     else:
-        raise ValueError("Unknown status {}".format(status))
+        raise ValueError(f"Unknown status {status}")

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -160,7 +160,7 @@ class Tuner(base_tuner.BaseTuner):
                 if config_module.DEBUG:
                     traceback.print_exc()
 
-                print("Invalid model %s/%s" % (i, MAX_FAIL_STREAK))
+                print(f"Invalid model {i}/{MAX_FAIL_STREAK}")
 
                 if i == MAX_FAIL_STREAK:
                     raise RuntimeError("Too many failed attempts to build model.")
@@ -176,7 +176,7 @@ class Tuner(base_tuner.BaseTuner):
             # Check model size.
             size = maybe_compute_model_size(model)
             if self.max_model_size and size > self.max_model_size:
-                print("Oversized model: {} parameters -- skipping".format(size))
+                print(f"Oversized model: {size} parameters -- skipping")
                 if i == MAX_FAIL_STREAK:
                     raise RuntimeError("Too many consecutive oversized models.")
                 continue

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -110,7 +110,7 @@ class Display(object):
 
             self.trial_number = int(trial.trial_id) + 1
             print()
-            print("Search: Running Trial #{}".format(self.trial_number))
+            print(f"Search: Running Trial #{self.trial_number}")
             print()
 
             self.trial_start = datetime.now()
@@ -126,18 +126,18 @@ class Display(object):
         utils.try_clear()
 
         time_taken_str = self.format_duration(datetime.now() - self.trial_start)
-        print("Trial {} Complete [{}]".format(self.trial_number, time_taken_str))
+        print(f"Trial {self.trial_number} Complete [{time_taken_str}]")
 
         if trial.score is not None:
-            print("{}: {}".format(self.oracle.objective.name, trial.score))
+            print(f"{self.oracle.objective.name}: {trial.score}")
 
         print()
         best_trials = self.oracle.get_best_trials()
         best_score = best_trials[0].score if len(best_trials) > 0 else None
-        print("Best {} So Far: {}".format(self.oracle.objective.name, best_score))
+        print(f"Best {self.oracle.objective.name} So Far: {best_score}")
 
         time_elapsed_str = self.format_duration(datetime.now() - self.search_start)
-        print("Total elapsed time: {}".format(time_elapsed_str))
+        print(f"Total elapsed time: {time_elapsed_str}")
 
     def show_hyperparameter_table(self, trial):
         template = "{{0:{0}}}|{{1:{0}}}|{{2}}".format(self.col_width)
@@ -165,7 +165,7 @@ class Display(object):
 
     def format_value(self, val):
         if isinstance(val, (int, float)) and not isinstance(val, bool):
-            return "{:.5g}".format(val)
+            return f"{val:.5g}"
         val_str = str(val)
         if len(val_str) > self.col_width:
             val_str = val_str[: self.col_width - 3] + "..."
@@ -181,8 +181,8 @@ class Display(object):
         s %= 60
 
         if d > 0:
-            return "{:d}d {:02d}h {:02d}m {:02d}s".format(d, h, m, s)
-        return "{:02d}h {:02d}m {:02d}s".format(h, m, s)
+            return f"{d:d}d {h:02d}h {m:02d}m {s:02d}s"
+        return f"{h:02d}h {m:02d}m {s:02d}s"
 
 
 class SaveBestEpoch(keras.callbacks.Callback):
@@ -379,7 +379,7 @@ def convert_hyperparams_to_hparams(hyperparams):
         elif isinstance(hp, hp_module.Fixed):
             hparams_domain = hparams_api.Discrete([hp.value])
         else:
-            raise ValueError("`HyperParameter` type not recognized: {}".format(hp))
+            raise ValueError(f"`HyperParameter` type not recognized: {hp}")
 
         hparams_key = hparams_api.HParam(hp.name, hparams_domain)
         hparams[hparams_key] = hparams_value

--- a/keras_tuner/test_utils/mock_distribute.py
+++ b/keras_tuner/test_utils/mock_distribute.py
@@ -87,7 +87,7 @@ def mock_distribute(fn, num_workers=2):
                 os.environ["KERASTUNER_ORACLE_PORT"] = port
                 # Workers that are part of the same multi-worker
                 # DistributionStrategy should have the same TUNER_ID.
-                os.environ["KERASTUNER_TUNER_ID"] = "worker{}".format(i)
+                os.environ["KERASTUNER_TUNER_ID"] = f"worker{i}"
                 fn()
 
             worker_thread = ExceptionStoringThread(target=worker_fn)


### PR DESCRIPTION
Hi,

Similar to https://github.com/keras-team/keras/pull/16872 I want to propose to standardize the f-string usage of the whole codebase. I have formated it with [flynt](https://github.com/ikamensh/flynt). Considering the comment from @fchollet on the linked PR, I have not added `flynt` neither to the `shell/format` nor `shell/lint`. The reformatting was all made by flynt. I am not using flynt's --aggressive to avoid "conversions with potentially changed behavior".