### PR TITLE
revise error message for better upgrading

### DIFF
--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -1106,7 +1106,10 @@ def test_run_trial_return_none(tmp_path):
                 trial.trial_id, {"loss": min(history.history["loss"])}
             )
 
-    with pytest.raises(errors.FatalTypeError, match="return the metrics directly"):
+    with pytest.raises(
+        errors.FatalTypeError,
+        match="`self\.oracle\.update_trial\(trial_id, metrics\)`",
+    ):
         assert_found_best_score(tmp_path, MockHyperModel(), MyTuner)
 
 

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -301,9 +301,11 @@ def validate_trial_results(results, objective, func_name):
         )
         if func_name == "Tuner.run_trial()":
             error_message += (
-                "\nIf you are calling Oracle.update_trial() "
-                "in Tuner.run_trial() to report the metrics, "
-                "please remove the call and return the metrics directly."
+                "\nIf you are calling "
+                "`self.oracle.update_trial(trial_id, metrics)` "
+                "in `Tuner.run_trial()` to report the metrics, "
+                "please remove the call and `return metrics` "
+                "in `Tuner.run_trial()` instead."
             )
         raise errors.FatalTypeError(error_message)
 


### PR DESCRIPTION
Revised the error message for returning None in `Tuner.run_trial()`. It is now
more specific. It is easier for the user to upgrade their code to adapt to the
latest KerasTuner.