### PR TITLE
add tensorflow as a dependency

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,7 +30,6 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
-          pip install tensorflow
           pip install -e ".[tests]" --progress-bar off --upgrade
       - name: Test with pytest
         run: |
@@ -92,7 +91,6 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Install dependencies
         run: |
-          pip install tensorflow
           pip install -e ".[tests]" --progress-bar off --upgrade
       - name: Lint
         run: bash shell/lint.sh

--- a/setup.py
+++ b/setup.py
@@ -24,14 +24,10 @@ setup(
     author="The KerasTuner authors",
     author_email="kerastuner@google.com",
     license="Apache License 2.0",
-    # tensorflow isn't a dependency because it would force the
-    # download of the gpu version or the cpu version.
-    # users should install it manually.
     install_requires=[
         "packaging",
-        "numpy",
+        "tensorflow>=2.0",
         "requests",
-        "tensorboard",
         "ipython",
         "kt-legacy",
     ],


### PR DESCRIPTION
KerasTuner cannot be imported without TensorFlow installed. So adding
TensorFlow as a dependency. The reason why it was not added earlier is that we
want the user to choose between tensorflow-cpu and tensorflow-gpu, which is no
longer a problem.