### PR TITLE
Bug fix for using concrete optimizer to override compile arg

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -42,3 +42,5 @@
   argument for hyperparameters. This is now fixed.
 * `num_initial_points` of the `BayesianOptimization` should defaults to `3 *
   dimension`, but it defaults to 2. This is now fixed.
+* It would through an error when using a concrete Keras optimizer object to
+  override the `HyperModel` compile arg. This is now fixed.

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -47,10 +47,10 @@ class Tuner(base_tuner.BaseTuner):
             `self.hypermodel`.
         max_model_size: Integer, maximum number of scalars in the parameters of
             a model. Models larger than this are rejected.
-        optimizer: Optional `Optimizer` instance.  May be used to override the
-            `optimizer` argument in the `compile` step for the models. If the
-            hypermodel does not compile the models it generates, then this
-            argument must be specified.
+        optimizer: Optional optimizer. It is used to override the `optimizer`
+            argument in the `compile` step for the models. If the hypermodel
+            does not compile the models it generates, then this argument must be
+            specified.
         loss: Optional loss. May be used to override the `loss` argument in the
             `compile` step for the models. If the hypermodel does not compile
             the models it generates, then this argument must be specified.
@@ -176,8 +176,12 @@ class Tuner(base_tuner.BaseTuner):
                 if self.loss:
                     compile_kwargs["loss"] = self.loss
                 if self.optimizer:
-                    optimizer = keras.optimizers.deserialize(
-                        keras.optimizers.serialize(self.optimizer)
+                    optimizer = (
+                        self.optimizer
+                        if isinstance(self.optimizer, str)
+                        else keras.optimizers.deserialize(
+                            keras.optimizers.serialize(self.optimizer)
+                        )
                     )
                     compile_kwargs["optimizer"] = optimizer
                 if self.metrics:

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -176,7 +176,10 @@ class Tuner(base_tuner.BaseTuner):
                 if self.loss:
                     compile_kwargs["loss"] = self.loss
                 if self.optimizer:
-                    compile_kwargs["optimizer"] = self.optimizer
+                    optimizer = keras.optimizers.deserialize(
+                        keras.optimizers.serialize(self.optimizer)
+                    )
+                    compile_kwargs["optimizer"] = optimizer
                 if self.metrics:
                     compile_kwargs["metrics"] = self.metrics
                 model.compile(**compile_kwargs)

--- a/keras_tuner/engine/tuner_test.py
+++ b/keras_tuner/engine/tuner_test.py
@@ -455,6 +455,22 @@ def test_override_compile(tmp_path):
     assert model.loss == "mse"
 
 
+def test_override_optimizer_with_actual_optimizer_object(tmp_path):
+    tuner = keras_tuner.tuners.RandomSearch(
+        build_model,
+        objective="val_loss",
+        max_trials=4,
+        optimizer=keras.optimizers.Adam(0.01),
+        directory=tmp_path,
+    )
+    tuner.search(
+        x=TRAIN_INPUTS,
+        y=TRAIN_TARGETS,
+        epochs=2,
+        validation_data=(VAL_INPUTS, VAL_TARGETS),
+    )
+
+
 def test_static_space(tmp_path):
     def build_model_static(hp):
         inputs = keras.Input(shape=(INPUT_DIM,))


### PR DESCRIPTION
The optimizer passed to the `Tuner` would be used in the `.compile()` function call to multiple Keras models, which causes bugs. We want to a new optimizer with the exact same config as the one passed by the user for each new Keras model, so we serialize and deserialize the optimizer to get a new copy.