### PR TITLE
Fix default `num_initial_points` to match doc

### DIFF
--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -463,7 +463,7 @@ class BayesianOptimization(tuner_module.Tuner):
         hypermodel=None,
         objective=None,
         max_trials=10,
-        num_initial_points=2,
+        num_initial_points=None,
         alpha=1e-4,
         beta=2.6,
         seed=None,


### PR DESCRIPTION
Currently, the argument `num_initial_points` of the `BayesianOptimization` tuner defaults to 2 even if the doc states that it should default to 3*dimension when unspecified.

I just made it default to `None` in order to avoid having to pass `None` manually to get the behaviour specified in the doc.