### PR TITLE
update how build.py export keras_tuner.__version__

### DIFF
--- a/build.py
+++ b/build.py
@@ -21,6 +21,14 @@ namex.convert_codebase(package, code_directory="src")
 # Generate API __init__.py files in `keras_tuner/`
 namex.generate_api_files(package, code_directory="src", verbose=True)
 
+# Make sure to export the __version__ string
+from keras_tuner.src import __version__  # noqa: E402
+
+with open(os.path.join(package, "__init__.py")) as f:
+    init_contents = f.read()
+with open(os.path.join(package, "__init__.py"), "w") as f:
+    f.write(init_contents + "\n\n" + f'__version__ = "{__version__}"\n')
+
 # Build the package
 os.system("python3 -m build")
 

--- a/keras_tuner/__init__.py
+++ b/keras_tuner/__init__.py
@@ -35,10 +35,4 @@ from keras_tuner.utils import check_tf_version
 
 check_tf_version()
 
-
-class Version(str):
-    __name__ = "Version"
-
-
-__version__ = Version("1.2.2dev")
-keras_tuner_export("keras_tuner.__version__")(__version__)
+__version__ = "1.2.2dev"

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,15 @@
 from setuptools import find_packages
 from setuptools import setup
 
+__version__ = "1.2.2dev"
+
 setup(
     name="keras-tuner",
     description="A Hyperparameter Tuning Library for Keras",
     url="https://github.com/keras-team/keras-tuner",
     author="The KerasTuner authors",
-    author_email="kerastuner@google.com",
     license="Apache License 2.0",
-    version="1.2.2dev",
+    version=__version__,
     install_requires=[
         "packaging",
         "tensorflow>=2.0",


### PR DESCRIPTION
* Updated how `build.py` export `keras_tuner.__version__`.
* Removed the deprecated author email address in `setup.py`.
* Extract the version variable in `setup.py` to make it easier to find.