### PR TITLE
export more public APIs

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -17,6 +17,8 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
+from keras_tuner.api_export import keras_tuner_export
+
 try:
     from tensorflow.keras.layers.experimental import (  # isort:skip
         preprocessing,
@@ -38,6 +40,7 @@ if preprocessing is not None:
     }
 
 
+@keras_tuner_export("keras_tuner.applications.HyperImageAugment")
 class HyperImageAugment(hypermodel.HyperModel):
     """A image augmentation hypermodel.
 

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import layers
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import hypermodel
 
 try:
@@ -58,6 +59,7 @@ EFFICIENTNET_IMG_SIZE = {
 }
 
 
+@keras_tuner_export("keras_tuner.applications.HyperEfficientNet")
 class HyperEfficientNet(hypermodel.HyperModel):
     """An EfficientNet hypermodel.
 

--- a/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/boolean_hp.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hyperparameter
 from keras_tuner.protos import keras_tuner_pb2
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.Boolean")
 class Boolean(hyperparameter.HyperParameter):
     """Choice between True and False.
 

--- a/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/choice_hp.py
@@ -14,12 +14,14 @@
 
 import six
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hp_utils
 from keras_tuner.engine.hyperparameters import hyperparameter
 from keras_tuner.protos import keras_tuner_pb2
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.Choice")
 class Choice(hyperparameter.HyperParameter):
     """Choice of one value among a predefined set of possible values.
 

--- a/keras_tuner/engine/hyperparameters/hp_types/fixed_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/fixed_hp.py
@@ -14,11 +14,13 @@
 
 import six
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hyperparameter
 from keras_tuner.protos import keras_tuner_pb2
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.Fixed")
 class Fixed(hyperparameter.HyperParameter):
     """Fixed, untunable value.
 

--- a/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/float_hp.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hp_utils
 from keras_tuner.engine.hyperparameters.hp_types import numerical
 from keras_tuner.protos import keras_tuner_pb2
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.Float")
 class Float(numerical.Numerical):
     """Floating point value hyperparameter.
 

--- a/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
+++ b/keras_tuner/engine/hyperparameters/hp_types/int_hp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hp_utils
 from keras_tuner.engine.hyperparameters.hp_types import numerical
@@ -27,6 +28,7 @@ def _check_int(val, arg):
     return int_val
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.Int")
 class Int(numerical.Numerical):
     """Integer hyperparameter.
 

--- a/keras_tuner/engine/hyperparameters/hyperparameter.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameter.py
@@ -15,9 +15,11 @@
 import random
 
 from keras_tuner import utils
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 
 
+@keras_tuner_export("keras_tuner.engine.hyperparameters.HyperParameter")
 class HyperParameter:
     """Hyperparameter base class.
 

--- a/keras_tuner/engine/objective.py
+++ b/keras_tuner/engine/objective.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import metrics_tracking
 
 
+@keras_tuner_export("keras_tuner.Objective")
 class Objective:
     """The objective for optimization during tuning.
 

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -41,6 +41,7 @@ LOCKS = collections.defaultdict(lambda: threading.Lock())
 THREADS = collections.defaultdict(lambda: None)
 
 
+@keras_tuner_export("keras_tuner.synchronized")
 def synchronized(func, *args, **kwargs):
     """Decorator to synchronize the multi-threaded calls to `Oracle` functions.
 

--- a/keras_tuner/oracles/__init__.py
+++ b/keras_tuner/oracles/__init__.py
@@ -15,6 +15,7 @@
 # Keep the name of `BayesianOptimization`, `Hyperband` and `RandomSearch`
 # for backward compatibility for 1.0.2 or earlier.
 from keras_tuner.tuners.bayesian import BayesianOptimizationOracle
+from keras_tuner.tuners.gridsearch import GridSearchOracle
 from keras_tuner.tuners.hyperband import HyperbandOracle
 from keras_tuner.tuners.hyperband import HyperbandOracle as Hyperband
 from keras_tuner.tuners.randomsearch import RandomSearchOracle


### PR DESCRIPTION
This pull request exported the remaining public APIs of KerasTuner, which are listed as follows.

`keras_tuner.applications.HyperImageAugment`
`keras_tuner.applications.HyperEfficientNet`
`keras_tuner.Objective`
`keras_tuner.synchronized`

Exported the following objects for AutoKeras usages.
`keras_tuner.engine.hyperparameters.Boolean`
`keras_tuner.engine.hyperparameters.Choice`
`keras_tuner.engine.hyperparameters.Fixed`
`keras_tuner.engine.hyperparameters.Float`
`keras_tuner.engine.hyperparameters.Int`
`keras_tuner.engine.hyperparameters.HyperParameter`

See https://github.com/keras-team/autokeras/issues/1420 for more details.