### PR TITLE
fix: :recycle: Removed pytest skipif for python=2.7

### DIFF
--- a/keras_tuner/distribute/oracle_chief_test.py
+++ b/keras_tuner/distribute/oracle_chief_test.py
@@ -14,9 +14,6 @@
 """Tests for the OracleServicer class."""
 
 import os
-import sys
-
-import pytest
 
 import keras_tuner
 from keras_tuner.distribute import oracle_chief
@@ -99,7 +96,6 @@ def test_create_trial(tmp_path):
     mock_distribute.mock_distribute(_test_create_trial)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_update_trial(tmp_path):
     def _test_update_trial():
         hps = keras_tuner.HyperParameters()
@@ -127,7 +123,6 @@ def test_update_trial(tmp_path):
     mock_distribute.mock_distribute(_test_update_trial)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_end_trial(tmp_path):
     def _test_end_trial():
         hps = keras_tuner.HyperParameters()

--- a/keras_tuner/test_utils/mock_distribute_test.py
+++ b/keras_tuner/test_utils/mock_distribute_test.py
@@ -14,7 +14,6 @@
 """Test mock running KerasTuner in a distributed tuning setting."""
 
 import os
-import sys
 import time
 
 import pytest
@@ -23,7 +22,6 @@ import tensorflow as tf
 from keras_tuner.test_utils import mock_distribute
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_mock_distribute(tmp_path):
     def process_fn():
         assert "KERASTUNER_ORACLE_IP" in os.environ

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import logging
-import sys
 
 import numpy as np
-import pytest
 import tensorflow as tf
 
 import keras_tuner
@@ -61,7 +59,6 @@ def test_hyperband_oracle_bracket_configs(tmp_path):
     assert oracle._get_epochs(bracket_num=0, round_num=0) == 8
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_hyperband_oracle_one_sweep_single_thread(tmp_path):
     hp = keras_tuner.HyperParameters()
     hp.Float("a", -100, 100)
@@ -167,7 +164,6 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
     assert t.status == "STOPPED", oracle._current_sweep
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_hyperband_integration(tmp_path):
     tuner = hyperband_module.Hyperband(
         objective="val_loss",
@@ -193,7 +189,6 @@ def test_hyperband_integration(tmp_path):
     assert best_model.evaluate(x, y) == best_score
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")
 def test_hyperband_save_and_restore(tmp_path):
     tuner = hyperband_module.Hyperband(
         objective="val_loss",


### PR DESCRIPTION
Removed `@pytest.mark.skipif(sys.version_info < (3, 0), reason="TODO: Enable test for Py2")`

Fixes #755