### PR TITLE
add keras.io guides as integration tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -85,6 +85,31 @@ jobs:
           pip install -e ".[tests]" --progress-bar off --upgrade
       - name: Lint
         run: bash shell/lint.sh
+  guides:
+    name: Run the keras.io guides
+    if: github.event_name == 'release' && github.event.action == 'created'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          python -m pip install --upgrade pip setuptools
+          echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
+      - name: pip cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
+      - name: Install dependencies
+        run: |
+          pip install -e ".[tests]" --progress-bar off --upgrade
+      - name: Run the guides
+        run: bash shell/run_guides.sh
   deploy:
     needs: [build, format,compatibility]
     if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,7 +3,6 @@ name: Integration tests using keras.io guides
 on:
   schedule:
     - cron: '0 0 * * 0'
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,6 +31,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e ".[tests]" --progress-bar off --upgrade
-      - name: Test with pytest
+      - name: Run the guides
         run: |
-          shell/run_guides.sh
+          bash shell/run_guides.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,8 +1,8 @@
-name: Test TF Nightly
+name: Integration tests using keras.io guides
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
   push:
     branches: [ master ]
   pull_request:
@@ -30,8 +30,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
       - name: Install dependencies
         run: |
-          pip install tf-nightly --progress-bar off --upgrade
           pip install -e ".[tests]" --progress-bar off --upgrade
       - name: Test with pytest
         run: |
-          pytest
+          shell/run_guides.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,11 +2,11 @@ name: Integration tests using keras.io guides
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:
-  build:
+  guides:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
@@ -29,5 +29,4 @@ jobs:
         run: |
           pip install -e ".[tests]" --progress-bar off --upgrade
       - name: Run the guides
-        run: |
-          bash shell/run_guides.sh
+        run: bash shell/run_guides.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,8 +3,6 @@ name: Integration tests using keras.io guides
 on:
   schedule:
     - cron: '0 0 * * 0'
-  push:
-    branches: [ master ]
   pull_request:
   workflow_dispatch:
 

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -268,6 +268,7 @@ class Tuner(base_tuner.BaseTuner):
         """
         # Not using `ModelCheckpoint` to support MultiObjective.
         # It can only track one of the metrics to save the best model.
+        assert False
         model_checkpoint = tuner_utils.SaveBestEpoch(
             objective=self.oracle.objective,
             filepath=self._get_checkpoint_fname(trial.trial_id),

--- a/keras_tuner/engine/tuner.py
+++ b/keras_tuner/engine/tuner.py
@@ -268,7 +268,6 @@ class Tuner(base_tuner.BaseTuner):
         """
         # Not using `ModelCheckpoint` to support MultiObjective.
         # It can only track one of the metrics to save the best model.
-        assert False
         model_checkpoint = tuner_utils.SaveBestEpoch(
             objective=self.oracle.objective,
             filepath=self._get_checkpoint_fname(trial.trial_id),

--- a/shell/run_guides.sh
+++ b/shell/run_guides.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+guides=(
+    https://raw.githubusercontent.com/keras-team/keras-io/master/guides/keras_tuner/getting_started.py
+    https://raw.githubusercontent.com/keras-team/keras-io/master/guides/keras_tuner/distributed_tuning.py
+    https://raw.githubusercontent.com/keras-team/keras-io/master/guides/keras_tuner/custom_tuner.py
+    https://raw.githubusercontent.com/keras-team/keras-io/master/guides/keras_tuner/visualize_tuning.py
+    https://raw.githubusercontent.com/keras-team/keras-io/master/guides/keras_tuner/tailor_the_search_space.py
+)
+
+for guide in ${guides[@]}; do
+    wget $guide -O /tmp/a.py
+    if ! python /tmp/a.py; then
+        echo "error occured!"
+        exit 1
+    fi
+done


### PR DESCRIPTION
The keras.io guides on KerasTuner would run every day to test the master branch.
It can also be manually triggered to run.
It will also run at each release before uploading to PyPI.