### PR TITLE
Improve `Int` and `Float` functionality, docstirngs and code structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cov.xml
 *.swp
 .idea
 *.pyc

--- a/keras_tuner/engine/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters.py
@@ -415,7 +415,7 @@ class Int(Numerical):
             # prob is in range [0.0, 1.0), use max_value + 1 so that
             # max_value may be sampled.
             return int(self._sample_numerical_value(prob, self.max_value + 1))
-        return self._sample_with_step(prob)
+        return int(self._sample_with_step(prob))
 
     def value_to_prob(self, value):
         if self.step is None:

--- a/keras_tuner/engine/hyperparameters_test.py
+++ b/keras_tuner/engine/hyperparameters_test.py
@@ -293,13 +293,13 @@ def test_sampling_arg():
 
     with pytest.raises(
         ValueError,
-        match="`sampling` `min_value` 1 is greater than the `max_value` 0",
+        match="`min_value` 1 is greater than the `max_value` 0",
     ):
         hp_module.Int("k", 1, 0, sampling="linear")
 
     with pytest.raises(
         ValueError,
-        match="`sampling` `min_value` 1 is greater than the `max_value` 0",
+        match="`min_value` 1 is greater than the `max_value` 0",
     ):
         hp_module.Int("k", 1, 0, sampling="linear")
 
@@ -310,8 +310,8 @@ def test_sampling_zero_length_intervals():
     assert rand_sample == 2
 
     val = 2
-    prob = hp_module.value_to_cumulative_prob(val, f)
-    assert prob == 1
+    prob = f.value_to_prob(val)
+    assert prob == 0.5
 
 
 def test_log_sampling_random_state():
@@ -321,21 +321,21 @@ def test_log_sampling_random_state():
     assert rand_sample <= f.max_value
 
     val = 1e-3
-    prob = hp_module.value_to_cumulative_prob(val, f)
+    prob = f.value_to_prob(val)
     assert prob == 0
-    new_val = hp_module.cumulative_prob_to_value(prob, f)
+    new_val = f.prob_to_value(prob)
     assert np.isclose(val, new_val)
 
     val = 1
-    prob = hp_module.value_to_cumulative_prob(val, f)
+    prob = f.value_to_prob(val)
     assert prob == 0.5
-    new_val = hp_module.cumulative_prob_to_value(prob, f)
+    new_val = f.prob_to_value(prob)
     assert np.isclose(val, new_val)
 
     val = 1e3
-    prob = hp_module.value_to_cumulative_prob(val, f)
+    prob = f.value_to_prob(val)
     assert prob == 1
-    new_val = hp_module.cumulative_prob_to_value(prob, f)
+    new_val = f.prob_to_value(prob)
     assert np.isclose(val, new_val)
 
 
@@ -346,15 +346,15 @@ def test_reverse_log_sampling_random_state():
     assert rand_sample <= f.max_value
 
     val = 1e-3
-    prob = hp_module.value_to_cumulative_prob(val, f)
+    prob = f.value_to_prob(val)
     assert prob == 0
-    new_val = hp_module.cumulative_prob_to_value(prob, f)
+    new_val = f.prob_to_value(prob)
     assert np.isclose(val, new_val)
 
     val = 1
-    prob = hp_module.value_to_cumulative_prob(val, f)
+    prob = f.value_to_prob(val)
     assert prob > 0 and prob < 1
-    new_val = hp_module.cumulative_prob_to_value(prob, f)
+    new_val = f.prob_to_value(prob)
     assert np.isclose(val, new_val)
 
 
@@ -469,7 +469,7 @@ def test_int_proto():
     assert proto.sampling == keras_tuner_pb2.Sampling.LOG
     # Proto stores the implicit default.
     assert proto.default == 1
-    assert proto.step == 1
+    assert proto.step == 0
 
     new_hp = hp_module.Int.from_proto(proto)
     assert new_hp._default == 1
@@ -568,10 +568,10 @@ def test_dict_methods():
 def test_prob_one_choice():
     hp = hp_module.Choice("a", [0, 1, 2])
     # Check that boundaries are valid.
-    value = hp_module.cumulative_prob_to_value(1, hp)
+    value = hp.prob_to_value(1)
     assert value == 2
 
-    value = hp_module.cumulative_prob_to_value(0, hp)
+    value = hp.prob_to_value(0)
     assert value == 0
 
 

--- a/keras_tuner/engine/hyperparameters_test.py
+++ b/keras_tuner/engine/hyperparameters_test.py
@@ -279,6 +279,16 @@ def test_Float():
     assert linear.default == 0.5
 
 
+def test_float_log_with_step():
+    rg = hp_module.Float(
+        "rg", min_value=0.01, max_value=100, step=10, sampling="log"
+    )
+    for i in range(10):
+        assert rg.random_sample() in [0.01, 0.1, 1.0, 10.0, 100.0]
+    assert abs(rg.value_to_prob(0.1) - 0.3) < 1e-4
+    assert rg.prob_to_value(0.3) == 0.1
+
+
 def test_sampling_arg():
     f = hp_module.Float("f", 1e-20, 1e10, sampling="log")
     f = hp_module.Float.from_config(f.get_config())
@@ -368,6 +378,14 @@ def test_Int():
     # No default
     rg = hp_module.Int("rg", min_value=5, max_value=9, step=1)
     assert rg.default == 5
+
+
+def test_int_log_with_step():
+    rg = hp_module.Int("rg", min_value=2, max_value=32, step=2, sampling="log")
+    for i in range(10):
+        assert rg.random_sample() in [2, 4, 8, 16, 32]
+    assert abs(rg.value_to_prob(4) - 0.3) < 1e-4
+    assert rg.prob_to_value(0.3) == 4
 
 
 def test_Boolean():

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -322,7 +322,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                     trial_value = hp.default
 
                 # Embed an HP value into the continuous space [0, 1].
-                prob = hp_module.value_to_cumulative_prob(trial_value, hp)
+                prob = hp.value_to_prob(trial_value)
                 vector.append(prob)
 
             if trial in ongoing_trials and self.gpr.can_predict():
@@ -358,7 +358,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
             else:
                 prob = vector[vector_index]
                 vector_index += 1
-                value = hp_module.cumulative_prob_to_value(prob, hp)
+                value = hp.prob_to_value(prob)
 
             if hps.is_active(hp):
                 hps.values[hp.name] = value

--- a/shell/coverage.sh
+++ b/shell/coverage.sh
@@ -1,0 +1,1 @@
+pytest --cov-report xml:cov.xml --cov keras_tuner $1


### PR DESCRIPTION
Here is a list of changes in this PR:
* Supported new use case for `Int` and `Float` for specifying `step` and `sampling="log"` the same time. The `step` value will be multiplied to `min_value` to generate samples until reaching `max_value`.
* Improved docstring for `Int` and `Float` for using `step` and `sampling`, especially for `sampling="log"`.
* Refactored conversion between cumulative probability and hp value from procedural style to OOP style. Now, one can use `hp.value_to_prob()` and `hp.prob_to_value()` to do the conversion. See usages in changes in `bayesian.py`.
* Extracted a super class, named `Numerical`, for `Int` and `Float` extending `HyperParameter`, which contains the code for conversion between cumulative probability and numerical values.

Resolves #715
Resolves #716