### PR TITLE
Change `end_trial` signature

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,8 +5,8 @@
   with `Oracle.update_trial()` in `Tuner.run_trial()` is deprecated. Please
   return the metrics in `Tuner.run_trial()` instead.
 * If you implemented your own `Oracle` and overrided `Oracle.end_trial()`, you
-  need to change the signature of the function to
-  `Oracle.end_trial(trial_id, status, message)`.
+  need to change the signature of the function from
+  `Oracle.end_trial(trial.trial_id, trial.status)` to `Oracle.end_trial(trial)`.
 * The default value of the `step` argument in `keras_tuner.HyperParameters.Int()` is
   changed to `None`, which was `1` before. No change in default behavior.
 * The default value of the `sampling` argument in

--- a/keras_tuner/distribute/oracle_chief.py
+++ b/keras_tuner/distribute/oracle_chief.py
@@ -52,8 +52,8 @@ class OracleServicer(service_pb2_grpc.OracleServicer):
         return service_pb2.UpdateTrialResponse(status=status_proto)
 
     def EndTrial(self, request, context):
-        status = trial_module.TrialStatus.from_proto(request.status)
-        self.oracle.end_trial(request.trial_id, status, request.message)
+        trial = trial_module.Trial.from_proto(request.trial)
+        self.oracle.end_trial(trial)
         return service_pb2.EndTrialResponse()
 
     def GetTrial(self, request, context):

--- a/keras_tuner/distribute/oracle_chief_test.py
+++ b/keras_tuner/distribute/oracle_chief_test.py
@@ -141,7 +141,8 @@ def test_end_trial(tmp_path):
             trial = client.create_trial(tuner_id)
             trial_id = trial.trial_id
             client.update_trial(trial_id, {"score": 1}, step=2)
-            client.end_trial(trial_id, "FAILED")
+            trial.status = "FAILED"
+            client.end_trial(trial)
             updated_trial = client.get_trial(trial_id)
             assert updated_trial.status == "FAILED"
 
@@ -172,7 +173,8 @@ def test_get_best_trials(tmp_path):
                 assert "b" in trial.hyperparameters.values
                 trial_id = trial.trial_id
                 client.update_trial(trial_id, {"score": score})
-                client.end_trial(trial_id)
+                trial.status = "COMPLETED"
+                client.end_trial(trial)
                 trial_scores[trial_id] = score
             best_trials = client.get_best_trials(3)
             best_scores = [t.score for t in best_trials]

--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -86,13 +86,10 @@ class OracleClient(object):
                 return trial_module.TrialStatus.from_proto(response.status)
         return "RUNNING"
 
-    def end_trial(self, trial_id, status="COMPLETED", message=None):
+    def end_trial(self, trial):
         if self.should_report:
-            status = trial_module.TrialStatus.to_proto(status)
             self.stub.EndTrial(
-                service_pb2.EndTrialRequest(
-                    trial_id=trial_id, status=status, message=message
-                ),
+                service_pb2.EndTrialRequest(trial=trial.to_proto()),
                 wait_for_ready=True,
             )
 

--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -84,7 +84,7 @@ class OracleClient(object):
             )
             if not self.multi_worker:
                 return trial_module.TrialStatus.from_proto(response.status)
-        return self.get_trial(trial_id)
+        return "RUNNING"
 
     def end_trial(self, trial):
         if self.should_report:

--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -84,7 +84,7 @@ class OracleClient(object):
             )
             if not self.multi_worker:
                 return trial_module.TrialStatus.from_proto(response.status)
-        return "RUNNING"
+        return self.get_trial(trial_id)
 
     def end_trial(self, trial):
         if self.should_report:

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -316,8 +316,7 @@ class BaseTuner(stateful.Stateful):
         if self.logger:
             self.logger.report_trial_state(trial.trial_id, trial.get_state())
 
-        self.oracle.end_trial(trial.trial_id, trial.status, trial.message)
-        self.oracle.update_space(trial.hyperparameters)
+        self.oracle.end_trial(trial)
         # Display needs the updated trial scored by the Oracle.
         self._display.on_trial_end(self.oracle.get_trial(trial.trial_id))
         self.save()

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -288,7 +288,9 @@ class Oracle(stateful.Stateful):
                 )
 
     def end_trial(self, trial):
-        """Record the measured objective for a set of parameter values.
+        """Logistics when a `Trial` finished running.
+
+        Record the `Trial` information and end the trial or send it for retry.
 
         Args:
             trial: The Trial to be ended. `trial.status` should be one of
@@ -303,7 +305,9 @@ class Oracle(stateful.Stateful):
                 self.ongoing_trials.pop(tuner_id)
                 break
 
-        # Update the self.trials with the given trial.
+        # To support parallel tuning, the information in the `trial` argument is
+        # synced back to the `Oracle`. Update the self.trials with the given
+        # trial.
         old_trial = self.trials[trial.trial_id]
         old_trial.hyperparameters = trial.hyperparameters
         old_trial.status = trial.status

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -305,6 +305,7 @@ class Oracle(stateful.Stateful):
 
         # Update the self.trials with the given trial.
         old_trial = self.trials[trial.trial_id]
+        old_trial.hyperparameters = trial.hyperparameters
         old_trial.status = trial.status
         old_trial.message = trial.message
         trial = old_trial

--- a/keras_tuner/protos/service.proto
+++ b/keras_tuner/protos/service.proto
@@ -47,13 +47,11 @@ message UpdateTrialRequest {
 }
 
 message UpdateTrialResponse {
-    keras_tuner.TrialStatus status = 1;
+    keras_tuner.Trial trial = 1;
 }
 
 message EndTrialRequest {
-    string trial_id = 1;
-    keras_tuner.TrialStatus status = 2;
-    string message = 3;
+    keras_tuner.Trial trial = 1;
 }
 
 message EndTrialResponse {}

--- a/keras_tuner/protos/service_pb2.py
+++ b/keras_tuner/protos/service_pb2.py
@@ -40,7 +40,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto3",
     serialized_options=None,
     serialized_pb=_b(
-        '\n keras_tuner/protos/service.proto\x12\x0bkeras_tuner\x1a$keras_tuner/protos/keras_tuner.proto"\x11\n\x0fGetSpaceRequest"I\n\x10GetSpaceResponse\x12\x35\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1c.keras_tuner.HyperParameters"K\n\x12UpdateSpaceRequest\x12\x35\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1c.keras_tuner.HyperParameters"\x15\n\x13UpdateSpaceResponse"&\n\x12\x43reateTrialRequest\x12\x10\n\x08tuner_id\x18\x01 \x01(\t"8\n\x13\x43reateTrialResponse\x12!\n\x05trial\x18\x01 \x01(\x0b\x32\x12.keras_tuner.Trial"\xa3\x01\n\x12UpdateTrialRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t\x12=\n\x07metrics\x18\x02 \x03(\x0b\x32,.keras_tuner.UpdateTrialRequest.MetricsEntry\x12\x0c\n\x04step\x18\x03 \x01(\x03\x1a.\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01:\x02\x38\x01"?\n\x13UpdateTrialResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.keras_tuner.TrialStatus"^\n\x0f\x45ndTrialRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t\x12(\n\x06status\x18\x02 \x01(\x0e\x32\x18.keras_tuner.TrialStatus\x12\x0f\n\x07message\x18\x03 \x01(\t"\x12\n\x10\x45ndTrialResponse"*\n\x14GetBestTrialsRequest\x12\x12\n\nnum_trials\x18\x01 \x01(\x03";\n\x15GetBestTrialsResponse\x12"\n\x06trials\x18\x01 \x03(\x0b\x32\x12.keras_tuner.Trial"#\n\x0fGetTrialRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t"5\n\x10GetTrialResponse\x12!\n\x05trial\x18\x01 \x01(\x0b\x32\x12.keras_tuner.Trial2\xbf\x04\n\x06Oracle\x12I\n\x08GetSpace\x12\x1c.keras_tuner.GetSpaceRequest\x1a\x1d.keras_tuner.GetSpaceResponse"\x00\x12R\n\x0bUpdateSpace\x12\x1f.keras_tuner.UpdateSpaceRequest\x1a .keras_tuner.UpdateSpaceResponse"\x00\x12R\n\x0b\x43reateTrial\x12\x1f.keras_tuner.CreateTrialRequest\x1a .keras_tuner.CreateTrialResponse"\x00\x12R\n\x0bUpdateTrial\x12\x1f.keras_tuner.UpdateTrialRequest\x1a .keras_tuner.UpdateTrialResponse"\x00\x12I\n\x08\x45ndTrial\x12\x1c.keras_tuner.EndTrialRequest\x1a\x1d.keras_tuner.EndTrialResponse"\x00\x12X\n\rGetBestTrials\x12!.keras_tuner.GetBestTrialsRequest\x1a".keras_tuner.GetBestTrialsResponse"\x00\x12I\n\x08GetTrial\x12\x1c.keras_tuner.GetTrialRequest\x1a\x1d.keras_tuner.GetTrialResponse"\x00\x62\x06proto3'
+        '\n keras_tuner/protos/service.proto\x12\x0bkeras_tuner\x1a$keras_tuner/protos/keras_tuner.proto"\x11\n\x0fGetSpaceRequest"I\n\x10GetSpaceResponse\x12\x35\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1c.keras_tuner.HyperParameters"K\n\x12UpdateSpaceRequest\x12\x35\n\x0fhyperparameters\x18\x01 \x01(\x0b\x32\x1c.keras_tuner.HyperParameters"\x15\n\x13UpdateSpaceResponse"&\n\x12\x43reateTrialRequest\x12\x10\n\x08tuner_id\x18\x01 \x01(\t"8\n\x13\x43reateTrialResponse\x12!\n\x05trial\x18\x01 \x01(\x0b\x32\x12.keras_tuner.Trial"\xa3\x01\n\x12UpdateTrialRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t\x12=\n\x07metrics\x18\x02 \x03(\x0b\x32,.keras_tuner.UpdateTrialRequest.MetricsEntry\x12\x0c\n\x04step\x18\x03 \x01(\x03\x1a.\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01:\x02\x38\x01"?\n\x13UpdateTrialResponse\x12(\n\x06status\x18\x01 \x01(\x0e\x32\x18.keras_tuner.TrialStatus"4\n\x0f\x45ndTrialRequest\x12!\n\x05trial\x18\x01 \x01(\x0b\x32\x12.keras_tuner.Trial"\x12\n\x10\x45ndTrialResponse"*\n\x14GetBestTrialsRequest\x12\x12\n\nnum_trials\x18\x01 \x01(\x03";\n\x15GetBestTrialsResponse\x12"\n\x06trials\x18\x01 \x03(\x0b\x32\x12.keras_tuner.Trial"#\n\x0fGetTrialRequest\x12\x10\n\x08trial_id\x18\x01 \x01(\t"5\n\x10GetTrialResponse\x12!\n\x05trial\x18\x01 \x01(\x0b\x32\x12.keras_tuner.Trial2\xbf\x04\n\x06Oracle\x12I\n\x08GetSpace\x12\x1c.keras_tuner.GetSpaceRequest\x1a\x1d.keras_tuner.GetSpaceResponse"\x00\x12R\n\x0bUpdateSpace\x12\x1f.keras_tuner.UpdateSpaceRequest\x1a .keras_tuner.UpdateSpaceResponse"\x00\x12R\n\x0b\x43reateTrial\x12\x1f.keras_tuner.CreateTrialRequest\x1a .keras_tuner.CreateTrialResponse"\x00\x12R\n\x0bUpdateTrial\x12\x1f.keras_tuner.UpdateTrialRequest\x1a .keras_tuner.UpdateTrialResponse"\x00\x12I\n\x08\x45ndTrial\x12\x1c.keras_tuner.EndTrialRequest\x1a\x1d.keras_tuner.EndTrialResponse"\x00\x12X\n\rGetBestTrials\x12!.keras_tuner.GetBestTrialsRequest\x1a".keras_tuner.GetBestTrialsResponse"\x00\x12I\n\x08GetTrial\x12\x1c.keras_tuner.GetTrialRequest\x1a\x1d.keras_tuner.GetTrialResponse"\x00\x62\x06proto3'
     ),
     dependencies=[
         keras__tuner_dot_protos_dot_keras__tuner__pb2.DESCRIPTOR,
@@ -424,51 +424,15 @@ _ENDTRIALREQUEST = _descriptor.Descriptor(
     containing_type=None,
     fields=[
         _descriptor.FieldDescriptor(
-            name="trial_id",
-            full_name="keras_tuner.EndTrialRequest.trial_id",
+            name="trial",
+            full_name="keras_tuner.EndTrialRequest.trial",
             index=0,
             number=1,
-            type=9,
-            cpp_type=9,
+            type=11,
+            cpp_type=10,
             label=1,
             has_default_value=False,
-            default_value=_b("").decode("utf-8"),
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="status",
-            full_name="keras_tuner.EndTrialRequest.status",
-            index=1,
-            number=2,
-            type=14,
-            cpp_type=8,
-            label=1,
-            has_default_value=False,
-            default_value=0,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-        ),
-        _descriptor.FieldDescriptor(
-            name="message",
-            full_name="keras_tuner.EndTrialRequest.message",
-            index=2,
-            number=3,
-            type=9,
-            cpp_type=9,
-            label=1,
-            has_default_value=False,
-            default_value=_b("").decode("utf-8"),
+            default_value=None,
             message_type=None,
             enum_type=None,
             containing_type=None,
@@ -487,7 +451,7 @@ _ENDTRIALREQUEST = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=610,
-    serialized_end=704,
+    serialized_end=662,
 )
 
 
@@ -506,8 +470,8 @@ _ENDTRIALRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=706,
-    serialized_end=724,
+    serialized_start=664,
+    serialized_end=682,
 )
 
 
@@ -545,8 +509,8 @@ _GETBESTTRIALSREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=726,
-    serialized_end=768,
+    serialized_start=684,
+    serialized_end=726,
 )
 
 
@@ -584,8 +548,8 @@ _GETBESTTRIALSRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=770,
-    serialized_end=829,
+    serialized_start=728,
+    serialized_end=787,
 )
 
 
@@ -623,8 +587,8 @@ _GETTRIALREQUEST = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=831,
-    serialized_end=866,
+    serialized_start=789,
+    serialized_end=824,
 )
 
 
@@ -662,8 +626,8 @@ _GETTRIALRESPONSE = _descriptor.Descriptor(
     syntax="proto3",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=868,
-    serialized_end=921,
+    serialized_start=826,
+    serialized_end=879,
 )
 
 _GETSPACERESPONSE.fields_by_name[
@@ -683,8 +647,8 @@ _UPDATETRIALRESPONSE.fields_by_name[
     "status"
 ].enum_type = keras__tuner_dot_protos_dot_keras__tuner__pb2._TRIALSTATUS
 _ENDTRIALREQUEST.fields_by_name[
-    "status"
-].enum_type = keras__tuner_dot_protos_dot_keras__tuner__pb2._TRIALSTATUS
+    "trial"
+].message_type = keras__tuner_dot_protos_dot_keras__tuner__pb2._TRIAL
 _GETBESTTRIALSRESPONSE.fields_by_name[
     "trials"
 ].message_type = keras__tuner_dot_protos_dot_keras__tuner__pb2._TRIAL
@@ -880,8 +844,8 @@ _ORACLE = _descriptor.ServiceDescriptor(
     file=DESCRIPTOR,
     index=0,
     serialized_options=None,
-    serialized_start=924,
-    serialized_end=1499,
+    serialized_start=882,
+    serialized_end=1457,
     methods=[
         _descriptor.MethodDescriptor(
             name="GetSpace",

--- a/keras_tuner/tuners/bayesian_test.py
+++ b/keras_tuner/tuners/bayesian_test.py
@@ -88,7 +88,8 @@ def test_bayesian_oracle(tmp_path):
     for i in range(5):
         trial = oracle.create_trial(str(i))
         oracle.update_trial(trial.trial_id, {"score": i})
-        oracle.end_trial(trial.trial_id, "COMPLETED")
+        trial.status = "COMPLETED"
+        oracle.end_trial(trial)
 
 
 def test_bayesian_oracle_with_zero_y(tmp_path):
@@ -108,7 +109,8 @@ def test_bayesian_oracle_with_zero_y(tmp_path):
     for i in range(5):
         trial = oracle.create_trial(str(i))
         oracle.update_trial(trial.trial_id, {"score": 0})
-        oracle.end_trial(trial.trial_id, "COMPLETED")
+        trial.status = "COMPLETED"
+        oracle.end_trial(trial)
 
 
 def test_bayesian_dynamic_space(tmp_path):
@@ -148,7 +150,8 @@ def test_bayesian_save_reload(tmp_path):
     for _ in range(3):
         trial = oracle.create_trial("tuner_id")
         oracle.update_trial(trial.trial_id, {"score": 1.0})
-        oracle.end_trial(trial.trial_id, "COMPLETED")
+        trial.status = "COMPLETED"
+        oracle.end_trial(trial)
 
     oracle.save()
     oracle = bo_module.BayesianOptimizationOracle(
@@ -162,7 +165,8 @@ def test_bayesian_save_reload(tmp_path):
     for _ in range(3):
         trial = oracle.create_trial("tuner_id")
         oracle.update_trial(trial.trial_id, {"score": 1.0})
-        oracle.end_trial(trial.trial_id, "COMPLETED")
+        trial.status = "COMPLETED"
+        oracle.end_trial(trial)
 
     assert len(oracle.trials) == 6
 
@@ -358,7 +362,8 @@ def test_distributed_optimization(tmp_path):
                 trial.trial_id, {"score": evaluate(trial.hyperparameters)}
             )
         for trial in trials:
-            oracle.end_trial(trial.trial_id, "COMPLETED")
+            trial.status = "COMPLETED"
+            oracle.end_trial(trial)
 
     atol, rtol = 1e-1, 1e-1
     best_trial = oracle.get_best_trials()[0]
@@ -403,7 +408,8 @@ def test_interleaved_distributed_optimization(tmp_path):
     oracle.update_trial(
         trial_1.trial_id, {"score": evaluate(trial_1.hyperparameters)}
     )
-    oracle.end_trial(trial_1.trial_id, "COMPLETED")
+    trial_1.status = "COMPLETED"
+    oracle.end_trial(trial_1)
 
     # tuner_0 request a new trial (trial_3)
     trial_3 = oracle.create_trial("tuner_0")
@@ -412,7 +418,8 @@ def test_interleaved_distributed_optimization(tmp_path):
     oracle.update_trial(
         trial_2.trial_id, {"score": evaluate(trial_2.hyperparameters)}
     )
-    oracle.end_trial(trial_2.trial_id, "COMPLETED")
+    trial_2.status = "COMPLETED"
+    oracle.end_trial(trial_2)
 
     # tuner_1 requests the final new trial (trial_4)
     # the Bayesian optimizer will use ongoing trial_3 to hallucinate
@@ -422,12 +429,14 @@ def test_interleaved_distributed_optimization(tmp_path):
     oracle.update_trial(
         trial_3.trial_id, {"score": evaluate(trial_3.hyperparameters)}
     )
-    oracle.end_trial(trial_3.trial_id, "COMPLETED")
+    trial_3.status = "COMPLETED"
+    oracle.end_trial(trial_3)
 
     # tuner_1 finishes trial_4
     oracle.update_trial(
         trial_4.trial_id, {"score": evaluate(trial_4.hyperparameters)}
     )
-    oracle.end_trial(trial_4.trial_id, "COMPLETED")
+    trial_4.status = "COMPLETED"
+    oracle.end_trial(trial_4)
 
     assert True

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -307,14 +307,14 @@ class GridSearchOracle(oracle_module.Oracle):
         hps.ensure_active_values()
         return hps.values if bumped_value else None
 
-    def end_trial(self, trial_id, status="COMPLETED", message=None):
-        super().end_trial(trial_id=trial_id, status=status, message=message)
+    def end_trial(self, trial):
+        super().end_trial(trial)
         # It is OK for a trial_id to be pushed into _populate_next multiple
         # times. It will be skipped during _populate_space if its next
         # combination has been tried.
 
         # For not blocking _populate_space, we push it regardless of the status.
-        self._populate_next.append(trial_id)
+        self._populate_next.append(trial.trial_id)
 
 
 class GridSearch(tuner_module.Tuner):

--- a/keras_tuner/tuners/gridsearch_test.py
+++ b/keras_tuner/tuners/gridsearch_test.py
@@ -170,9 +170,8 @@ def test_exhaust_trials_in_between_before_the_latter_finishes(tmp_path):
         oracle.update_trial(
             trial_id=trial.trial_id, metrics={oracle.objective.name: random.random()}
         )
-        oracle.end_trial(
-            trial_id=trial.trial_id, status=trial_module.TrialStatus.COMPLETED
-        )
+        trial.status = trial_module.TrialStatus.COMPLETED
+        oracle.end_trial(trial)
 
     trial_1 = oracle.create_trial(tuner_id="1")
     assert trial_1.status == trial_module.TrialStatus.RUNNING

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -82,7 +82,8 @@ def test_hyperband_oracle_one_sweep_single_thread(tmp_path):
                 assert trial.status == "RUNNING"
                 score += 1
                 oracle.update_trial(trial.trial_id, {"score": score})
-                oracle.end_trial(trial.trial_id, status="COMPLETED")
+                trial.status = "COMPLETED"
+                oracle.end_trial(trial)
             assert len(oracle._brackets[0]["rounds"][round_num]) == oracle._get_size(
                 bracket_num, round_num
             )
@@ -130,7 +131,8 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
 
     for t in round0_trials:
         oracle.update_trial(t.trial_id, {"score": 1})
-        oracle.end_trial(t.trial_id, "COMPLETED")
+        t.status = "COMPLETED"
+        oracle.end_trial(t)
 
     round1_trials = []
     for i in range(4):
@@ -148,7 +150,8 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
 
     for t in round1_trials:
         oracle.update_trial(t.trial_id, {"score": 1})
-        oracle.end_trial(t.trial_id, "COMPLETED")
+        t.status = "COMPLETED"
+        oracle.end_trial(t)
 
     # Only one trial runs in round 2.
     round2_trial = oracle.create_trial("tuner0")
@@ -160,7 +163,8 @@ def test_hyperband_oracle_one_sweep_parallel(tmp_path):
     assert t.status == "IDLE"
 
     oracle.update_trial(round2_trial.trial_id, {"score": 1})
-    oracle.end_trial(round2_trial.trial_id, "COMPLETED")
+    round2_trial.status = "COMPLETED"
+    oracle.end_trial(round2_trial)
 
     t = oracle.create_trial("tuner10")
     assert t.status == "STOPPED", oracle._current_sweep
@@ -240,7 +244,8 @@ def test_hyperband_load_weights(tmp_path):
             tuner_utils.convert_to_metrics_dict(result, tuner.oracle.objective),
             tuner_utils.get_best_step(result, tuner.oracle.objective),
         )
-        tuner.oracle.end_trial(trial.trial_id, "COMPLETED")
+        trial.status = "COMPLETED"
+        tuner.oracle.end_trial(trial)
 
     # ensure the model run in round 1 is loaded from the best model in round 0
     trial = tuner.oracle.create_trial("tuner0")


### PR DESCRIPTION
Some newly appeared `HyperParameter`s during a `Trial` needs to be write back to the corresponding `Trial` in `Oracle`.
It is fine for single machine settings, where the same `Trial` object are shared between the `Oracle` and the `Tuner`.
However, for parallel tuning, the `Trial` are passed to the workers through gRPC. The new `HyperParameter`s appeared on the worker side are not updated on the `Oracle` side.

We use `Oracle.update_space(hp)` to update the newly appeared `HyperParameter`s before this PR, which does only accepts a `HyperParameters` object, no `trial_id` to identify the corresponding `Trial`.

We propose changing the current signature of `Oracle.end_trial(trial_id, status, message)` to `Oracle.end_trial(trial)`. The `trial` argument contains all the information in old signature arguments and contains the `HyperParameters` object, which contains the newly appeared `HyperParameter`s we need to write back.

It is more consistent with `Oracle.create_trial()` logically. `Oracle.create_trial()` returns a `Trial`. After the trial, the updated `Trial` is reported back with `Oracle.end_trial(Trial)`.

In this way, we also do not need to call `Oracle.update_space()` in the `Tuner` class since it can be done during the `Oracle.end_trial()`.

It also makes the code cleaner, from:

https://github.com/keras-team/keras-tuner/blob/aec47050039483c78ec2cc6c065b4e20ef68e76b/keras_tuner/engine/base_tuner.py#L319-L320

to:

```py
 self.oracle.end_trial(trial)
```