### PR TITLE
fix: 🚨Additional commits for issue #778

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -167,8 +167,8 @@ class HyperImageAugment(hypermodel.HyperModel):
                 and isinstance(augment_layers_max, int)
             ):
                 raise ValueError(
-                    "Keyword argument `augment_layers` must be int,"
-                    "but received {}. ".format(augment_layers)
+                    "Keyword argument `augment_layers` must be "
+                    f"int,but received {augment_layers}."
                 )
 
             self.augment_layers_min = augment_layers_min
@@ -270,8 +270,8 @@ class HyperImageAugment(hypermodel.HyperModel):
             and isinstance(transform_factor_min, (int, float))
         ):
             raise ValueError(
-                "Keyword argument {} must be int or float, "
-                "but received {}. ".format(transform_name, transform_params)
+                f"Keyword argument {transform_name} must be int "
+                f"or float, but received {transform_params}."
             )
 
         self.transforms.append(

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -98,8 +98,8 @@ class HyperEfficientNet(hypermodel.HyperModel):
         ):
             raise ValueError(
                 "Keyword augmentation_model should be "
-                "a `HyperModel`, a Keras `Model` or empty. "
-                "Received {}.".format(augmentation_model)
+                "a `HyperModel`, a Keras `Model` or "
+                f"empty. Received {augmentation_model}."
             )
 
         if not classes:

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -50,7 +50,7 @@ class HyperResNet(hypermodel.HyperModel):
         input_shape=None,
         input_tensor=None,
         classes=None,
-        **kwargs
+        **kwargs,
     ):
 
         super(HyperResNet, self).__init__(**kwargs)
@@ -166,33 +166,38 @@ def block1(x, filters, kernel_size=3, stride=1, conv_shortcut=True, name=None):
 
     if conv_shortcut is True:
         shortcut = layers.Conv2D(
-            4 * filters, 1, strides=stride, name=name + "_0_conv"
+            4 * filters, 1, strides=stride, name=f"{name}_0_conv"
         )(x)
+
         shortcut = layers.BatchNormalization(
-            axis=bn_axis, epsilon=1.001e-5, name=name + "_0_bn"
+            axis=bn_axis, epsilon=1.001e-5, name=f"{name}_0_bn"
         )(shortcut)
+
     else:
         shortcut = x
 
-    x = layers.Conv2D(filters, 1, strides=stride, name=name + "_1_conv")(x)
+    x = layers.Conv2D(filters, 1, strides=stride, name=f"{name}_1_conv")(x)
     x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_1_bn"
-    )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
-
-    x = layers.Conv2D(filters, kernel_size, padding="same", name=name + "_2_conv")(x)
-    x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_2_bn"
-    )(x)
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
-
-    x = layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
-    x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_3_bn"
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_1_bn"
     )(x)
 
-    x = layers.Add(name=name + "_add")([shortcut, x])
-    x = layers.Activation("relu", name=name + "_out")(x)
+    x = layers.Activation("relu", name=f"{name}_1_relu")(x)
+
+    x = layers.Conv2D(filters, kernel_size, padding="same", name=f"{name}_2_conv")(x)
+
+    x = layers.BatchNormalization(
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_2_bn"
+    )(x)
+
+    x = layers.Activation("relu", name=f"{name}_2_relu")(x)
+
+    x = layers.Conv2D(4 * filters, 1, name=f"{name}_3_conv")(x)
+    x = layers.BatchNormalization(
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_3_bn"
+    )(x)
+
+    x = layers.Add(name=f"{name}_add")([shortcut, x])
+    x = layers.Activation("relu", name=f"{name}_out")(x)
     return x
 
 
@@ -209,9 +214,9 @@ def stack1(x, filters, blocks, stride1=2, name=None):
     Returns:
         Output tensor for the stacked blocks.
     """
-    x = block1(x, filters, stride=stride1, name=name + "_block1")
+    x = block1(x, filters, stride=stride1, name=f"{name}_block1")
     for i in range(2, blocks + 1):
-        x = block1(x, filters, conv_shortcut=False, name=name + "_block" + str(i))
+        x = block1(x, filters, conv_shortcut=False, name=f"{name}_block{str(i)}")
     return x
 
 
@@ -233,36 +238,42 @@ def block2(x, filters, kernel_size=3, stride=1, conv_shortcut=False, name=None):
     bn_axis = 3 if backend.image_data_format() == "channels_last" else 1
 
     preact = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_preact_bn"
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_preact_bn"
     )(x)
-    preact = layers.Activation("relu", name=name + "_preact_relu")(preact)
+
+    preact = layers.Activation("relu", name=f"{name}_preact_relu")(preact)
 
     if conv_shortcut is True:
         shortcut = layers.Conv2D(
-            4 * filters, 1, strides=stride, name=name + "_0_conv"
+            4 * filters, 1, strides=stride, name=f"{name}_0_conv"
         )(preact)
+
     else:
         shortcut = layers.MaxPooling2D(1, strides=stride)(x) if stride > 1 else x
 
-    x = layers.Conv2D(filters, 1, strides=1, use_bias=False, name=name + "_1_conv")(
+    x = layers.Conv2D(filters, 1, strides=1, use_bias=False, name=f"{name}_1_conv")(
         preact
     )
-    x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_1_bn"
-    )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
 
-    x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=name + "_2_pad")(x)
+    x = layers.BatchNormalization(
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_1_bn"
+    )(x)
+
+    x = layers.Activation("relu", name=f"{name}_1_relu")(x)
+
+    x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=f"{name}_2_pad")(x)
     x = layers.Conv2D(
-        filters, kernel_size, strides=stride, use_bias=False, name=name + "_2_conv"
+        filters, kernel_size, strides=stride, use_bias=False, name=f"{name}_2_conv"
     )(x)
-    x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_2_bn"
-    )(x)
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
 
-    x = layers.Conv2D(4 * filters, 1, name=name + "_3_conv")(x)
-    x = layers.Add(name=name + "_out")([shortcut, x])
+    x = layers.BatchNormalization(
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_2_bn"
+    )(x)
+
+    x = layers.Activation("relu", name=f"{name}_2_relu")(x)
+
+    x = layers.Conv2D(4 * filters, 1, name=f"{name}_3_conv")(x)
+    x = layers.Add(name=f"{name}_out")([shortcut, x])
     return x
 
 
@@ -279,10 +290,10 @@ def stack2(x, filters, blocks, stride1=2, name=None):
     Returns:
         Output tensor for the stacked blocks.
     """
-    x = block2(x, filters, conv_shortcut=True, name=name + "_block1")
+    x = block2(x, filters, conv_shortcut=True, name=f"{name}_block1")
     for i in range(2, blocks):
-        x = block2(x, filters, name=name + "_block" + str(i))
-    x = block2(x, filters, stride=stride1, name=name + "_block" + str(blocks))
+        x = block2(x, filters, name=f"{name}_block{str(i)}")
+    x = block2(x, filters, stride=stride1, name=f"{name}_block{str(blocks)}")
     return x
 
 
@@ -312,29 +323,33 @@ def block3(
             1,
             strides=stride,
             use_bias=False,
-            name=name + "_0_conv",
+            name=f"{name}_0_conv",
         )(x)
+
         shortcut = layers.BatchNormalization(
-            axis=bn_axis, epsilon=1.001e-5, name=name + "_0_bn"
+            axis=bn_axis, epsilon=1.001e-5, name=f"{name}_0_bn"
         )(shortcut)
+
     else:
         shortcut = x
 
-    x = layers.Conv2D(filters, 1, use_bias=False, name=name + "_1_conv")(x)
+    x = layers.Conv2D(filters, 1, use_bias=False, name=f"{name}_1_conv")(x)
     x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_1_bn"
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_1_bn"
     )(x)
-    x = layers.Activation("relu", name=name + "_1_relu")(x)
+
+    x = layers.Activation("relu", name=f"{name}_1_relu")(x)
 
     c = filters // groups
-    x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=name + "_2_pad")(x)
+    x = layers.ZeroPadding2D(padding=((1, 1), (1, 1)), name=f"{name}_2_pad")(x)
     x = layers.DepthwiseConv2D(
         kernel_size,
         strides=stride,
         depth_multiplier=c,
         use_bias=False,
-        name=name + "_2_conv",
+        name=f"{name}_2_conv",
     )(x)
+
     x_shape = backend.int_shape(x)[1:-1]
     x = layers.Reshape(x_shape + (groups, c, c))(x)
     output_shape = x_shape + (groups, c) if backend.backend() == "theano" else None
@@ -342,27 +357,27 @@ def block3(
     x = layers.Lambda(
         lambda x: sum([x[:, :, :, :, i] for i in range(c)]),
         output_shape=output_shape,
-        name=name + "_2_reduce",
+        name=f"{name}_2_reduce",
     )(x)
 
     x = layers.Reshape(x_shape + (filters,))(x)
 
     x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_2_bn"
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_2_bn"
     )(x)
 
-    x = layers.Activation("relu", name=name + "_2_relu")(x)
+    x = layers.Activation("relu", name=f"{name}_2_relu")(x)
 
     x = layers.Conv2D(
-        (64 // groups) * filters, 1, use_bias=False, name=name + "_3_conv"
+        (64 // groups) * filters, 1, use_bias=False, name=f"{name}_3_conv"
     )(x)
 
     x = layers.BatchNormalization(
-        axis=bn_axis, epsilon=1.001e-5, name=name + "_3_bn"
+        axis=bn_axis, epsilon=1.001e-5, name=f"{name}_3_bn"
     )(x)
 
-    x = layers.Add(name=name + "_add")([shortcut, x])
-    x = layers.Activation("relu", name=name + "_out")(x)
+    x = layers.Add(name=f"{name}_add")([shortcut, x])
+    x = layers.Activation("relu", name=f"{name}_out")(x)
     return x
 
 
@@ -380,7 +395,7 @@ def stack3(x, filters, blocks, stride1=2, groups=32, name=None):
     Returns:
         Output tensor for the stacked blocks.
     """
-    x = block3(x, filters, stride=stride1, groups=groups, name=name + "_block1")
+    x = block3(x, filters, stride=stride1, groups=groups, name=f"{name}_block1")
 
     for i in range(2, blocks + 1):
         x = block3(
@@ -388,6 +403,7 @@ def stack3(x, filters, blocks, stride1=2, groups=32, name=None):
             filters,
             groups=groups,
             conv_shortcut=False,
-            name=name + "_block" + str(i),
+            name=f"{name}_block{str(i)}",
         )
+
     return x

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -355,7 +355,7 @@ def block3(
     output_shape = x_shape + (groups, c) if backend.backend() == "theano" else None
 
     x = layers.Lambda(
-        lambda x: sum([x[:, :, :, :, i] for i in range(c)]),
+        lambda x: sum(x[:, :, :, :, i] for i in range(c)),
         output_shape=output_shape,
         name=f"{name}_2_reduce",
     )(x)

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -73,8 +73,8 @@ class HyperResNet(hypermodel.HyperModel):
         conv4_depth = hp.Choice("conv4_depth", [6, 23, 36])
 
         # Version-conditional fixed parameters
-        preact = True if version == "v2" else False
-        use_bias = False if version == "next" else True
+        preact = bool(version == "v2")
+        use_bias = bool(version != "next")
 
         # Model definition.
         bn_axis = 3 if backend.image_data_format() == "channels_last" else 1

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -106,32 +106,31 @@ class HyperXception(hypermodel.HyperModel):
         else:
             x = layers.GlobalMaxPooling2D()(x)
 
-        if self.include_top:
-            # Dense
-            num_dense_layers = hp.Int("num_dense_layers", 1, 3)
-            dropout_rate = hp.Float("dropout_rate", 0.0, 0.6, step=0.1, default=0.5)
-            dense_use_bn = hp.Choice("dense_use_bn", [True, False])
-            for _ in range(num_dense_layers):
-                x = dense(
-                    x,
-                    self.classes,
-                    activation=activation,
-                    batchnorm=dense_use_bn,
-                    dropout_rate=dropout_rate,
-                )
-            output = layers.Dense(self.classes, activation="softmax")(x)
-            model = keras.Model(inputs, output, name="Xception")
-
-            model.compile(
-                optimizer=keras.optimizers.Adam(
-                    hp.Choice("learning_rate", [1e-3, 1e-4, 1e-5])
-                ),
-                loss="categorical_crossentropy",
-                metrics=["accuracy"],
-            )
-            return model
-        else:
+        if not self.include_top:
             return keras.Model(inputs, x, name="Xception")
+        # Dense
+        num_dense_layers = hp.Int("num_dense_layers", 1, 3)
+        dropout_rate = hp.Float("dropout_rate", 0.0, 0.6, step=0.1, default=0.5)
+        dense_use_bn = hp.Choice("dense_use_bn", [True, False])
+        for _ in range(num_dense_layers):
+            x = dense(
+                x,
+                self.classes,
+                activation=activation,
+                batchnorm=dense_use_bn,
+                dropout_rate=dropout_rate,
+            )
+        output = layers.Dense(self.classes, activation="softmax")(x)
+        model = keras.Model(inputs, output, name="Xception")
+
+        model.compile(
+            optimizer=keras.optimizers.Adam(
+                hp.Choice("learning_rate", [1e-3, 1e-4, 1e-5])
+            ),
+            loss="categorical_crossentropy",
+            metrics=["accuracy"],
+        )
+        return model
 
 
 def sep_conv(x, num_filters, kernel_size=(3, 3), activation="relu"):

--- a/keras_tuner/distribute/oracle_chief_test.py
+++ b/keras_tuner/distribute/oracle_chief_test.py
@@ -175,11 +175,5 @@ def test_get_best_trials(tmp_path):
                 client.end_trial(trial_id)
                 trial_scores[trial_id] = score
             return
-            best_trials = client.get_best_trials(3)
-            best_scores = [t.score for t in best_trials]
-            assert best_scores == [9, 8, 7]
-            # Check that trial_ids are correctly mapped to scores.
-            for t in best_trials:
-                assert trial_scores[t.trial_id] == t.score
 
     mock_distribute.mock_distribute(_test_get_best_trials, num_workers=1)

--- a/keras_tuner/distribute/oracle_chief_test.py
+++ b/keras_tuner/distribute/oracle_chief_test.py
@@ -174,5 +174,12 @@ def test_get_best_trials(tmp_path):
                 client.update_trial(trial_id, {"score": score})
                 client.end_trial(trial_id)
                 trial_scores[trial_id] = score
+            return
+            best_trials = client.get_best_trials(3)
+            best_scores = [t.score for t in best_trials]
+            assert best_scores == [9, 8, 7]
+            # Check that trial_ids are correctly mapped to scores.
+            for t in best_trials:
+                assert trial_scores[t.trial_id] == t.score
 
     mock_distribute.mock_distribute(_test_get_best_trials, num_workers=1)

--- a/keras_tuner/distribute/oracle_chief_test.py
+++ b/keras_tuner/distribute/oracle_chief_test.py
@@ -174,6 +174,5 @@ def test_get_best_trials(tmp_path):
                 client.update_trial(trial_id, {"score": score})
                 client.end_trial(trial_id)
                 trial_scores[trial_id] = score
-            return
 
     mock_distribute.mock_distribute(_test_get_best_trials, num_workers=1)

--- a/keras_tuner/distribute/utils.py
+++ b/keras_tuner/distribute/utils.py
@@ -87,7 +87,7 @@ Experimental. API is subject to change.
 
 def _get_base_dirpath(strategy):
     task_id = strategy.extended._task_id  # pylint: disable=protected-access
-    return "workertemp_" + str(task_id)
+    return f"workertemp_{str(task_id)}"
 
 
 def _is_temp_dir(dirpath, strategy):

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -420,9 +420,9 @@ class BaseTuner(stateful.Stateful):
         return dirname
 
     def get_trial_dir(self, trial_id):
-        dirname = os.path.join(str(self.project_dir), "trial_" + str(trial_id))
+        dirname = os.path.join(str(self.project_dir), f"trial_{str(trial_id)}")
         utils.create_directory(dirname)
         return dirname
 
     def _get_tuner_fname(self):
-        return os.path.join(str(self.project_dir), str(self.tuner_id) + ".json")
+        return os.path.join(str(self.project_dir), f"{str(self.tuner_id)}.json")

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -166,7 +166,7 @@ class BaseTuner(stateful.Stateful):
                         scopes_never_active.append(copy.deepcopy(conditions))
 
                 # All conditional scopes are activated.
-                if len(scopes_never_active) == 0:
+                if not scopes_never_active:
                     break
 
                 # Generate new values to activate new conditions.

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -60,7 +60,7 @@ class Condition(object):
         return cls(**config)  # pytype: disable=not-instantiable
 
     @classmethod
-    def from_proto(self, proto):
+    def from_proto(cls, proto):
         kind = proto.WhichOneof("kind")
         if kind == "parent":
             parent = getattr(proto, kind)

--- a/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
@@ -46,9 +46,7 @@ class Boolean(hyperparameter.HyperParameter):
 
     def value_to_prob(self, value):
         # Center the value in its probability bucket.
-        if value:
-            return 0.75
-        return 0.25
+        return 0.75 if value else 0.25
 
     @classmethod
     def from_proto(cls, proto):

--- a/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
@@ -46,8 +46,8 @@ class Choice(hyperparameter.HyperParameter):
         types = {type(v) for v in values}
         if len(types) > 1:
             raise TypeError(
-                "A `Choice` can contain only one type of value, found "
-                f"values: {str(values)} with types {str(types)}."
+                "A `Choice` can contain only one type of value, "
+                f"found values: {str(values)} with types {types}."
             )
 
         # Standardize on str, int, float, bool.
@@ -95,9 +95,7 @@ class Choice(hyperparameter.HyperParameter):
 
     @property
     def default(self):
-        if self._default is None:
-            return self._values[0]
-        return self._default
+        return self._values[0] if self._default is None else self._default
 
     def prob_to_value(self, prob):
         return self._values[hp_utils.prob_to_index(prob, len(self._values))]

--- a/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
@@ -43,7 +43,7 @@ class Choice(hyperparameter.HyperParameter):
             raise ValueError("`values` must be provided for `Choice`.")
 
         # Type checking.
-        types = set(type(v) for v in values)
+        types = {type(v) for v in values}
         if len(types) > 1:
             raise TypeError(
                 "A `Choice` can contain only one type of value, found "

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
@@ -112,9 +112,7 @@ class Float(numerical.Numerical):
 
     @property
     def default(self):
-        if self._default is not None:
-            return self._default
-        return self.min_value
+        return self._default if self._default is not None else self.min_value
 
     def prob_to_value(self, prob):
         if self.step is None:
@@ -143,7 +141,7 @@ class Float(numerical.Numerical):
             name=proto.name,
             min_value=proto.min_value,
             max_value=proto.max_value,
-            step=proto.step if proto.step else None,
+            step=proto.step or None,
             sampling=hp_utils.sampling_from_proto(proto.sampling),
             default=proto.default,
             conditions=conditions,

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
@@ -105,15 +105,9 @@ class Float(numerical.Numerical):
 
     def __repr__(self):
         return (
-            'Float(name: "{}", min_value: {}, max_value: {}, step: {}, '
-            "sampling: {}, default: {})"
-        ).format(
-            self.name,
-            self.min_value,
-            self.max_value,
-            self.step,
-            self.sampling,
-            self.default,
+            f"Float(name: '{self.name}', min_value: '{self.min_value}', "
+            f"max_value: '{self.max_value}', step: '{self.step}', "
+            f"sampling: '{self.sampling}', default: '{self.default}')"
         )
 
     @property

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp_test.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp_test.py
@@ -52,7 +52,7 @@ def test_float_log_with_step():
     rg = hp_module.Float(
         "rg", min_value=0.01, max_value=100, step=10, sampling="log"
     )
-    for i in range(10):
+    for _ in range(10):
         assert rg.random_sample() in [0.01, 0.1, 1.0, 10.0, 100.0]
     assert abs(rg.value_to_prob(0.1) - 0.3) < 1e-4
     assert rg.prob_to_value(0.3) == 0.1
@@ -62,7 +62,7 @@ def test_float_reverse_log_with_step():
     rg = hp_module.Float(
         "rg", min_value=0.01, max_value=100, step=10, sampling="reverse_log"
     )
-    for i in range(10):
+    for _ in range(10):
         # print(rg.random_sample())
         # assert rg.random_sample() in [0.01, 0.1, 1.0, 10.0, 100.0]
         # [0.09, 0.9, 9, 90]

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp_test.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp_test.py
@@ -69,7 +69,7 @@ def test_float_reverse_log_with_step():
         # [90, 9, 0.9, 0.09]
         sample = rg.random_sample()
         assert any(
-            [abs(sample - x) < 1e-4 for x in [0.01, 90.01, 99.01, 99.91, 100.0]]
+            abs(sample - x) < 1e-4 for x in [0.01, 90.01, 99.01, 99.91, 100.0]
         )
     assert abs(rg.value_to_prob(99.91) - 0.3) < 1e-4
     assert abs(rg.prob_to_value(0.3) - 99.91) < 1e-4

--- a/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
@@ -144,9 +144,7 @@ class Int(numerical.Numerical):
 
     @property
     def default(self):
-        if self._default is not None:
-            return self._default
-        return self.min_value
+        return self._default if self._default is not None else self.min_value
 
     def get_config(self):
         config = super(Int, self).get_config()
@@ -166,7 +164,7 @@ class Int(numerical.Numerical):
             name=proto.name,
             min_value=proto.min_value,
             max_value=proto.max_value,
-            step=proto.step if proto.step else None,
+            step=proto.step or None,
             sampling=hp_utils.sampling_from_proto(proto.sampling),
             default=proto.default,
             conditions=conditions,

--- a/keras_tuner/engine/hyperparameters/hp_types/int_hp_test.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/int_hp_test.py
@@ -67,7 +67,7 @@ def test_int():
 
 def test_int_log_with_step():
     rg = hp_module.Int("rg", min_value=2, max_value=32, step=2, sampling="log")
-    for i in range(10):
+    for _ in range(10):
         assert rg.random_sample() in [2, 4, 8, 16, 32]
     assert abs(rg.value_to_prob(4) - 0.3) < 1e-4
     assert rg.prob_to_value(0.3) == 4

--- a/keras_tuner/engine/hyperparameters/hp_types/numerical.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/numerical.py
@@ -147,7 +147,7 @@ class Numerical(hyperparameter.HyperParameter):
     def values(self):
         if self.step is None:
             # Evenly select 10 samples as the values.
-            return tuple(set(self.prob_to_value(i * 0.1 + 0.05) for i in range(10)))
+            return tuple({self.prob_to_value(i * 0.1 + 0.05) for i in range(10)})
         n_values = self._get_n_values()
         return (self._get_value_by_index(i) for i in range(n_values))
 

--- a/keras_tuner/engine/hyperparameters/hp_types/numerical.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/numerical.py
@@ -55,9 +55,10 @@ class Numerical(hyperparameter.HyperParameter):
         if self.sampling not in sampling_values:
             raise ValueError(
                 f"For HyperParameters.{self.__class__.__name__}"
-                f"(name='{self.name}'), "
-                f"sampling must be one of {str(sampling_values)}"
+                f"(name='{self.name}'), sampling must be one "
+                f"of {sampling_values}"
             )
+
         if self.sampling in {"log", "reverse_log"} and self.min_value <= 0:
             raise ValueError(
                 f"For HyperParameters.{self.__class__.__name__}"

--- a/keras_tuner/engine/hyperparameters/hp_utils.py
+++ b/keras_tuner/engine/hyperparameters/hp_utils.py
@@ -49,7 +49,7 @@ def prob_to_index(prob, n_index):
     index = int(math.floor(prob / ele_prob))
     # Can happen when `prob` is very close to 1.
     if index == n_index:
-        index = index - 1
+        index -= 1
     return index
 
 

--- a/keras_tuner/engine/hyperparameters/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameters.py
@@ -583,21 +583,36 @@ class HyperParameters(object):
         space = []
         if isinstance(proto, keras_tuner_pb2.HyperParameters.Values):
             # Allows passing in only values, space becomes `Fixed`.
-            for name, value in proto.values.items():
-                space.append(
-                    hp_types.Fixed(name, getattr(value, value.WhichOneof("kind")))
-                )
+            space.extend(
+                hp_types.Fixed(name, getattr(value, value.WhichOneof("kind")))
+                for name, value in proto.values.items()
+            )
+
         else:
-            for fixed_proto in proto.space.fixed_space:
-                space.append(hp_types.Fixed.from_proto(fixed_proto))
-            for float_proto in proto.space.float_space:
-                space.append(hp_types.Float.from_proto(float_proto))
-            for int_proto in proto.space.int_space:
-                space.append(hp_types.Int.from_proto(int_proto))
-            for choice_proto in proto.space.choice_space:
-                space.append(hp_types.Choice.from_proto(choice_proto))
-            for boolean_proto in proto.space.boolean_space:
-                space.append(hp_types.Boolean.from_proto(boolean_proto))
+            space.extend(
+                hp_types.Fixed.from_proto(fixed_proto)
+                for fixed_proto in proto.space.fixed_space
+            )
+
+            space.extend(
+                hp_types.Float.from_proto(float_proto)
+                for float_proto in proto.space.float_space
+            )
+
+            space.extend(
+                hp_types.Int.from_proto(int_proto)
+                for int_proto in proto.space.int_space
+            )
+
+            space.extend(
+                hp_types.Choice.from_proto(choice_proto)
+                for choice_proto in proto.space.choice_space
+            )
+
+            space.extend(
+                hp_types.Boolean.from_proto(boolean_proto)
+                for boolean_proto in proto.space.boolean_space
+            )
 
         hps.merge(space)
 

--- a/keras_tuner/engine/hyperparameters/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameters.py
@@ -542,7 +542,7 @@ class HyperParameters(object):
                 {"class_name": p.__class__.__name__, "config": p.get_config()}
                 for p in self.space
             ],
-            "values": dict((k, v) for (k, v) in self.values.items()),
+            "values": {k: v for (k, v) in self.values.items()},
         }
 
     @classmethod
@@ -552,7 +552,7 @@ class HyperParameters(object):
             p = hp_types.deserialize(p)
             hps._hps[p.name].append(p)
             hps._space.append(p)
-        hps.values = dict((k, v) for (k, v) in config["values"].items())
+        hps.values = {k: v for (k, v) in config["values"].items()}
         return hps
 
     def copy(self):

--- a/keras_tuner/engine/logger_test.py
+++ b/keras_tuner/engine/logger_test.py
@@ -90,8 +90,5 @@ def test_cloud_logger(tmp_path):
         ("register_trial", 6),
     ]
     for key, count in keys:
-        actual_count = 0
-        for url in MOCK_POST.url_calls:
-            if key in url:
-                actual_count += 1
+        actual_count = sum(key in url for url in MOCK_POST.url_calls)
         assert count == actual_count

--- a/keras_tuner/engine/logger_test.py
+++ b/keras_tuner/engine/logger_test.py
@@ -49,8 +49,9 @@ def build_model(hp):
     x = inputs
     for i in range(hp.Int("num_layers", 1, 4)):
         x = keras.layers.Dense(
-            units=hp.Int("units_" + str(i), 5, 9, 1, default=6), activation="relu"
+            units=hp.Int(f"units_{str(i)}", 5, 9, 1, default=6), activation="relu"
         )(x)
+
     outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
     model = keras.Model(inputs, outputs)
     model.compile(

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -56,9 +56,11 @@ class MetricObservation(object):
         return cls(**config)
 
     def __eq__(self, other):
-        if not isinstance(other, MetricObservation):
-            return False
-        return other.value == self.value and other.step == self.step
+        return (
+            other.value == self.value and other.step == self.step
+            if isinstance(other, MetricObservation)
+            else False
+        )
 
     def __repr__(self):
         return f"MetricObservation(value={self.value}, step={self.step})"
@@ -101,9 +103,7 @@ class MetricHistory(object):
         values = [obs.mean() for obs in self._observations.values()]
         if not values:
             return None
-        if self.direction == "min":
-            return np.nanmin(values)
-        return np.nanmax(values)
+        return np.nanmin(values) if self.direction == "min" else np.nanmax(values)
 
     def get_best_step(self):
         best_value = self.get_best_value()
@@ -123,16 +123,18 @@ class MetricHistory(object):
     def get_statistics(self):
         history = self.get_history()
         history_values = [obs.mean() for obs in history]
-        if not len(history_values):
-            return {}
-        return {
-            "min": float(np.nanmin(history_values)),
-            "max": float(np.nanmax(history_values)),
-            "mean": float(np.nanmean(history_values)),
-            "median": float(np.nanmedian(history_values)),
-            "var": float(np.nanvar(history_values)),
-            "std": float(np.nanstd(history_values)),
-        }
+        return (
+            {
+                "min": float(np.nanmin(history_values)),
+                "max": float(np.nanmax(history_values)),
+                "mean": float(np.nanmean(history_values)),
+                "median": float(np.nanmedian(history_values)),
+                "var": float(np.nanvar(history_values)),
+                "std": float(np.nanstd(history_values)),
+            }
+            if len(history_values)
+            else {}
+        )
 
     def get_last_value(self):
         history = self.get_history()
@@ -143,9 +145,11 @@ class MetricHistory(object):
             return None
 
     def get_config(self):
-        config = {}
-        config["direction"] = self.direction
-        config["observations"] = [obs.get_config() for obs in self.get_history()]
+        config = {
+            "direction": self.direction,
+            "observations": [obs.get_config() for obs in self.get_history()],
+        }
+
         return config
 
     @classmethod
@@ -332,7 +336,7 @@ def infer_metric_direction(metric):
         except ValueError:
             try:
                 metric = keras.losses.get(metric_name)
-            except:
+            except Exception:
                 # Direction can't be inferred.
                 return None
 

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -98,7 +98,7 @@ class MetricHistory(object):
             self._observations[step] = MetricObservation(value, step=step)
 
     def get_best_value(self):
-        values = list(obs.mean() for obs in self._observations.values())
+        values = [obs.mean() for obs in self._observations.values()]
         if not values:
             return None
         if self.direction == "min":

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -126,7 +126,7 @@ def create_objective(objective):
     if not isinstance(objective, str):
         raise ValueError(
             "`objective` not understood, expected str or "
-            "`Objective` object, found: {}".format(objective)
+            f"`Objective` object, found: {objective}"
         )
 
     direction = metrics_tracking.infer_metric_direction(objective)

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -95,7 +95,7 @@ class MultiObjective(Objective):
         }
 
     def has_value(self, logs):
-        return all([key in logs for key in self.name_to_direction])
+        return all(key in logs for key in self.name_to_direction)
 
     def get_value(self, logs):
         obj_value = 0

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -404,20 +404,18 @@ class Oracle(stateful.Stateful):
     def get_state(self):
         # `self.trials` are saved in their own, Oracle-agnostic files.
         # Just save the IDs for ongoing trials, since these are in `trials`.
-        state = {
+        return {
             "ongoing_trials": {
                 tuner_id: trial.trial_id
                 for tuner_id, trial in self.ongoing_trials.items()
-            }
+            },
+            # Hyperparameters are part of the state because they can be added to
+            # during the course of the search.
+            "hyperparameters": self.hyperparameters.get_config(),
+            "seed": self.seed,
+            "seed_state": self._seed_state,
+            "tried_so_far": list(self._tried_so_far),
         }
-
-        # Hyperparameters are part of the state because they can be added to
-        # during the course of the search.
-        state["hyperparameters"] = self.hyperparameters.get_config()
-        state["seed"] = self.seed
-        state["seed_state"] = self._seed_state
-        state["tried_so_far"] = list(self._tried_so_far)
-        return state
 
     def set_state(self, state):
         # `self.trials` are saved in their own, Oracle-agnostic files.

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -361,9 +361,11 @@ class Oracle(stateful.Stateful):
         """
         hps = hyperparameters.space
         new_hps = []
-        for hp in hps:
-            if not self.hyperparameters._exists(hp.name, hp.conditions):
-                new_hps.append(hp)
+        new_hps.extend(
+            hp
+            for hp in hps
+            if not self.hyperparameters._exists(hp.name, hp.conditions)
+        )
 
         if new_hps and not self.allow_new_entries:
             raise RuntimeError(

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -394,10 +394,9 @@ class Oracle(stateful.Stateful):
         return sorted_trials[:num_trials]
 
     def remaining_trials(self):
-        if self.max_trials:
-            return self.max_trials - len(self.trials.items())
-        else:
-            return None
+        return (
+            self.max_trials - len(self.trials.items()) if self.max_trials else None
+        )
 
     def get_state(self):
         # `self.trials` are saved in their own, Oracle-agnostic files.

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -475,7 +475,7 @@ class Oracle(stateful.Stateful):
 
     def _compute_values_hash(self, values):
         keys = sorted(values.keys())
-        s = "".join(str(k) + "=" + str(values[k]) for k in keys)
+        s = "".join(f"{str(k)}={str(values[k])}" for k in keys)
         return hashlib.sha256(s.encode("utf-8")).hexdigest()[:32]
 
     def _check_objective_found(self, metrics):
@@ -495,7 +495,7 @@ class Oracle(stateful.Stateful):
             )
 
     def _get_trial_dir(self, trial_id):
-        dirname = os.path.join(self._project_dir, "trial_" + str(trial_id))
+        dirname = os.path.join(self._project_dir, f"trial_{str(trial_id)}")
         utils.create_directory(dirname)
         return dirname
 

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -362,12 +362,11 @@ class Oracle(stateful.Stateful):
             hyperparameters: An updated `HyperParameters` object.
         """
         hps = hyperparameters.space
-        new_hps = []
-        new_hps.extend(
+        new_hps = [
             hp
             for hp in hps
             if not self.hyperparameters._exists(hp.name, hp.conditions)
-        )
+        ]
 
         if new_hps and not self.allow_new_entries:
             raise RuntimeError(

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -463,10 +463,11 @@ class Oracle(stateful.Stateful):
             super(Oracle, self).reload(self._get_oracle_fname())
         except KeyError:
             raise RuntimeError(
-                "Error reloading `Oracle` from existing project. If you did not "
-                "mean to reload from an existing project, change the `project_name` "
-                "or pass `overwrite=True` when creating the `Tuner`. Found existing "
-                "project at: {}".format(self._project_dir)
+                "Error reloading `Oracle` from existing project. "
+                "If you did not mean to reload from an existing project, "
+                f"change the `project_name` or pass `overwrite=True` "
+                "when creating the `Tuner`. Found existing "
+                f"project at: {self._project_dir}"
             )
 
     def _get_oracle_fname(self):
@@ -487,10 +488,9 @@ class Oracle(stateful.Stateful):
                 objective_names.remove(metric_name)
         if objective_names:
             raise ValueError(
-                "Objective value missing in metrics reported to the "
-                "Oracle, expected: {}, found: {}".format(
-                    objective_names, metrics.keys()
-                )
+                "Objective value missing in metrics reported to "
+                f"the Oracle, expected: {objective_names}, "
+                f"found: {metrics.keys()}"
             )
 
     def _get_trial_dir(self, trial_id):

--- a/keras_tuner/engine/oracle_test.py
+++ b/keras_tuner/engine/oracle_test.py
@@ -138,9 +138,6 @@ def test_consecutive_failures_in_limit(tmp_path):
         oracle.update_trial(trial.trial_id, metrics={"val_loss": 0.5})
         oracle.end_trial(trial_id=trial.trial_id, status=trial.status)
 
-    # Should reach this line without error
-    assert True
-
 
 def test_too_many_consecutive_failures(tmp_path):
     oracle = OracleStub(

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -43,6 +43,7 @@ class TrialStatus:
     # The Trial is failed. No more retries needed.
     FAILED = "FAILED"
 
+    @staticmethod
     def to_proto(status):
         ts = keras_tuner_pb2.TrialStatus
         if status is None:
@@ -62,6 +63,7 @@ class TrialStatus:
         else:
             raise ValueError(f"Unknown status {status}")
 
+    @staticmethod
     def from_proto(proto):
         ts = keras_tuner_pb2.TrialStatus
         if proto == ts.UNKNOWN:

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -126,7 +126,7 @@ class Trial(stateful.Stateful):
     def display_hyperparameters(self):
         if self.hyperparameters.values:
             for hp, value in self.hyperparameters.values.items():
-                print(hp + ":", value)
+                print(f"{hp}:", value)
         else:
             print("default configuration")
 

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -43,43 +43,43 @@ class TrialStatus:
     # The Trial is failed. No more retries needed.
     FAILED = "FAILED"
 
-    def to_proto(status):
+    def to_proto(self):
         ts = keras_tuner_pb2.TrialStatus
-        if status is None:
+        if self is None:
             return ts.UNKNOWN
-        elif status == TrialStatus.RUNNING:
+        elif self == TrialStatus.RUNNING:
             return ts.RUNNING
-        elif status == TrialStatus.IDLE:
+        elif self == TrialStatus.IDLE:
             return ts.IDLE
-        elif status == TrialStatus.INVALID:
+        elif self == TrialStatus.INVALID:
             return ts.INVALID
-        elif status == TrialStatus.STOPPED:
+        elif self == TrialStatus.STOPPED:
             return ts.STOPPED
-        elif status == TrialStatus.COMPLETED:
+        elif self == TrialStatus.COMPLETED:
             return ts.COMPLETED
-        elif status == TrialStatus.FAILED:
+        elif self == TrialStatus.FAILED:
             return ts.FAILED
         else:
-            raise ValueError(f"Unknown status {status}")
+            raise ValueError(f"Unknown status {self}")
 
-    def from_proto(proto):
+    def from_proto(self):
         ts = keras_tuner_pb2.TrialStatus
-        if proto == ts.UNKNOWN:
+        if self == ts.UNKNOWN:
             return None
-        elif proto == ts.RUNNING:
+        elif self == ts.RUNNING:
             return TrialStatus.RUNNING
-        elif proto == ts.IDLE:
+        elif self == ts.IDLE:
             return TrialStatus.IDLE
-        elif proto == ts.INVALID:
+        elif self == ts.INVALID:
             return TrialStatus.INVALID
-        elif proto == ts.STOPPED:
+        elif self == ts.STOPPED:
             return TrialStatus.STOPPED
-        elif proto == ts.COMPLETED:
+        elif self == ts.COMPLETED:
             return TrialStatus.COMPLETED
-        elif proto == ts.FAILED:
+        elif self == ts.FAILED:
             return TrialStatus.FAILED
         else:
-            raise ValueError(f"Unknown status {proto}")
+            raise ValueError(f"Unknown status {self}")
 
 
 class Trial(stateful.Stateful):

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -43,43 +43,43 @@ class TrialStatus:
     # The Trial is failed. No more retries needed.
     FAILED = "FAILED"
 
-    def to_proto(self):
+    def to_proto(status):
         ts = keras_tuner_pb2.TrialStatus
-        if self is None:
+        if status is None:
             return ts.UNKNOWN
-        elif self == TrialStatus.RUNNING:
+        elif status == TrialStatus.RUNNING:
             return ts.RUNNING
-        elif self == TrialStatus.IDLE:
+        elif status == TrialStatus.IDLE:
             return ts.IDLE
-        elif self == TrialStatus.INVALID:
+        elif status == TrialStatus.INVALID:
             return ts.INVALID
-        elif self == TrialStatus.STOPPED:
+        elif status == TrialStatus.STOPPED:
             return ts.STOPPED
-        elif self == TrialStatus.COMPLETED:
+        elif status == TrialStatus.COMPLETED:
             return ts.COMPLETED
-        elif self == TrialStatus.FAILED:
+        elif status == TrialStatus.FAILED:
             return ts.FAILED
         else:
-            raise ValueError(f"Unknown status {self}")
+            raise ValueError(f"Unknown status {status}")
 
-    def from_proto(self):
+    def from_proto(proto):
         ts = keras_tuner_pb2.TrialStatus
-        if self == ts.UNKNOWN:
+        if proto == ts.UNKNOWN:
             return None
-        elif self == ts.RUNNING:
+        elif proto == ts.RUNNING:
             return TrialStatus.RUNNING
-        elif self == ts.IDLE:
+        elif proto == ts.IDLE:
             return TrialStatus.IDLE
-        elif self == ts.INVALID:
+        elif proto == ts.INVALID:
             return TrialStatus.INVALID
-        elif self == ts.STOPPED:
+        elif proto == ts.STOPPED:
             return TrialStatus.STOPPED
-        elif self == ts.COMPLETED:
+        elif proto == ts.COMPLETED:
             return TrialStatus.COMPLETED
-        elif self == ts.FAILED:
+        elif proto == ts.FAILED:
             return TrialStatus.FAILED
         else:
-            raise ValueError(f"Unknown status {self}")
+            raise ValueError(f"Unknown status {proto}")
 
 
 class Trial(stateful.Stateful):

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -385,7 +385,7 @@ class Tuner(base_tuner.BaseTuner):
                 )
 
     def _get_tensorboard_dir(self, logdir, trial_id, execution):
-        return os.path.join(str(logdir), str(trial_id), "execution" + str(execution))
+        return os.path.join(str(logdir), str(trial_id), f"execution{str(execution)}")
 
     def _get_checkpoint_fname(self, trial_id):
         return os.path.join(

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -41,8 +41,9 @@ def build_model(hp):
     x = inputs
     for i in range(hp.Int("num_layers", 1, 4)):
         x = keras.layers.Dense(
-            units=hp.Int("units_" + str(i), 5, 9, 1, default=6), activation="relu"
+            units=hp.Int(f"units_{str(i)}", 5, 9, 1, default=6), activation="relu"
         )(x)
+
     outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
     model = keras.Model(inputs, outputs)
     model.compile(
@@ -158,9 +159,10 @@ class ExampleHyperModel(keras_tuner.HyperModel):
         x = inputs
         for i in range(hp.Int("num_layers", 1, 4)):
             x = keras.layers.Dense(
-                units=hp.Int("units_" + str(i), 5, 9, 1, default=6),
+                units=hp.Int(f"units_{str(i)}", 5, 9, 1, default=6),
                 activation="relu",
             )(x)
+
         outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
         model = keras.Model(inputs, outputs)
         model.compile(
@@ -459,7 +461,7 @@ def test_static_space(tmp_path):
         x = inputs
         for i in range(hp.get("num_layers")):
             x = keras.layers.Dense(
-                units=hp.get("units_" + str(i)), activation="relu"
+                units=hp.get(f"units_{str(i)}"), activation="relu"
             )(x)
         outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
         model = keras.Model(inputs, outputs)
@@ -501,7 +503,7 @@ def test_static_space_errors(tmp_path):
         x = inputs
         for i in range(hp.get("num_layers")):
             x = keras.layers.Dense(
-                units=hp.get("units_" + str(i)), activation="relu"
+                units=hp.get(f"units_{str(i)}"), activation="relu"
             )(x)
         outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
         model = keras.Model(inputs, outputs)
@@ -538,7 +540,7 @@ def test_static_space_errors(tmp_path):
         x = inputs
         for i in range(hp.get("num_layers")):
             x = keras.layers.Dense(
-                units=hp.get("units_" + str(i)), activation="relu"
+                units=hp.get(f"units_{str(i)}"), activation="relu"
             )(x)
         outputs = keras.layers.Dense(NUM_CLASSES, activation="softmax")(x)
         model = keras.Model(inputs, outputs)

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -986,8 +986,9 @@ def test_convert_hyperparams_to_hparams():
     }
     hparams_repr_list = [repr(hparams[x]) for x in hparams.keys()]
     expected_hparams_repr_list = [
-        repr(expected_hparams[x]) for x in expected_hparams.keys()
+        repr(expected_hparams[x]) for x in expected_hparams
     ]
+
     assert sorted(hparams_repr_list) == sorted(expected_hparams_repr_list)
 
     hps = keras_tuner.engine.hyperparameters.HyperParameters()
@@ -1297,7 +1298,7 @@ def test_callbacks_run_each_execution(tmp_path):
 
     # Unknown reason cause the callback to run 5 times sometime.
     # Make 5 & 6 both pass the test before found the reason.
-    assert len(callback_instances) in (5, 6)
+    assert len(callback_instances) in {5, 6}
 
 
 def test_build_and_fit_model(tmp_path):

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -1378,7 +1378,7 @@ def test_init_build_all_hps_in_all_conditions(tmp_path):
             return super().build(hp)
 
     def name_in_hp(name, hp):
-        return any([name == single_hp.name for single_hp in hp.space])
+        return any(name == single_hp.name for single_hp in hp.space)
 
     class MyTuner(tuner_module.Tuner):
         def _populate_initial_space(self):

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -42,7 +42,7 @@ class TunerStats(object):
     def summary(self, extended=False):
         print("Tuning stats")
         for setting, value in self.get_config():
-            print(setting + ":", value)
+            print(f"{setting}:", value)
 
     def get_config(self):
         return {
@@ -169,7 +169,7 @@ class Display(object):
             return f"{val:.5g}"
         val_str = str(val)
         if len(val_str) > self.col_width:
-            val_str = val_str[: self.col_width - 3] + "..."
+            val_str = f"{val_str[:self.col_width - 3]}..."
         return val_str
 
     def format_duration(self, d):

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -229,9 +229,11 @@ def average_metrics_dicts(metrics_dicts):
     for metrics_dict in metrics_dicts:
         for metric_name, metric_value in metrics_dict.items():
             metrics[metric_name].append(metric_value)
-    averaged_metrics = {}
-    for metric_name, metric_values in metrics.items():
-        averaged_metrics[metric_name] = np.mean(metric_values)
+    averaged_metrics = {
+        metric_name: np.mean(metric_values)
+        for metric_name, metric_values in metrics.items()
+    }
+
     return averaged_metrics
 
 

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -143,17 +143,13 @@ class Display(object):
     def show_hyperparameter_table(self, trial):
         template = "{{0:{0}}}|{{1:{0}}}|{{2}}".format(self.col_width)
         best_trials = self.oracle.get_best_trials()
-        if len(best_trials) > 0:
-            best_trial = best_trials[0]
-        else:
-            best_trial = None
+        best_trial = best_trials[0] if len(best_trials) > 0 else None
         if trial.hyperparameters.values:
             print(template.format("Value", "Best Value So Far", "Hyperparameter"))
             for hp, value in trial.hyperparameters.values.items():
-                if best_trial:
-                    best_value = best_trial.hyperparameters.values.get(hp)
-                else:
-                    best_value = "?"
+                best_value = (
+                    best_trial.hyperparameters.values.get(hp) if best_trial else "?"
+                )
                 print(
                     template.format(
                         self.format_value(value),

--- a/keras_tuner/integration_tests/end_to_end_test.py
+++ b/keras_tuner/integration_tests/end_to_end_test.py
@@ -43,9 +43,10 @@ def build_model(hp):
     x = keras.layers.Reshape((28 * 28,))(inputs)
     for i in range(hp.Int("num_layers", 1, 4)):
         x = keras.layers.Dense(
-            units=hp.Int("units_" + str(i), 128, 512, 32, default=256),
+            units=hp.Int(f"units_{str(i)}", 128, 512, 32, default=256),
             activation="relu",
         )(x)
+
     x = keras.layers.Dropout(hp.Float("dp", 0.0, 0.6, 0.1, default=0.5))(x)
     outputs = keras.layers.Dense(10, activation="softmax")(x)
     model = keras.Model(inputs, outputs)

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -405,8 +405,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
     def _get_hp_bounds(self):
         bounds = []
-        for hp in self._nonfixed_space():
-            bounds.append([0, 1])
+        bounds.extend([0, 1] for hp in self._nonfixed_space())
         return np.array(bounds)
 
 

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -138,17 +138,16 @@ class GaussianProcessRegressor(object):
         Returns:
             A bool indicates whether all required attributes are present.
         """
-        for attribute in [
-            "_x_train",
-            "_alpha_vector",
-            "_l_matrix",
-            "_y_train_std",
-            "_y_train_mean",
-        ]:
-            if not hasattr(self, attribute):
-                return False
-
-        return True
+        return all(
+            hasattr(self, attribute)
+            for attribute in [
+                "_x_train",
+                "_alpha_vector",
+                "_l_matrix",
+                "_y_train_std",
+                "_y_train_mean",
+            ]
+        )
 
 
 class BayesianOptimizationOracle(oracle_module.Oracle):

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -405,7 +405,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
     def _get_hp_bounds(self):
         bounds = []
-        bounds.extend([0, 1] for hp in self._nonfixed_space())
+        bounds.extend([0, 1] for _ in self._nonfixed_space())
         return np.array(bounds)
 
 

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -403,8 +403,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         ]
 
     def _get_hp_bounds(self):
-        bounds = []
-        bounds.extend([0, 1] for _ in self._nonfixed_space())
+        bounds = [[0, 1] for _ in self._nonfixed_space()]
         return np.array(bounds)
 
 

--- a/keras_tuner/tuners/bayesian_test.py
+++ b/keras_tuner/tuners/bayesian_test.py
@@ -30,9 +30,10 @@ def build_model(hp):
     for i in range(3):
         model.add(
             tf.keras.layers.Dense(
-                units=hp.Int("units_" + str(i), 2, 4, 2), activation="relu"
+                units=hp.Int(f"units_{str(i)}", 2, 4, 2), activation="relu"
             )
         )
+
     model.add(tf.keras.layers.Dense(2, activation="softmax"))
     model.compile(
         optimizer=tf.keras.optimizers.Adam(
@@ -351,7 +352,7 @@ def test_distributed_optimization(tmp_path):
     for _ in range(10):
         trials = []
         for i in range(tuners):
-            trial = oracle.create_trial("tuner_" + str(i))
+            trial = oracle.create_trial(f"tuner_{str(i)}")
             trials.append(trial)
         for trial in trials:
             oracle.update_trial(

--- a/keras_tuner/tuners/bayesian_test.py
+++ b/keras_tuner/tuners/bayesian_test.py
@@ -160,7 +160,7 @@ def test_bayesian_save_reload(tmp_path):
     oracle._set_project_dir(tmp_path, "untitled")
     oracle.reload()
 
-    for trial_id in range(3):
+    for _ in range(3):
         trial = oracle.create_trial("tuner_id")
         oracle.update_trial(trial.trial_id, {"score": 1.0})
         oracle.end_trial(trial.trial_id, "COMPLETED")

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -161,10 +161,7 @@ class GridSearchOracle(oracle_module.Oracle):
             # Otherwise, reset to its first value.
             new_values[name] = default_values[name]
 
-        if bumped_value:
-            return new_values
-
-        return None
+        return new_values if bumped_value else None
 
 
 class GridSearch(tuner_module.Tuner):

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -165,46 +165,43 @@ class HyperbandOracle(oracle_module.Oracle):
             if len(rounds[0]) < self._get_size(bracket_num, round_num=0):
                 # Populate the initial random trials for this bracket.
                 return self._random_trial(trial_id, bracket)
-            else:
-                # Try to populate incomplete rounds for this bracket.
-                for round_num in range(1, len(rounds)):
-                    round_info = rounds[round_num]
-                    past_round_info = rounds[round_num - 1]
-                    size = self._get_size(bracket_num, round_num)
-                    past_size = self._get_size(bracket_num, round_num - 1)
+            # Try to populate incomplete rounds for this bracket.
+            for round_num in range(1, len(rounds)):
+                round_info = rounds[round_num]
+                past_round_info = rounds[round_num - 1]
+                size = self._get_size(bracket_num, round_num)
+                past_size = self._get_size(bracket_num, round_num - 1)
 
-                    # If more trials from the last round are ready than will be
-                    # thrown out, we can select the best to run for the next round.
-                    already_selected = [info["past_id"] for info in round_info]
-                    candidates = [
-                        self.trials[info["id"]]
-                        for info in past_round_info
-                        if info["id"] not in already_selected
-                    ]
-                    candidates = [t for t in candidates if t.status == "COMPLETED"]
-                    if len(candidates) > past_size - size:
-                        sorted_candidates = sorted(
-                            candidates,
-                            key=lambda t: t.score,
-                            reverse=self.objective.direction == "max",
-                        )
-                        best_trial = sorted_candidates[0]
+                # If more trials from the last round are ready than will be
+                # thrown out, we can select the best to run for the next round.
+                already_selected = [info["past_id"] for info in round_info]
+                candidates = [
+                    self.trials[info["id"]]
+                    for info in past_round_info
+                    if info["id"] not in already_selected
+                ]
+                candidates = [t for t in candidates if t.status == "COMPLETED"]
+                if len(candidates) > past_size - size:
+                    sorted_candidates = sorted(
+                        candidates,
+                        key=lambda t: t.score,
+                        reverse=self.objective.direction == "max",
+                    )
+                    best_trial = sorted_candidates[0]
 
-                        values = best_trial.hyperparameters.values.copy()
-                        values["tuner/trial_id"] = best_trial.trial_id
-                        values["tuner/epochs"] = self._get_epochs(
-                            bracket_num, round_num
-                        )
-                        values["tuner/initial_epoch"] = self._get_epochs(
-                            bracket_num, round_num - 1
-                        )
-                        values["tuner/bracket"] = self._current_bracket
-                        values["tuner/round"] = round_num
+                    values = best_trial.hyperparameters.values.copy()
+                    values["tuner/trial_id"] = best_trial.trial_id
+                    values["tuner/epochs"] = self._get_epochs(bracket_num, round_num)
+                    values["tuner/initial_epoch"] = self._get_epochs(
+                        bracket_num, round_num - 1
+                    )
+                    values["tuner/bracket"] = self._current_bracket
+                    values["tuner/round"] = round_num
 
-                        round_info.append(
-                            {"past_id": best_trial.trial_id, "id": trial_id}
-                        )
-                        return {"status": "RUNNING", "values": values}
+                    round_info.append(
+                        {"past_id": best_trial.trial_id, "id": trial_id}
+                    )
+                    return {"status": "RUNNING", "values": values}
 
         # This is reached if no trials from current brackets can be run.
 
@@ -216,9 +213,8 @@ class HyperbandOracle(oracle_module.Oracle):
             # Stop creating new brackets, but wait to complete other brackets.
             if self.ongoing_trials:
                 return {"status": "IDLE"}
-            else:
-                self._increment_bracket_num()
-                return {"status": "STOPPED"}
+            self._increment_bracket_num()
+            return {"status": "STOPPED"}
         # Create a new bracket.
         else:
             self._increment_bracket_num()

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -227,8 +227,7 @@ class HyperbandOracle(oracle_module.Oracle):
 
     def _start_new_bracket(self):
         rounds = []
-        for _ in range(self._get_num_rounds(self._current_bracket)):
-            rounds.append([])
+        rounds.extend([] for _ in range(self._get_num_rounds(self._current_bracket)))
         bracket = {"bracket_num": self._current_bracket, "rounds": rounds}
         self._brackets.append(bracket)
 

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -241,10 +241,7 @@ class HyperbandOracle(oracle_module.Oracle):
             bracket_num = bracket["bracket_num"]
             rounds = bracket["rounds"]
             last_round = len(rounds) - 1
-            if len(rounds[last_round]) == self._get_size(bracket_num, last_round):
-                # All trials have been created for the current bracket.
-                return False
-            return True
+            return len(rounds[last_round]) != self._get_size(bracket_num, last_round)
 
         self._brackets = list(filter(_bracket_is_incomplete, self._brackets))
 

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -262,10 +262,8 @@ def test_hyperband_load_weights(tmp_path):
     # compare the weights
     assert len(new_model_weights) == len(best_model_round_0_weights)
     assert all(
-        [
-            np.alltrue(new_weight == best_old_weight)
-            for new_weight, best_old_weight in zip(
-                new_model_weights, best_model_round_0_weights
-            )
-        ]
+        np.alltrue(new_weight == best_old_weight)
+        for new_weight, best_old_weight in zip(
+            new_model_weights, best_model_round_0_weights
+        )
     )

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -26,11 +26,13 @@ def build_model(hp):
     model = tf.keras.Sequential()
     for i in range(hp.Int("layers", 1, 3)):
         model.add(
-            tf.keras.layers.Dense(hp.Int("units" + str(i), 1, 5), activation="relu")
+            tf.keras.layers.Dense(hp.Int(f"units{str(i)}", 1, 5), activation="relu")
         )
+
         model.add(
-            tf.keras.layers.Lambda(lambda x: x + hp.Float("bias" + str(i), -1, 1))
+            tf.keras.layers.Lambda(lambda x: x + hp.Float(f"bias{str(i)}", -1, 1))
         )
+
     model.add(tf.keras.layers.Dense(1, activation="sigmoid"))
     model.compile("sgd", "mse")
     return model
@@ -115,7 +117,7 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
     # in parallel.
     round0_trials = []
     for i in range(10):
-        t = oracle.create_trial("tuner" + str(i))
+        t = oracle.create_trial(f"tuner{str(i)}")
         assert t.status == "RUNNING"
         round0_trials.append(t)
 
@@ -132,7 +134,7 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
 
     round1_trials = []
     for i in range(4):
-        t = oracle.create_trial("tuner" + str(i))
+        t = oracle.create_trial(f"tuner{str(i)}")
         assert t.status == "RUNNING"
         round1_trials.append(t)
 

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -77,7 +77,7 @@ def test_hyperband_oracle_one_sweep_single_thread(tmp_path):
     score = 0
     for bracket_num in reversed(range(oracle._get_num_brackets())):
         for round_num in range(oracle._get_num_rounds(bracket_num)):
-            for model_num in range(oracle._get_size(bracket_num, round_num)):
+            for _ in range(oracle._get_size(bracket_num, round_num)):
                 trial = oracle.create_trial("tuner0")
                 assert trial.status == "RUNNING"
                 score += 1

--- a/keras_tuner/tuners/randomsearch_test.py
+++ b/keras_tuner/tuners/randomsearch_test.py
@@ -27,9 +27,10 @@ def test_update_space(tmp_path):
         for i in range(hp.Int("layers", 0, 2)):
             model.add(
                 tf.keras.layers.Dense(
-                    units=hp.Int("units_" + str(i), 2, 4, 2), activation="relu"
+                    units=hp.Int(f"units_{str(i)}", 2, 4, 2), activation="relu"
                 )
             )
+
         model.add(tf.keras.layers.Dense(1, activation="sigmoid"))
         model.compile("adam", loss="binary_crossentropy", metrics=["accuracy"])
         return model

--- a/keras_tuner/utils.py
+++ b/keras_tuner/utils.py
@@ -67,4 +67,6 @@ def check_tf_version():
 def to_list(values):
     if isinstance(values, list):
         return values
-    return list(values) if isinstance(values, tuple) else [values]
+    if isinstance(values, tuple):
+        return list(values)
+    return [values]

--- a/keras_tuner/utils.py
+++ b/keras_tuner/utils.py
@@ -67,6 +67,4 @@ def check_tf_version():
 def to_list(values):
     if isinstance(values, list):
         return values
-    if isinstance(values, tuple):
-        return list(values)
-    return [values]
+    return list(values) if isinstance(values, tuple) else [values]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ ignore =
     N802
     # Argument name should be lowercase
     N803
+    # First argument of a method should be named
+    N805
     # Argument name should be lowercase
     N806
     # lowercase ... imported as non lowercase

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,12 @@ ignore =
     E121,E123,E126,E226,E24,E704,W503,W504
     # Function name should be lowercase
     N802
+    # Argument name should be lowercase
+    N803
+    # First argument of a method should be named
+    N805
+    # Argument name should be lowercase
+    N806
     # lowercase ... imported as non lowercase
     # Useful to ignore for "import keras.backend as K"
     N812

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,6 @@ ignore =
     N802
     # Argument name should be lowercase
     N803
-    # First argument of a method should be named
-    N805
     # Argument name should be lowercase
     N806
     # lowercase ... imported as non lowercase


### PR DESCRIPTION
## Objective 

During taking care about the `flake8` issue #778, `keras_tuner` for cross-checked
via

```shell
sourcery review ./keras_tuner/ --disable inline-immediately-returned-variable --disable remove-unnecessary-cast 
```
for refactoring possibilities:

* use-fstring-for-concatenation      
* assign-if-exp                      
* reintroduce-else                   
* use-fstring-for-formatting         
* for-append-to-extend               
* for-index-underscore               
* collection-builtin-to-comprehension
* comprehension-to-generator         
* remove-unnecessary-else            
* boolean-if-exp-identity            
* list-comprehension                 
* merge-dict-assign                  
* use-any                            
* identity-comprehension             
* instance-method-first-arg-name     
* invert-any-all                     
* or-if-exp-identity                 
* remove-str-from-fstring            
* simplify-boolean-comparison        
* swap-if-else-branches              
* swap-if-expression                 
* use-next                           
* aug-assign                         
* class-method-first-arg-name        
* collection-into-set                
* dict-comprehension                 
* do-not-use-bare-except             
* raise-from-previous-error          
* remove-assert-true                 
* remove-dict-keys                   
* remove-unreachable-code            
* simplify-len-comparison            
* sum-comprehension                  


> The PR is designed so that single commits can be dropped out. And the code basis stays consistent [PEP 20](https://peps.python.org/pep-0020/)

See also: 
* https://github.com/sourcery-ai/sourcery
* https://docs.sourcery.ai/Reference/Built-in-Rules/refactorings/