### PR TITLE
simplify lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 85
+
+[tool.isort]
+profile = "black"
+known_first_party = ["keras_tuner", "tests"]
+default_section = "THIRDPARTY"
+line_length = 85
+skip_glob = "keras_tuner/protos/*"
+force_single_line = "True"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,6 @@ addopts=-vv
 # Do not run tests in the build folder
 norecursedirs= build
 
-[isort]
-known_first_party = keras_tuner,tests
-default_section = THIRDPARTY
-line_length = 85
-skip_glob = keras_tuner/protos/*
-
 [coverage:report]
 exclude_lines =
     pragma: no cover

--- a/shell/format.sh
+++ b/shell/format.sh
@@ -1,5 +1,5 @@
-isort --sl --profile=black .
-black --line-length 85 .
+isort .
+black .
 
 for i in $(find keras_tuner -name '*.py') # or whatever other pattern...
 do

--- a/shell/lint.sh
+++ b/shell/lint.sh
@@ -1,4 +1,4 @@
-isort --sl --profile=black -c .
+isort -c .
 if ! [ $? -eq 0 ]
 then
   echo "Please run \"sh shell/format.sh\" to format the code."
@@ -10,7 +10,7 @@ then
   echo "Please fix the code style issue."
   exit 1
 fi
-black --check --line-length 85 .
+black --check .
 if ! [ $? -eq 0 ]
 then
   echo "Please run \"sh shell/format.sh\" to format the code."


### PR DESCRIPTION
Put `isort` and `black` configurations into `pyproject.toml` to removed the commandline args when calling them.