### PR TITLE
replace deprecated inspect.getargspec with inspect.getfullargspec, make keras-tuner work on 3.11

### DIFF
--- a/keras_tuner/engine/metrics_tracking.py
+++ b/keras_tuner/engine/metrics_tracking.py
@@ -342,7 +342,7 @@ def infer_metric_direction(metric):
         try:
             if (
                 "use_legacy_format"
-                in inspect.getargspec(keras.metrics.deserialize).args
+                in inspect.getfullargspec(keras.metrics.deserialize).args
             ):
                 metric = keras.metrics.deserialize(
                     metric_name, use_legacy_format=True
@@ -353,7 +353,7 @@ def infer_metric_direction(metric):
             try:
                 if (
                     "use_legacy_format"
-                    in inspect.getargspec(keras.losses.deserialize).args
+                    in inspect.getfullargspec(keras.losses.deserialize).args
                 ):
                     metric = keras.losses.deserialize(
                         metric_name, use_legacy_format=True


### PR DESCRIPTION
`getargspec` [is deprecated since python 3.0](https://docs.python.org/3.10/library/inspect.html#inspect.getargspec) and was removed in python 3.11. [`getfullargspec`](https://docs.python.org/3.11/library/inspect.html#inspect.getfullargspec) is a drop-in replacement.

Previously on 3.11 this exception was raised:

```python
AttributeError: module 'inspect' has no attribute 'getargspec'
```
One other issue I came across that made the tests fail, is an incompatibility with `wrapt` - this is already fixed upstream, but not released yet afaik: https://github.com/tensorflow/tensorflow/issues/59869#issuecomment-1452785730, so test might fail due to this.