### PR TITLE
Use sklearn Gaussian process implementation in Bayesian optimization

### DIFF
--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -12,141 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-
 import numpy as np
-import tensorflow as tf
+
+try:
+    import sklearn
+    import sklearn.exceptions
+    import sklearn.gaussian_process
+except ImportError:  # pragma: no cover
+    sklearn = None  # pragma: no cover
 
 try:
     import scipy
     import scipy.optimize
-except ImportError:
-    scipy = None
+except ImportError:  # pragma: no cover
+    scipy = None  # pragma: no cover
 
 from keras_tuner.engine import hyperparameters as hp_module
 from keras_tuner.engine import oracle as oracle_module
 from keras_tuner.engine import trial as trial_module
 from keras_tuner.engine import tuner as tuner_module
-
-
-def cdist(x, y=None):
-    if y is None:
-        y = x
-    return np.linalg.norm(x[:, None, :] - y[None, :, :], axis=-1)
-
-
-def solve_triangular(a, b, lower):
-    if np.isfinite(a).all() and np.isfinite(b).all():
-        a = tf.constant(a, dtype=tf.float32)
-        b = tf.constant(b, dtype=tf.float32)
-        return tf.linalg.triangular_solve(a, b, lower=lower).numpy()
-    else:
-        raise ValueError("array must not contain infs or NaNs")
-
-
-def cho_solve(l_matrix, b):
-    # Ax=b LL^T=A => Ly=b L^Tx=y
-    y = solve_triangular(l_matrix, b.reshape(-1, 1), lower=True)
-    return solve_triangular(l_matrix.T, y.reshape(-1, 1), lower=False)
-
-
-def matern_kernel(x, y=None):
-    # nu = 2.5
-    dists = cdist(x, y)
-    dists *= math.sqrt(5)
-    kernel_matrix = (1.0 + dists + dists**2 / 3.0) * np.exp(-dists)
-    return kernel_matrix
-
-
-class GaussianProcessRegressor(object):
-    """A Gaussian process regressor.
-
-    Args:
-        alpha: Float, the value added to the diagonal of the kernel matrix
-            during fitting. It represents the expected amount of noise in the
-            observed performances in Bayesian optimization.
-        seed: Optional int, the random seed.
-    """
-
-    def __init__(self, alpha, seed=None):
-        self.kernel = matern_kernel
-        self.n_restarts_optimizer = 20
-        self.normalize_y = True
-        self.alpha = alpha
-        self.seed = seed
-        self._x = None
-        self._y = None
-
-    def fit(self, x, y):
-        """Fit the Gaussian process regressor.
-
-        Args:
-            x: np.ndarray with shape (samples, features).
-            y: np.ndarray with shape (samples,).
-        """
-        self._x_train = np.copy(x)
-        self._y_train = np.copy(y)
-
-        # Normalize y.
-        self._y_train_mean = np.mean(self._y_train, axis=0)
-        self._y_train_std = np.std(self._y_train, axis=0)
-        self._y_train = (self._y_train - self._y_train_mean) / self._y_train_std
-
-        # TODO: choose a theta for the kernel.
-        kernel_matrix = self.kernel(self._x_train)
-        kernel_matrix[np.diag_indices_from(kernel_matrix)] += self.alpha
-
-        # l_matrix * l_matrix^T == kernel_matrix
-        self._l_matrix = np.linalg.cholesky(kernel_matrix)
-        self._alpha_vector = cho_solve(self._l_matrix, self._y_train)
-
-    def predict(self, x):
-        """Predict the mean and standard deviation of the target.
-
-        Args:
-            x: np.ndarray with shape (samples, features).
-
-        Returns:
-            Two 1-D vectors, the mean vector and standard deviation vector.
-        """
-        # Compute the mean.
-        kernel_trans = self.kernel(x, self._x_train)
-        y_mean = kernel_trans.dot(self._alpha_vector)
-
-        # Compute the variance.
-        l_inv = solve_triangular(
-            self._l_matrix.T, np.eye(self._l_matrix.shape[0]), lower=False
-        )
-        kernel_inv = l_inv.dot(l_inv.T)
-
-        y_var = np.ones(len(x), dtype=float)
-        y_var -= np.einsum(
-            "ij,ij->i", np.dot(kernel_trans, kernel_inv), kernel_trans
-        )
-        y_var[y_var < 0] = 0.0
-
-        # Undo normalize y.
-        y_var *= self._y_train_std**2
-        y_mean = self._y_train_std * y_mean + self._y_train_mean
-
-        return y_mean.flatten(), np.sqrt(y_var)
-
-    def can_predict(self) -> bool:
-        """Checks if predict can be called without raising exceptions.
-
-        Returns:
-            A bool indicates whether all required attributes are present.
-        """
-        return all(
-            hasattr(self, attribute)
-            for attribute in [
-                "_x_train",
-                "_alpha_vector",
-                "_l_matrix",
-                "_y_train_std",
-                "_y_train_mean",
-            ]
-        )
 
 
 class BayesianOptimizationOracle(oracle_module.Oracle):
@@ -213,6 +97,16 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
     ):
+        if scipy is None:
+            raise ImportError(
+                "Please install scipy before using the `BayesianOptimization`."
+            )
+
+        if sklearn is None:
+            raise ImportError(
+                "Please install scikit-learn (sklearn) before using the "
+                "`BayesianOptimization`."
+            )
         super(BayesianOptimizationOracle, self).__init__(
             objective=objective,
             max_trials=max_trials,
@@ -230,9 +124,12 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         self.gpr = self._make_gpr()
 
     def _make_gpr(self):
-        return GaussianProcessRegressor(
+        return sklearn.gaussian_process.GaussianProcessRegressor(
+            kernel=sklearn.gaussian_process.kernels.Matern(nu=2.5),
+            n_restarts_optimizer=20,
+            normalize_y=True,
             alpha=self.alpha,
-            seed=self.seed,
+            random_state=self.seed,
         )
 
     def populate_space(self, trial_id):
@@ -263,16 +160,16 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
 
         # Fit a GPR to the completed trials and return the predicted optimum values.
         x, y = self._vectorize_trials()
-        try:
-            self.gpr.fit(x, y)
-        except ValueError as e:
-            if "array must not contain infs or NaNs" in str(e):
-                return self._random_populate_space()
-            raise e
+
+        # Ensure no nan, inf in x, y. GPR cannot process nan or inf.
+        x = np.nan_to_num(x, posinf=0, neginf=0)
+        y = np.nan_to_num(y, posinf=0, neginf=0)
+
+        self.gpr.fit(x, y)
 
         def _upper_confidence_bound(x):
             x = x.reshape(1, -1)
-            mu, sigma = self.gpr.predict(x)
+            mu, sigma = self.gpr.predict(x, return_std=True)
             return mu - self.beta * sigma
 
         optimal_val = float("inf")
@@ -342,12 +239,11 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                 prob = hp.value_to_prob(trial_value)
                 vector.append(prob)
 
-            if trial in ongoing_trials and self.gpr.can_predict():
-                # Check if self.gpr.predict can be called and then
-                # "hallucinate" the results of ongoing trials. This ensures that
+            if trial in ongoing_trials:
+                # "Hallucinate" the results of ongoing trials. This ensures that
                 # repeat trials are not selected when running distributed.
                 x_h = np.array(vector).reshape((1, -1))
-                y_h_mean, y_h_std = self.gpr.predict(x_h)
+                y_h_mean, y_h_std = self.gpr.predict(x_h, return_std=True)
                 # Give a pessimistic estimate of the ongoing trial.
                 score = y_h_mean[0] + y_h_std[0]
             elif trial.status == "COMPLETED":
@@ -356,6 +252,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                 if self.objective.direction == "max":
                     score = -1 * score
             else:
+                # Skip the failed and invalid trials.
                 continue
 
             x.append(vector)
@@ -486,7 +383,3 @@ class BayesianOptimization(tuner_module.Tuner):
             BayesianOptimization,
             self,
         ).__init__(oracle=oracle, hypermodel=hypermodel, **kwargs)
-        if scipy is None:
-            raise ImportError(
-                "Please install scipy before using the `BayesianOptimization`."
-            )

--- a/keras_tuner/tuners/bayesian_test.py
+++ b/keras_tuner/tuners/bayesian_test.py
@@ -58,18 +58,17 @@ def test_scipy_not_install_error(tmp_path):
     keras_tuner.tuners.bayesian.scipy = scipy_module
 
 
-def test_gpr_mse_is_small():
-    x_train = np.random.rand(1000, 2)
-    y_train = np.multiply(x_train, x_train).mean(axis=-1)
-    x_test = np.random.rand(1000, 2)
-    y_test = np.multiply(x_test, x_test).mean(axis=-1)
+def test_sklearn_not_install_error(tmp_path):
+    sklearn_module = keras_tuner.tuners.bayesian.sklearn
+    keras_tuner.tuners.bayesian.sklearn = None
 
-    gpr = bo_module.GaussianProcessRegressor(alpha=1e-4, seed=3)
-    gpr.fit(x_train, y_train)
-    y_predict_mean, y_predict_std = gpr.predict(x_test)
+    with pytest.raises(ImportError, match="Please install scikit-learn"):
+        keras_tuner.BayesianOptimization(
+            hypermodel=build_model,
+            directory=tmp_path,
+        )
 
-    assert ((y_predict_mean - y_test) ** 2).mean(axis=0) < 1e-8
-    assert y_predict_std.shape == (1000,)
+    keras_tuner.tuners.bayesian.sklearn = sklearn_module
 
 
 def test_bayesian_oracle(tmp_path):


### PR DESCRIPTION
As there are issues regarding the correctness and effectiveness of Bayesian optimization (#608), we change it back to the sklearn implementation to reduce maintenance burden.

Require Scikit-learn installed if use Bayesian optimizaiton.
Reverting #499, #505, #650.

When the following conditions are achieved, we will migrate to TF implementation of Bayesian optimization.
* We have enough engineering resource to maintain it.
* The TF implementation is faster than sklearn implementation. (As I tested before in #506, TF is slower).
* We are able to implement the [`lbfgs_minimize`](https://www.tensorflow.org/probability/api_docs/python/tfp/optimizer/lbfgs_minimize) algorithm.