### PR TITLE
remove old confusing names of oracles

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,12 @@
 ## Breaking changes
 * Removed `Logger` and `CloudLogger` and the related arguments in
   `BaseTuner.__init__(logger=...)`.
+* Removed `keras_tuner.oracles.BayesianOptimization`,
+  `keras_tuner.oracles.Hyperband`, `keras_tuner.oracles.RandomSearch`, which
+  were actually `Oracle`s instead of `Tuner`s. Please
+  use`keras_tuner.oracles.BayesianOptimizationOracle`,
+  `keras_tuner.oracles.HyperbandOracle`,
+  `keras_tuner.oracles.RandomSearchOracle` instead.
 
 # Release v1.2.1
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
   use`keras_tuner.oracles.BayesianOptimizationOracle`,
   `keras_tuner.oracles.HyperbandOracle`,
   `keras_tuner.oracles.RandomSearchOracle` instead.
+* Removed `keras_tuner.Sklearn`. Please use `keras_tuner.SklearnTuner` instead.
 
 # Release v1.2.1
 

--- a/keras_tuner/distribute/oracle_client_test.py
+++ b/keras_tuner/distribute/oracle_client_test.py
@@ -57,7 +57,7 @@ def test_base_tuner_distribution(tmp_path):
             return hp.Int("a", 1, 100)
 
         tuner = SimpleTuner(
-            oracle=keras_tuner.oracles.RandomSearch(
+            oracle=keras_tuner.oracles.RandomSearchOracle(
                 objective=keras_tuner.Objective("score", "max"), max_trials=10
             ),
             hypermodel=build_model,

--- a/keras_tuner/integration_tests/legacy_import_test.py
+++ b/keras_tuner/integration_tests/legacy_import_test.py
@@ -18,13 +18,9 @@ import pytest
 def test_kerastuner_same_as_keras_tuner():
     with pytest.deprecated_call():
         import kerastuner
-        from kerastuner.tuners import RandomSearch
-        from kerastuner.tuners import BayesianOptimization
-        from kerastuner.tuners import Hyperband
-        from kerastuner.tuners import Sklearn  # noqa: F401
-        from kerastuner.oracles import RandomSearch  # noqa: F401,F811
-        from kerastuner.oracles import BayesianOptimization  # noqa: F401,F811
-        from kerastuner.oracles import Hyperband  # noqa: F401,F811
+        from kerastuner.tuners import RandomSearch  # noqa: F401
+        from kerastuner.tuners import BayesianOptimization  # noqa: F401
+        from kerastuner.tuners import Hyperband  # noqa: F401
         from kerastuner.engine.base_tuner import BaseTuner  # noqa: F401
         from kerastuner.engine.conditions import Condition  # noqa: F401
         from kerastuner.engine.hypermodel import HyperModel  # noqa: F401

--- a/keras_tuner/oracles/__init__.py
+++ b/keras_tuner/oracles/__init__.py
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Keep the name of `BayesianOptimization`, `Hyperband` and `RandomSearch`
-# for backward compatibility for 1.0.2 or earlier.
 from keras_tuner.tuners.bayesian import BayesianOptimizationOracle
 from keras_tuner.tuners.hyperband import HyperbandOracle
-from keras_tuner.tuners.hyperband import HyperbandOracle as Hyperband
 from keras_tuner.tuners.randomsearch import RandomSearchOracle
-from keras_tuner.tuners.randomsearch import RandomSearchOracle as RandomSearch
-
-from keras_tuner.tuners.bayesian import (  # isort:skip
-    BayesianOptimizationOracle as BayesianOptimization,
-)

--- a/keras_tuner/tuners/__init__.py
+++ b/keras_tuner/tuners/__init__.py
@@ -17,5 +17,4 @@ from keras_tuner.tuners.bayesian import BayesianOptimization
 from keras_tuner.tuners.gridsearch import GridSearch
 from keras_tuner.tuners.hyperband import Hyperband
 from keras_tuner.tuners.randomsearch import RandomSearch
-from keras_tuner.tuners.sklearn_tuner import Sklearn
 from keras_tuner.tuners.sklearn_tuner import SklearnTuner

--- a/keras_tuner/tuners/bayesian_test.py
+++ b/keras_tuner/tuners/bayesian_test.py
@@ -311,7 +311,7 @@ def test_float_optimization(tmp_path):
     hps.Float("d", -1, 1)
 
     tuner = PolynomialTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"),
             hyperparameters=hps,
             max_trials=50,

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -16,7 +16,6 @@ import collections
 import inspect
 import os
 import pickle
-import warnings
 
 import numpy as np
 import tensorflow as tf
@@ -219,12 +218,3 @@ class SklearnTuner(base_tuner.BaseTuner):
         fname = os.path.join(self.get_trial_dir(trial.trial_id), "model.pickle")
         with tf.io.gfile.GFile(fname, "rb") as f:
             return pickle.load(f)
-
-
-class Sklearn(SklearnTuner):
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "The `Sklearn` class is deprecated, please use `SklearnTuner`.",
-            DeprecationWarning,
-        )
-        super().__init__(*args, **kwargs)

--- a/keras_tuner/tuners/sklearn_tuner_test.py
+++ b/keras_tuner/tuners/sklearn_tuner_test.py
@@ -310,14 +310,3 @@ def test_sklearn_not_install_error(tmp_path):
         )
 
     keras_tuner.tuners.sklearn_tuner.sklearn = sklearn_module
-
-
-def test_sklearn_deprecation_warning(tmp_path):
-    with pytest.deprecated_call():
-        keras_tuner.tuners.SklearnTuner(
-            oracle=keras_tuner.oracles.BayesianOptimizationOracle(
-                objective=keras_tuner.Objective("score", "max"), max_trials=10
-            ),
-            hypermodel=build_model,
-            directory=tmp_path,
-        )

--- a/keras_tuner/tuners/sklearn_tuner_test.py
+++ b/keras_tuner/tuners/sklearn_tuner_test.py
@@ -88,7 +88,7 @@ def build_pipeline(hp):
 
 def test_sklearn_tuner_simple_with_np(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -115,7 +115,7 @@ def test_sklearn_tuner_simple_with_np(tmp_path):
 @pytest.mark.filterwarnings("ignore:.*column-vector")
 def test_sklearn_tuner_with_df(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -131,7 +131,7 @@ def test_sklearn_tuner_with_df(tmp_path):
 
 def test_sklearn_custom_scoring_and_cv(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -159,7 +159,7 @@ def test_sklearn_custom_scoring_and_cv(tmp_path):
 
 def test_sklearn_additional_metrics(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -188,7 +188,7 @@ def test_sklearn_additional_metrics(tmp_path):
 
 def test_sklearn_sample_weight(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -215,7 +215,7 @@ def test_sklearn_sample_weight(tmp_path):
 
 def test_sklearn_pipeline(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_pipeline,
@@ -242,7 +242,7 @@ def test_sklearn_pipeline(tmp_path):
 
 def test_sklearn_cv_with_groups(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -270,7 +270,7 @@ def test_sklearn_cv_with_groups(tmp_path):
 
 def test_sklearn_real_data(tmp_path):
     tuner = keras_tuner.SklearnTuner(
-        oracle=keras_tuner.oracles.BayesianOptimization(
+        oracle=keras_tuner.oracles.BayesianOptimizationOracle(
             objective=keras_tuner.Objective("score", "max"), max_trials=10
         ),
         hypermodel=build_model,
@@ -302,7 +302,7 @@ def test_sklearn_not_install_error(tmp_path):
 
     with pytest.raises(ImportError, match="Please install sklearn"):
         keras_tuner.SklearnTuner(
-            oracle=keras_tuner.oracles.BayesianOptimization(
+            oracle=keras_tuner.oracles.BayesianOptimizationOracle(
                 objective=keras_tuner.Objective("score", "max"), max_trials=10
             ),
             hypermodel=build_model,
@@ -314,8 +314,8 @@ def test_sklearn_not_install_error(tmp_path):
 
 def test_sklearn_deprecation_warning(tmp_path):
     with pytest.deprecated_call():
-        keras_tuner.tuners.Sklearn(
-            oracle=keras_tuner.oracles.BayesianOptimization(
+        keras_tuner.tuners.SklearnTuner(
+            oracle=keras_tuner.oracles.BayesianOptimizationOracle(
                 objective=keras_tuner.Objective("score", "max"), max_trials=10
             ),
             hypermodel=build_model,


### PR DESCRIPTION
This PR removes some confusing deprecated import names used before 1.0.2.

* Removed `keras_tuner.oracles.BayesianOptimization`, `keras_tuner.oracles.Hyperband`, `keras_tuner.oracles.RandomSearch`, which were actually `Oracle`s instead of `Tuner`s. Please use`keras_tuner.oracles.BayesianOptimizationOracle`, `keras_tuner.oracles.HyperbandOracle`, `keras_tuner.oracles.RandomSearchOracle` instead.
* Removed `keras_tuner.Sklearn`. Please use `keras_tuner.SklearnTuner` instead.