### PR TITLE
Resolves #813

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -178,7 +178,7 @@ class HyperImageAugment(hypermodel.HyperModel):
             # `randaug_count` is set to 0.
             self.model_name = "image_augment"
 
-        super(HyperImageAugment, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def build(self, hp):
         if self.input_tensor is not None:

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -115,7 +115,7 @@ class HyperEfficientNet(hypermodel.HyperModel):
         self.classes = classes
         self.augmentation_model = augmentation_model
 
-        super(HyperEfficientNet, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def build(self, hp):
 

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -53,7 +53,7 @@ class HyperResNet(hypermodel.HyperModel):
         **kwargs,
     ):
 
-        super(HyperResNet, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if include_top and classes is None:
             raise ValueError("You must specify `classes` when " "`include_top=True`")
 

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -49,7 +49,7 @@ class HyperXception(hypermodel.HyperModel):
         classes=None,
         **kwargs,
     ):
-        super(HyperXception, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         if include_top and classes is None:
             raise ValueError("You must specify `classes` when " "`include_top=True`")
 

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -427,13 +427,13 @@ class BaseTuner(stateful.Stateful):
         """Saves this object to its project directory."""
         if not dist_utils.has_chief_oracle():
             self.oracle.save()
-        super(BaseTuner, self).save(self._get_tuner_fname())
+        super().save(self._get_tuner_fname())
 
     def reload(self):
         """Reloads this object from its project directory."""
         if not dist_utils.has_chief_oracle():
             self.oracle.reload()
-        super(BaseTuner, self).reload(self._get_tuner_fname())
+        super().reload(self._get_tuner_fname())
 
     @property
     def project_dir(self):

--- a/keras_tuner/engine/hypermodel.py
+++ b/keras_tuner/engine/hypermodel.py
@@ -146,7 +146,7 @@ class DefaultHyperModel(HyperModel):
     """Produces HyperModel from a model building function."""
 
     def __init__(self, build, name=None, tunable=True):
-        super(DefaultHyperModel, self).__init__(name=name)
+        super().__init__(name=name)
         self.build = build
 
 

--- a/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
@@ -28,7 +28,7 @@ class Boolean(hyperparameter.HyperParameter):
     """
 
     def __init__(self, name, default=False, **kwargs):
-        super(Boolean, self).__init__(name=name, default=default, **kwargs)
+        super().__init__(name=name, default=default, **kwargs)
         if default not in {True, False}:
             raise ValueError(
                 f"`default` must be a Python boolean. You passed: default={default}"

--- a/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
@@ -38,7 +38,7 @@ class Choice(hyperparameter.HyperParameter):
     """
 
     def __init__(self, name, values, ordered=None, default=None, **kwargs):
-        super(Choice, self).__init__(name=name, default=default, **kwargs)
+        super().__init__(name=name, default=default, **kwargs)
         if not values:
             raise ValueError("`values` must be provided for `Choice`.")
 
@@ -104,7 +104,7 @@ class Choice(hyperparameter.HyperParameter):
         return hp_utils.index_to_prob(self._values.index(value), len(self._values))
 
     def get_config(self):
-        config = super(Choice, self).get_config()
+        config = super().get_config()
         config["values"] = self._values
         config["ordered"] = self.ordered
         return config

--- a/keras_tuner/engine/hyperparameters/hp_types/fixed_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/fixed_hp.py
@@ -29,7 +29,7 @@ class Fixed(hyperparameter.HyperParameter):
     """
 
     def __init__(self, name, value, **kwargs):
-        super(Fixed, self).__init__(name=name, default=value, **kwargs)
+        super().__init__(name=name, default=value, **kwargs)
         self.name = name
 
         if isinstance(value, bool):
@@ -63,7 +63,7 @@ class Fixed(hyperparameter.HyperParameter):
         return self.value
 
     def get_config(self):
-        config = super(Fixed, self).get_config()
+        config = super().get_config()
         config["name"] = self.name
         config.pop("default")
         config["value"] = self.value

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
@@ -125,7 +125,7 @@ class Float(numerical.Numerical):
         return self._to_prob_with_step(value)
 
     def get_config(self):
-        config = super(Float, self).get_config()
+        config = super().get_config()
         config["min_value"] = self.min_value
         config["max_value"] = self.max_value
         config["step"] = self.step

--- a/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
@@ -147,7 +147,7 @@ class Int(numerical.Numerical):
         return self._default if self._default is not None else self.min_value
 
     def get_config(self):
-        config = super(Int, self).get_config()
+        config = super().get_config()
         config["min_value"] = self.min_value
         config["max_value"] = self.max_value
         config["step"] = self.step

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -488,7 +488,7 @@ class Oracle(stateful.Stateful):
     def save(self):
         if self.should_report:
             # `self.trials` are saved in their own, Oracle-agnostic files.
-            super(Oracle, self).save(self._get_oracle_fname())
+            super().save(self._get_oracle_fname())
 
     def reload(self):
         # Reload trials from their own files.
@@ -502,7 +502,7 @@ class Oracle(stateful.Stateful):
             trial = trial_module.Trial.from_state(trial_state)
             self.trials[trial.trial_id] = trial
         try:
-            super(Oracle, self).reload(self._get_oracle_fname())
+            super().reload(self._get_oracle_fname())
         except KeyError as e:
             raise RuntimeError(
                 "Error reloading `Oracle` from existing project. "

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -108,7 +108,7 @@ class Tuner(base_tuner.BaseTuner):
                 "using a `HyperModel` instance."
             )
 
-        super(Tuner, self).__init__(
+        super().__init__(
             oracle=oracle,
             hypermodel=hypermodel,
             directory=directory,
@@ -353,7 +353,7 @@ class Tuner(base_tuner.BaseTuner):
             List of trained model instances sorted from the best to the worst.
         """
         # Method only exists in this class for the docstring override.
-        return super(Tuner, self).get_best_models(num_models)
+        return super().get_best_models(num_models)
 
     def _deepcopy_callbacks(self, callbacks):
         try:

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -58,7 +58,7 @@ def build_model(hp):
 
 class MockModel(keras.Model):
     def __init__(self, full_history):
-        super(MockModel, self).__init__()
+        super().__init__()
         self.full_history = full_history
         self.callbacks = []
         self.optimizer = True

--- a/keras_tuner/engine/tuner_utils.py
+++ b/keras_tuner/engine/tuner_utils.py
@@ -76,7 +76,7 @@ def get_max_epochs_and_steps(fit_args, fit_kwargs):
 
 class TunerCallback(keras.callbacks.Callback):
     def __init__(self, tuner, trial):
-        super(TunerCallback, self).__init__()
+        super().__init__()
         self.tuner = tuner
         self.trial = trial
 

--- a/keras_tuner/test_utils/mock_distribute.py
+++ b/keras_tuner/test_utils/mock_distribute.py
@@ -26,7 +26,7 @@ class ExceptionStoringThread(threading.Thread):
     def run(self):
         self.raised_exception = None
         try:
-            super(ExceptionStoringThread, self).run()
+            super().run()
         except BaseException:
             self.raised_exception = sys.exc_info()
 

--- a/keras_tuner/tuners/bayesian.py
+++ b/keras_tuner/tuners/bayesian.py
@@ -107,7 +107,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
                 "Please install scikit-learn (sklearn) before using the "
                 "`BayesianOptimization`."
             )
-        super(BayesianOptimizationOracle, self).__init__(
+        super().__init__(
             objective=objective,
             max_trials=max_trials,
             hyperparameters=hyperparameters,
@@ -199,7 +199,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         return {"status": trial_module.TrialStatus.RUNNING, "values": values}
 
     def get_state(self):
-        state = super(BayesianOptimizationOracle, self).get_state()
+        state = super().get_state()
         state.update(
             {
                 "num_initial_points": self.num_initial_points,
@@ -210,7 +210,7 @@ class BayesianOptimizationOracle(oracle_module.Oracle):
         return state
 
     def set_state(self, state):
-        super(BayesianOptimizationOracle, self).set_state(state)
+        super().set_state(state)
         self.num_initial_points = state["num_initial_points"]
         self.alpha = state["alpha"]
         self.beta = state["beta"]
@@ -379,7 +379,4 @@ class BayesianOptimization(tuner_module.Tuner):
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
         )
-        super(
-            BayesianOptimization,
-            self,
-        ).__init__(oracle=oracle, hypermodel=hypermodel, **kwargs)
+        super().__init__(oracle=oracle, hypermodel=hypermodel, **kwargs)

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -129,7 +129,7 @@ class GridSearchOracle(oracle_module.Oracle):
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
     ):
-        super(GridSearchOracle, self).__init__(
+        super().__init__(
             objective=objective,
             max_trials=max_trials,
             hyperparameters=hyperparameters,
@@ -408,4 +408,4 @@ class GridSearch(tuner_module.Tuner):
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
         )
-        super(GridSearch, self).__init__(oracle, hypermodel, **kwargs)
+        super().__init__(oracle, hypermodel, **kwargs)

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -391,9 +391,7 @@ class Hyperband(tuner_module.Tuner):
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
         )
-        super().__init__(
-            oracle=oracle, hypermodel=hypermodel, **kwargs
-        )
+        super().__init__(oracle=oracle, hypermodel=hypermodel, **kwargs)
 
     def run_trial(self, trial, *fit_args, **fit_kwargs):
         hp = trial.hyperparameters

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -110,7 +110,7 @@ class HyperbandOracle(oracle_module.Oracle):
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
     ):
-        super(HyperbandOracle, self).__init__(
+        super().__init__(
             objective=objective,
             hyperparameters=hyperparameters,
             allow_new_entries=allow_new_entries,
@@ -280,7 +280,7 @@ class HyperbandOracle(oracle_module.Oracle):
         return brackets
 
     def get_state(self):
-        state = super(HyperbandOracle, self).get_state()
+        state = super().get_state()
         state.update(
             {
                 "hyperband_iterations": self.hyperband_iterations,
@@ -295,7 +295,7 @@ class HyperbandOracle(oracle_module.Oracle):
         return state
 
     def set_state(self, state):
-        super(HyperbandOracle, self).set_state(state)
+        super().set_state(state)
         self.hyperband_iterations = state["hyperband_iterations"]
         self.max_epochs = state["max_epochs"]
         self.min_epochs = state["min_epochs"]
@@ -391,7 +391,7 @@ class Hyperband(tuner_module.Tuner):
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
         )
-        super(Hyperband, self).__init__(
+        super().__init__(
             oracle=oracle, hypermodel=hypermodel, **kwargs
         )
 
@@ -400,10 +400,10 @@ class Hyperband(tuner_module.Tuner):
         if "tuner/epochs" in hp.values:
             fit_kwargs["epochs"] = hp.values["tuner/epochs"]
             fit_kwargs["initial_epoch"] = hp.values["tuner/initial_epoch"]
-        return super(Hyperband, self).run_trial(trial, *fit_args, **fit_kwargs)
+        return super().run_trial(trial, *fit_args, **fit_kwargs)
 
     def _build_hypermodel(self, hp):
-        model = super(Hyperband, self)._build_hypermodel(hp)
+        model = super()._build_hypermodel(hp)
         if "tuner/trial_id" in hp.values:
             trial_id = hp.values["tuner/trial_id"]
             # Load best checkpoint from this trial.

--- a/keras_tuner/tuners/randomsearch.py
+++ b/keras_tuner/tuners/randomsearch.py
@@ -67,7 +67,7 @@ class RandomSearchOracle(oracle_module.Oracle):
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
     ):
-        super(RandomSearchOracle, self).__init__(
+        super().__init__(
             objective=objective,
             max_trials=max_trials,
             hyperparameters=hyperparameters,
@@ -164,4 +164,4 @@ class RandomSearch(tuner_module.Tuner):
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
         )
-        super(RandomSearch, self).__init__(oracle, hypermodel, **kwargs)
+        super().__init__(oracle, hypermodel, **kwargs)

--- a/keras_tuner/tuners/randomsearch_test.py
+++ b/keras_tuner/tuners/randomsearch_test.py
@@ -37,7 +37,7 @@ def test_update_space(tmp_path):
 
     class MyRandomSearch(randomsearch.RandomSearchOracle):
         def populate_space(self, trial_id):
-            result = super(MyRandomSearch, self).populate_space(trial_id)
+            result = super().populate_space(trial_id)
             if "values" in result:
                 result["values"]["layers"] = 2
             return result


### PR DESCRIPTION
Resolves #813

All super() class call styles have been updated to Python3 style. 
Previously, all super() classes were called in a Python2 style passing the inheriting class and self as arguments to super(). This is no longer recommended with Python3. 
As a result, all super() class calls were changed to Python3 style.