### PR TITLE
Preparation for switch in Keras serialization format

### DIFF
--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -17,7 +17,6 @@
 import abc
 
 import six
-from tensorflow import keras
 
 from keras_tuner import utils
 from keras_tuner.protos import keras_tuner_pb2

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -146,8 +146,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 def deserialize(config):
     return keras.utils.legacy.deserialize_keras_object(
-		config, module_objects=ALL_CLASSES
-	)
+            config, module_objects=ALL_CLASSES
+        )
 
 
 def serialize(obj):

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -145,8 +145,10 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
+    return keras.utils.legacy.deserialize_keras_object(
+		config, module_objects=ALL_CLASSES
+	)
 
 
 def serialize(obj):
-    return keras.utils.serialize_keras_object(obj)
+    return keras.utils.legacy.serialize_keras_object(obj)

--- a/keras_tuner/engine/conditions.py
+++ b/keras_tuner/engine/conditions.py
@@ -145,10 +145,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.legacy.deserialize_keras_object(
-            config, module_objects=ALL_CLASSES
-        )
+    return utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
 
 
 def serialize(obj):
-    return keras.utils.legacy.serialize_keras_object(obj)
+    return utils.serialize_keras_object(obj)

--- a/keras_tuner/engine/hyperparameters/__init__.py
+++ b/keras_tuner/engine/hyperparameters/__init__.py
@@ -32,8 +32,10 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
+    return keras.utils.legacy.deserialize_keras_object(
+		config, module_objects=ALL_CLASSES
+	)
 
 
 def serialize(obj):
-    return keras.utils.serialize_keras_object(obj)
+    return keras.utils.legacy.serialize_keras_object(obj)

--- a/keras_tuner/engine/hyperparameters/__init__.py
+++ b/keras_tuner/engine/hyperparameters/__init__.py
@@ -14,6 +14,7 @@
 
 from tensorflow import keras
 
+from keras_tuner import utils
 from keras_tuner.engine.hyperparameters import hp_types
 from keras_tuner.engine.hyperparameters.hp_types import Boolean
 from keras_tuner.engine.hyperparameters.hp_types import Choice
@@ -32,10 +33,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.legacy.deserialize_keras_object(
-            config, module_objects=ALL_CLASSES
-        )
+    return utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
 
 
 def serialize(obj):
-    return keras.utils.legacy.serialize_keras_object(obj)
+    return utils.serialize_keras_object(obj)

--- a/keras_tuner/engine/hyperparameters/__init__.py
+++ b/keras_tuner/engine/hyperparameters/__init__.py
@@ -33,8 +33,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 def deserialize(config):
     return keras.utils.legacy.deserialize_keras_object(
-		config, module_objects=ALL_CLASSES
-	)
+            config, module_objects=ALL_CLASSES
+        )
 
 
 def serialize(obj):

--- a/keras_tuner/engine/hyperparameters/hp_types/__init__.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/__init__.py
@@ -14,6 +14,7 @@
 
 from tensorflow import keras
 
+from keras_tuner import utils
 from keras_tuner.engine.hyperparameters.hp_types.boolean_hp import Boolean
 from keras_tuner.engine.hyperparameters.hp_types.choice_hp import Choice
 from keras_tuner.engine.hyperparameters.hp_types.fixed_hp import Fixed
@@ -32,10 +33,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.legacy.deserialize_keras_object(
-            config, module_objects=ALL_CLASSES
-        )
+    return utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
 
 
 def serialize(obj):
-    return keras.utils.legacy.serialize_keras_object(obj)
+    return utils.serialize_keras_object(obj)

--- a/keras_tuner/engine/hyperparameters/hp_types/__init__.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/__init__.py
@@ -32,8 +32,10 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 
 def deserialize(config):
-    return keras.utils.deserialize_keras_object(config, module_objects=ALL_CLASSES)
+    return keras.utils.legacy.deserialize_keras_object(
+		config, module_objects=ALL_CLASSES
+	)
 
 
 def serialize(obj):
-    return keras.utils.serialize_keras_object(obj)
+    return keras.utils.legacy.serialize_keras_object(obj)

--- a/keras_tuner/engine/hyperparameters/hp_types/__init__.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/__init__.py
@@ -33,8 +33,8 @@ ALL_CLASSES = {cls.__name__: cls for cls in OBJECTS}
 
 def deserialize(config):
     return keras.utils.legacy.deserialize_keras_object(
-		config, module_objects=ALL_CLASSES
-	)
+            config, module_objects=ALL_CLASSES
+        )
 
 
 def serialize(obj):

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -332,14 +332,16 @@ def infer_metric_direction(metric):
             return "max"
 
         try:
-            metric = keras.metrics.deserialize(
-                         metric_name, use_legacy_format=True
-                     )
+            if "use_legacy_format" in inspect.getargspec(keras.metrics.deserialize).args:
+                metric = keras.metrics.deserialize(metric_name, use_legacy_format=True)
+            else:
+                metric = keras.metrics.deserialize(metric_name)
         except ValueError:
             try:
-                metric = keras.losses.deserialize(
-                             metric_name, use_legacy_format=True
-                         )
+                if "use_legacy_format" in inspect.getargspec(keras.losses.deserialize).args:
+                    metric = keras.losses.deserialize(metric_name, use_legacy_format=True)
+                else:
+                    metric = keras.losses.deserialize(metric_name)
             except Exception:
                 # Direction can't be inferred.
                 return None

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -332,14 +332,24 @@ def infer_metric_direction(metric):
             return "max"
 
         try:
-            if "use_legacy_format" in inspect.getargspec(keras.metrics.deserialize).args:
-                metric = keras.metrics.deserialize(metric_name, use_legacy_format=True)
+            if (
+                "use_legacy_format"
+                in inspect.getargspec(keras.metrics.deserialize).args
+            ):
+                metric = keras.metrics.deserialize(
+                    metric_name, use_legacy_format=True
+                )
             else:
                 metric = keras.metrics.deserialize(metric_name)
         except ValueError:
             try:
-                if "use_legacy_format" in inspect.getargspec(keras.losses.deserialize).args:
-                    metric = keras.losses.deserialize(metric_name, use_legacy_format=True)
+                if (
+                    "use_legacy_format"
+                    in inspect.getargspec(keras.losses.deserialize).args
+                ):
+                    metric = keras.losses.deserialize(
+                        metric_name, use_legacy_format=True
+                    )
                 else:
                     metric = keras.losses.deserialize(metric_name)
             except Exception:

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 
 import numpy as np
 import six

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -332,10 +332,14 @@ def infer_metric_direction(metric):
             return "max"
 
         try:
-            metric = keras.metrics.get(metric_name)
+            metric = keras.metrics.deserialize(
+				metric_name, use_legacy_format=True
+			)
         except ValueError:
             try:
-                metric = keras.losses.get(metric_name)
+                metric = keras.losses.deserialize(
+					metric_name, use_legacy_format=True
+				)
             except Exception:
                 # Direction can't be inferred.
                 return None

--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -333,13 +333,13 @@ def infer_metric_direction(metric):
 
         try:
             metric = keras.metrics.deserialize(
-				metric_name, use_legacy_format=True
-			)
+                         metric_name, use_legacy_format=True
+                     )
         except ValueError:
             try:
                 metric = keras.losses.deserialize(
-					metric_name, use_legacy_format=True
-				)
+                             metric_name, use_legacy_format=True
+                         )
             except Exception:
                 # Direction can't be inferred.
                 return None

--- a/keras_tuner/utils.py
+++ b/keras_tuner/utils.py
@@ -73,9 +73,13 @@ def serialize_keras_object(obj):
 
 def deserialize_keras_object(config, module_objects=None, custom_objects=None):
     if hasattr(tf.keras.utils, "legacy"):
-        return tf.keras.utils.legacy.deserialize_keras_object(config, custom_objects, module_objects)
+        return tf.keras.utils.legacy.deserialize_keras_object(
+            config, custom_objects, module_objects
+        )
     else:
-        return tf.keras.utils.deserialize_keras_object(config, custom_objects, module_objects)
+        return tf.keras.utils.deserialize_keras_object(
+            config, custom_objects, module_objects
+        )
 
 
 def to_list(values):

--- a/keras_tuner/utils.py
+++ b/keras_tuner/utils.py
@@ -64,6 +64,20 @@ def check_tf_version():
         )
 
 
+def serialize_keras_object(obj):
+    if hasattr(tf.keras.utils, "legacy"):
+        return tf.keras.utils.legacy.serialize_keras_object(obj)
+    else:
+        return tf.keras.utils.serialize_keras_object(obj)
+
+
+def deserialize_keras_object(config, module_objects=None, custom_objects=None):
+    if hasattr(tf.keras.utils, "legacy"):
+        return tf.keras.utils.legacy.deserialize_keras_object(config, custom_objects, module_objects)
+    else:
+        return tf.keras.utils.deserialize_keras_object(config, custom_objects, module_objects)
+
+
 def to_list(values):
     if isinstance(values, list):
         return values


### PR DESCRIPTION
This PR changes serialization API calls in KerasTuner to the legacy APIs in preparation for a switch to the new Keras object serialization format. There is no change in functionality now by this switch to the legacy APIs.