### PR TITLE
Resolves #812

### DIFF
--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -23,7 +23,7 @@ from keras_tuner.protos import service_pb2
 from keras_tuner.protos import service_pb2_grpc
 
 
-class OracleClient(object):
+class OracleClient:
     """Wraps an `Oracle` on a worker to send requests to the chief."""
 
     def __init__(self, oracle):

--- a/keras_tuner/engine/base_tuner_test.py
+++ b/keras_tuner/engine/base_tuner_test.py
@@ -47,7 +47,7 @@ def test_base_tuner(tmp_path):
             return models
 
     def build_model(hp):
-        class MyModel(object):
+        class MyModel:
             def __init__(self):
                 self.factor = hp.Float("a", 0, 10)
 

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -24,7 +24,7 @@ from keras_tuner.protos import keras_tuner_pb2
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Condition(object):
+class Condition:
     """Abstract condition for a conditional hyperparameter.
 
     Subclasses of this object can be passed to a `HyperParameter` to specify

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -16,7 +16,7 @@
 from keras_tuner import errors
 
 
-class HyperModel(object):
+class HyperModel:
     """Defines a search space of models.
 
     A search space is a collection of models. The `build` function will build

--- a/keras_tuner/engine/hyperparameters/hyperparameter.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameter.py
@@ -18,7 +18,7 @@ from keras_tuner import utils
 from keras_tuner.engine import conditions as conditions_mod
 
 
-class HyperParameter(object):
+class HyperParameter:
     """Hyperparameter base class.
 
     A `HyperParameter` instance is uniquely identified by its `name` and

--- a/keras_tuner/engine/hyperparameters/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameters.py
@@ -25,7 +25,7 @@ from keras_tuner.engine.hyperparameters import hyperparameter as hp_module
 from keras_tuner.protos import keras_tuner_pb2
 
 
-class HyperParameters(object):
+class HyperParameters:
     """Container for both a hyperparameter space, and current values.
 
     A `HyperParameters` instance can be pass to `HyperModel.build(hp)` as an

--- a/keras_tuner/engine/logger.py
+++ b/keras_tuner/engine/logger.py
@@ -27,7 +27,7 @@ AUTH_ERROR = 3
 UPLOAD_ERROR = 4
 
 
-class Logger(object):
+class Logger:
     def register_tuner(self, tuner_state):
         """Informs the logger that a new search is starting."""
         raise NotImplementedError

--- a/keras_tuner/engine/logger_test.py
+++ b/keras_tuner/engine/logger_test.py
@@ -20,11 +20,11 @@ from tensorflow import keras
 import keras_tuner
 
 
-class OkResponse(object):
+class OkResponse:
     ok = True
 
 
-class MockPost(object):
+class MockPost:
     def __init__(self):
         self.url_calls = []
 

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -20,7 +20,7 @@ from tensorflow import keras
 from keras_tuner.protos import keras_tuner_pb2
 
 
-class MetricObservation(object):
+class MetricObservation:
     """Metric value at a given step of training across multiple executions.
 
     If the model is trained multiple
@@ -73,7 +73,7 @@ class MetricObservation(object):
         return cls(value=list(proto.value), step=proto.step)
 
 
-class MetricHistory(object):
+class MetricHistory:
     """Record of multiple executions of a single metric.
 
     It contains a collection of `MetricObservation` instances.
@@ -176,7 +176,7 @@ class MetricHistory(object):
         return instance
 
 
-class MetricsTracker(object):
+class MetricsTracker:
     """Record of the values of multiple executions of all metrics.
 
     It contains `MetricHistory` instances for the metrics.

--- a/keras_tuner/engine/stateful.py
+++ b/keras_tuner/engine/stateful.py
@@ -19,7 +19,7 @@ import json
 import tensorflow as tf
 
 
-class Stateful(object):
+class Stateful:
     """The base class for saving and restoring the state.
 
     The functionalities in this class is for the user to resume a previously

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -31,7 +31,7 @@ from keras_tuner.engine import hyperparameters as hp_module
 from keras_tuner.engine import objective as obj_module
 
 
-class TunerStats(object):
+class TunerStats:
     """Track tuner statistics."""
 
     def __init__(self):
@@ -94,7 +94,7 @@ class TunerCallback(keras.callbacks.Callback):
 
 
 # TODO: Add more extensive display.
-class Display(object):
+class Display:
     def __init__(self, oracle, verbose=1):
         self.verbose = verbose
         self.oracle = oracle

--- a/keras_tuner/protos/service_pb2_grpc.py
+++ b/keras_tuner/protos/service_pb2_grpc.py
@@ -20,7 +20,7 @@ from keras_tuner.protos import (
 )
 
 
-class OracleStub(object):
+class OracleStub:
     # missing associated documentation comment in .proto file
     pass
 
@@ -67,7 +67,7 @@ class OracleStub(object):
         )
 
 
-class OracleServicer(object):
+class OracleServicer:
     # missing associated documentation comment in .proto file
     pass
 


### PR DESCRIPTION
All BaseClass definitions have been updated to Python3 style. 
Previously, all BaseClasses were defined in a Python2 style having an explicit inheritance from object. This is no longer recommended with Python3. 
As a result, all BaseClass definitions were changed to Python3 style.