### PR TITLE
Resolve #614 key error when using conditional hp

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,3 +35,5 @@
   fixed.
 * Hyperband was not loading the weights correctly for half-trained models. This
   is now fixed.
+* `KeyError` may occur if using `hp.conditional_scope()`, or the `parent`
+  argument for hyperparameters. This is ow fixed.

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -113,7 +113,7 @@ class HyperModel(object):
         return self._build(hp, *args, **kwargs)
 
     def declare_hyperparameters(self, hp):
-        raise NotImplementedError
+        pass
 
     def fit(self, hp, model, *args, **kwargs):
         """Train the model.

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -1404,6 +1404,40 @@ def test_init_build_all_hps_in_all_conditions(tmp_path):
     )
 
 
+def test_populate_initial_space_with_hp_parent_arg(tmp_path):
+    def build_model(hp):
+        hp.Boolean("parent", default=True)
+        hp.Boolean(
+            "child",
+            parent_name="parent",
+            parent_values=[False],
+        )
+        return keras.Sequential()
+
+    keras_tuner.RandomSearch(
+        build_model,
+        objective="val_accuracy",
+        directory=tmp_path,
+        max_trials=1,
+    )
+
+
+def test_populate_initial_space_with_declare_hp(tmp_path):
+    class MyHyperModel(keras_tuner.HyperModel):
+        def declare_hyperparameters(self, hp):
+            hp.Boolean("bool")
+
+        def build(self, hp):
+            return keras.Sequential()
+
+    keras_tuner.RandomSearch(
+        MyHyperModel(),
+        objective="val_accuracy",
+        directory=tmp_path,
+        max_trials=1,
+    )
+
+
 def test_build_did_not_return_keras_model(tmp_path):
     tuner = keras_tuner.tuners.RandomSearch(
         hypermodel=lambda hp: None,

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import random
 
 import numpy as np
 import tensorflow as tf
@@ -227,10 +226,6 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         self.num_initial_points = num_initial_points
         self.alpha = alpha
         self.beta = beta
-        self.seed = seed or random.randint(1, int(1e4))
-        self._seed_state = self.seed
-        self._tried_so_far = set()
-        self._max_collisions = 20
         self._random_state = np.random.RandomState(self.seed)
         self.gpr = self._make_gpr()
 

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -151,13 +151,14 @@ class GridSearchOracle(oracle_module.Oracle):
         # conditional scope first instead of change the condition value first.
         for hp in reversed(hps.space):
             name = hp.name
-            value = new_values[name]
             # Bump up the hp value if possible and active.
-            if value != all_values[name][-1] and hps.is_active(hp):
-                index = all_values[name].index(value) + 1
-                new_values[name] = all_values[name][index]
-                bumped_value = True
-                break
+            if hps.is_active(hp):
+                value = new_values[name]
+                if value != all_values[name][-1]:
+                    index = all_values[name].index(value) + 1
+                    new_values[name] = all_values[name][index]
+                    bumped_value = True
+                    break
             # Otherwise, reset to its first value.
             new_values[name] = default_values[name]
 

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-import random
 
 from keras_tuner.engine import oracle as oracle_module
 from keras_tuner.engine import tuner as tuner_module
@@ -129,11 +128,6 @@ class HyperbandOracle(oracle_module.Oracle):
         # degress of aggressiveness.
         self.min_epochs = 1
         self.factor = factor
-
-        self.seed = seed or random.randint(1, 10000)
-        self._max_collisions = 20
-        self._seed_state = self.seed
-        self._tried_so_far = set()
 
         self._current_iteration = 0
         # Start with most aggressively halving bracket.


### PR DESCRIPTION
According to #614, the bug only exist for `keras-tuner>=1.0.4`.

### The cause of the bug

The bug is caused by introducing activating all conditional spaces when
initalize the search space with `BaseTuner._populate_initial_space()`.
In `BaseTuner._populate_initial_space()`, it only change the parent value to
activate the condition without populating the children values.
As mentioned in #242, KerasTuner do not populate values for inactive hps.
Therefore, the children values were not populated when registered if not active.
So, a `KeyError` would occur because cannot find the value for the children if
the children was registered when not active and parent value were changed to
activate it.

### The fix

We would like to keep the only populating active values requirement for
populating the space, which is strict and make the code less prune to bugs.
With such requirements, the change we make is to ensure the populated values are
valid, which means all the active hp values are populated and none of the
inactive hp values are populated.

We ensured it in `BaseTuner._populate_initial_space()` and in
`Oracle.create_trial()`. In this way, everything is ensured even the `Oracle`
populates the wrong set of values.