### PR TITLE
clean up reloading for parallel tuning

### DIFF
--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -46,7 +46,6 @@ class OracleClient:
             "max_trials",
             "allow_new_entries",
             "tune_new_entries",
-            "trials",
         }
         if name in whitelisted_attrs:
             return getattr(self._oracle, name)

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -108,6 +108,9 @@ class BaseTuner(stateful.Stateful):
         if overwrite and tf.io.gfile.exists(self.project_dir):
             tf.io.gfile.rmtree(self.project_dir)
 
+        # To support tuning distribution.
+        self.tuner_id = os.environ.get("KERASTUNER_TUNER_ID", "tuner0")
+
         # Reloading state.
         if not overwrite and tf.io.gfile.exists(self._get_tuner_fname()):
             tf.get_logger().info(f"Reloading Tuner from {self._get_tuner_fname()}")
@@ -115,9 +118,6 @@ class BaseTuner(stateful.Stateful):
         else:
             # Only populate initial space if not reloading.
             self._populate_initial_space()
-
-        # To support tuning distribution.
-        self.tuner_id = os.environ.get("KERASTUNER_TUNER_ID", "single")
 
         # Run in distributed mode.
         if dist_utils.is_chief_oracle():
@@ -425,7 +425,7 @@ class BaseTuner(stateful.Stateful):
     def set_state(self, state):
         pass
 
-    def _is_worker():
+    def _is_worker(self):
         """Return true only if in parallel tuning and is a worker tuner."""
         return dist_utils.has_chief_oracle() and not dist_utils.is_chief_oracle()
 

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -548,15 +548,10 @@ class Oracle(stateful.Stateful):
         self._id_to_hash = collections.defaultdict(lambda: None)
         self._id_to_hash.update(state["id_to_hash"])
 
-    def _set_project_dir(self, directory, project_name, overwrite=False):
+    def _set_project_dir(self, directory, project_name):
         """Sets the project directory and reloads the Oracle."""
         self._directory = directory
         self._project_name = project_name
-        if not overwrite and tf.io.gfile.exists(self._get_oracle_fname()):
-            tf.get_logger().info(
-                f"Reloading Oracle from existing project {self._get_oracle_fname()}"
-            )
-            self.reload()
 
     @property
     def _project_dir(self):
@@ -592,7 +587,7 @@ class Oracle(stateful.Stateful):
             ) from e
 
         # Empty the ongoing_trials and send them for retry.
-        for _, trial_id in self.ongoing_trials:
+        for _, trial_id in self.ongoing_trials.items():
             self._retry_queue.append(trial_id)
         self.ongoing_trials = {}
 

--- a/keras_tuner/engine/oracle_test.py
+++ b/keras_tuner/engine/oracle_test.py
@@ -26,9 +26,7 @@ class OracleStub(oracle_module.Oracle):
     def __init__(self, directory, **kwargs):
         super().__init__(**kwargs)
         self.score_trial_called = False
-        self._set_project_dir(
-            directory=directory, project_name="name", overwrite=True
-        )
+        self._set_project_dir(directory=directory, project_name="name")
 
     def populate_space(self, trial_id):
         return {
@@ -327,3 +325,33 @@ def test_synchronized_functions_in_different_oracle_doesnt_block(tmp_path):
 
     # All threads begin to sleep before anyone ends.
     assert set(log[:5]) == set(log[5:])
+
+
+def test_oracle_return_same_trial_if_same_tuner(tmp_path):
+    oracle = OracleStub(
+        directory=tmp_path, objective="val_loss", max_retries_per_trial=1
+    )
+    trial_1 = oracle.create_trial(tuner_id="a")
+    trial_2 = oracle.create_trial(tuner_id="a")
+
+    assert trial_1.trial_id == trial_2.trial_id
+
+
+def test_oracle_reload_ongoing_trials_to_retry(tmp_path):
+    oracle = OracleStub(
+        directory=tmp_path, objective="val_loss", max_retries_per_trial=1
+    )
+    trial_1 = oracle.create_trial(tuner_id="a")
+    trial_2 = oracle.create_trial(tuner_id="b")
+
+    oracle_2 = OracleStub(
+        directory=tmp_path, objective="val_loss", max_retries_per_trial=1
+    )
+    oracle_2.reload()
+
+    trial_3 = oracle.create_trial(tuner_id="a")
+    trial_4 = oracle.create_trial(tuner_id="b")
+
+    assert set([trial_3.trial_id, trial_4.trial_id]) == set(
+        [trial_1.trial_id, trial_2.trial_id]
+    )


### PR DESCRIPTION
This PR resolves #301.

* `Oracle.save()` and `Oracle.reload()` are only called in `Tuner.save()` and `Tuner.reload()`.
* `Tuner` would only save or reload the `Oracle` if it is the chief or it is not running in parallel.
* In parallel tuning, there is only one true `Oracle` on the chief, while the workers only have `OracleClient`s which communicates with the `Oracle`.
* In parallel tuning, only the chief writes the `Oracle`'s state to external storage.
* In parallel tuning, the worker only writes model checkpoints to external storage.