### PR TITLE
Improve test coverage for keras_tuner.applications

### DIFF
--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -23,8 +23,8 @@ try:
     from tensorflow.keras.layers.experimental import (  # isort:skip
         preprocessing,
     )  # pytype: disable=import-error
-except ImportError:
-    preprocessing = None
+except ImportError:  # pragma: no cover
+    preprocessing = None  # pragma: no cover
 
 from keras_tuner.engine import hypermodel
 

--- a/keras_tuner/applications/augment.py
+++ b/keras_tuner/applications/augment.py
@@ -170,8 +170,8 @@ class HyperImageAugment(hypermodel.HyperModel):
                 and isinstance(augment_layers_max, int)
             ):
                 raise ValueError(
-                    "Keyword argument `augment_layers` must be "
-                    f"int,but received {augment_layers}."
+                    "Keyword argument `augment_layers` must be int, "
+                    f"but received {augment_layers}."
                 )
 
             self.augment_layers_min = augment_layers_min

--- a/keras_tuner/applications/augment_test.py
+++ b/keras_tuner/applications/augment_test.py
@@ -182,6 +182,57 @@ def test_hyperparameter_existence_and_hp_defaults_rand_aug():
     parse(tf.__version__) < parse("2.3.0"),
     reason="Preprocessing layers only exist in TF2.3+.",
 )
+def test_augment_layers_not_int():
+    with pytest.raises(ValueError, match="must be int"):
+        hp = hp_module.HyperParameters()
+        hm = aug_module.HyperImageAugment(
+            input_shape=(32, 32, 3), augment_layers=1.5
+        )
+        hm.build(hp)
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers only exist in TF2.3+.",
+)
+def test_contrast_0_5_to_1():
+    hp = hp_module.HyperParameters()
+    hm = aug_module.HyperImageAugment(
+        input_shape=(32, 32, 3), augment_layers=[1, 2], contrast=[0.5, 1]
+    )
+    hm.build(hp)
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers only exist in TF2.3+.",
+)
+def test_3_range_params_raise_error():
+    with pytest.raises(ValueError, match="exceed 2"):
+        hp = hp_module.HyperParameters()
+        hm = aug_module.HyperImageAugment(
+            input_shape=(32, 32, 3), augment_layers=[1, 2], contrast=[0.5, 1, 2]
+        )
+        hm.build(hp)
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers only exist in TF2.3+.",
+)
+def test_contrast_range_receive_string_raise_error():
+    with pytest.raises(ValueError, match="must be int or float"):
+        hp = hp_module.HyperParameters()
+        hm = aug_module.HyperImageAugment(
+            input_shape=(32, 32, 3), augment_layers=[1, 2], contrast=[0.5, "a"]
+        )
+        hm.build(hp)
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers only exist in TF2.3+.",
+)
 def test_hyperparameter_override_fixed_aug():
     hp = hp_module.HyperParameters()
     hp.Fixed("factor_rotate", 0.9)

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -25,15 +25,15 @@ try:
     from tensorflow.keras.applications import (  # isort:skip
         efficientnet,
     )  # pytype: disable=import-error
-except ImportError:
-    efficientnet = None
+except ImportError:  # pragma: no cover
+    efficientnet = None  # pragma: no cover
 
 try:
     from tensorflow.keras.layers.experimental import (  # isort:skip
         preprocessing,
     )  # pytype: disable=import-error
-except ImportError:
-    preprocessing = None
+except ImportError:  # pragma: no cover
+    preprocessing = None  # pragma: no cover
 
 if efficientnet is not None:
     EFFICIENTNET_MODELS = {

--- a/keras_tuner/applications/efficientnet.py
+++ b/keras_tuner/applications/efficientnet.py
@@ -105,11 +105,11 @@ class HyperEfficientNet(hypermodel.HyperModel):
             )
 
         if not classes:
-            raise ValueError("You must specify `classes`")
+            raise ValueError("You must specify `classes`.")
 
         if input_shape is None and input_tensor is None:
             raise ValueError(
-                "You must specify either `input_shape` " "or `input_tensor`."
+                "You must specify either `input_shape` or `input_tensor`."
             )
 
         self.input_shape = input_shape

--- a/keras_tuner/applications/efficientnet_test.py
+++ b/keras_tuner/applications/efficientnet_test.py
@@ -183,3 +183,37 @@ def test_augmentation_param_hyper_model():
     model = hypermodel.build(hp)
     assert model.layers[1].name == "aug"
     assert hp.values["scaling_factor"] == 1
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers and "
+    "applications.efficientnet only exist in TF2.3+.",
+)
+def test_pooling_is_max():
+    hp = hp_module.HyperParameters()
+    hp.values["pooling"] = "max"
+    hypermodel = efficientnet.HyperEfficientNet(
+        input_shape=(32, 32, 3), classes=10
+    )
+    hypermodel.build(hp)
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers and "
+    "applications.efficientnet only exist in TF2.3+.",
+)
+def test_no_classes_raise_error():
+    with pytest.raises(ValueError, match="classes"):
+        efficientnet.HyperEfficientNet(input_shape=(32, 32, 3))
+
+
+@pytest.mark.skipif(
+    parse(tf.__version__) < parse("2.3.0"),
+    reason="Preprocessing layers and "
+    "applications.efficientnet only exist in TF2.3+.",
+)
+def test_no_input_shape_tensor_raise_error():
+    with pytest.raises(ValueError, match="input_tensor"):
+        efficientnet.HyperEfficientNet(classes=10)

--- a/keras_tuner/applications/resnet.py
+++ b/keras_tuner/applications/resnet.py
@@ -57,12 +57,12 @@ class HyperResNet(hypermodel.HyperModel):
         super().__init__(**kwargs)
         if include_top and classes is None:
             raise ValueError(
-                "You must specify `classes` when " "`include_top=True`"
+                "You must specify `classes` when `include_top=True`"
             )
 
         if input_shape is None and input_tensor is None:
             raise ValueError(
-                "You must specify either `input_shape` " "or `input_tensor`."
+                "You must specify either `input_shape` or `input_tensor`."
             )
 
         self.include_top = include_top

--- a/keras_tuner/applications/resnet_test.py
+++ b/keras_tuner/applications/resnet_test.py
@@ -77,3 +77,20 @@ def test_input_tensor():
     hypermodel = resnet.HyperResNet(input_tensor=inputs, include_top=False)
     model = hypermodel.build(hp)
     assert model.inputs == [inputs]
+
+
+def test_pooling_is_max():
+    hp = hp_module.HyperParameters()
+    hp.values["pooling"] = "max"
+    hypermodel = resnet.HyperResNet(input_shape=(32, 32, 3), classes=10)
+    hypermodel.build(hp)
+
+
+def test_no_classes_raise_error():
+    with pytest.raises(ValueError, match="classes"):
+        resnet.HyperResNet(input_shape=(32, 32, 3))
+
+
+def test_no_input_shape_tensor_raise_error():
+    with pytest.raises(ValueError, match="input_tensor"):
+        resnet.HyperResNet(classes=10)

--- a/keras_tuner/applications/xception.py
+++ b/keras_tuner/applications/xception.py
@@ -54,12 +54,12 @@ class HyperXception(hypermodel.HyperModel):
         super().__init__(**kwargs)
         if include_top and classes is None:
             raise ValueError(
-                "You must specify `classes` when " "`include_top=True`"
+                "You must specify `classes` when `include_top=True`"
             )
 
         if input_shape is None and input_tensor is None:
             raise ValueError(
-                "You must specify either `input_shape` " "or `input_tensor`."
+                "You must specify either `input_shape` or `input_tensor`."
             )
 
         self.include_top = include_top
@@ -156,8 +156,6 @@ def sep_conv(x, num_filters, kernel_size=(3, 3), activation="relu"):
         )(x)
         x = layers.BatchNormalization()(x)
         x = layers.Activation("relu")(x)
-    else:
-        ValueError(f"Unknown activation function: {activation}")
     return x
 
 
@@ -215,9 +213,6 @@ def conv(x, num_filters, kernel_size=(3, 3), activation="relu", strides=(2, 2)):
         )(x)
         x = layers.BatchNormalization()(x)
         x = layers.Activation("relu")(x)
-    else:
-        msg = f"Unknown activation function: {activation}"
-        ValueError(msg)
     return x
 
 
@@ -237,7 +232,4 @@ def dense(x, dims, activation="relu", batchnorm=True, dropout_rate=0):
             x = layers.BatchNormalization()(x)
         if dropout_rate:
             x = layers.Dropout(dropout_rate)(x)
-    else:
-        msg = f"Unknown activation function: {activation}"
-        ValueError(msg)
     return x

--- a/keras_tuner/applications/xception_test.py
+++ b/keras_tuner/applications/xception_test.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Tests for HyperXception Model."""
 
-import os
-
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -23,7 +21,6 @@ from keras_tuner.applications import xception
 from keras_tuner.engine import hyperparameters as hp_module
 
 
-@pytest.mark.skipif("TRAVIS" in os.environ, reason="Causes CI to stall")
 @pytest.mark.parametrize("pooling", ["flatten", "avg", "max"])
 def test_model_construction(pooling):
     hp = hp_module.HyperParameters()
@@ -83,3 +80,20 @@ def test_input_tensor():
     hypermodel = xception.HyperXception(input_tensor=inputs, include_top=False)
     model = hypermodel.build(hp)
     assert model.inputs == [inputs]
+
+
+def test_activation_selu():
+    hp = hp_module.HyperParameters()
+    hp.values["activation"] = "selu"
+    hypermodel = xception.HyperXception(input_shape=(256, 256, 3), classes=10)
+    hypermodel.build(hp)
+
+
+def test_no_classes_raise_error():
+    with pytest.raises(ValueError, match="classes"):
+        xception.HyperXception(input_shape=(256, 256, 3))
+
+
+def test_no_input_shape_tensor_raise_error():
+    with pytest.raises(ValueError, match="input_tensor"):
+        xception.HyperXception(classes=10)

--- a/keras_tuner/tuners/sklearn_tuner.py
+++ b/keras_tuner/tuners/sklearn_tuner.py
@@ -22,15 +22,15 @@ import tensorflow as tf
 
 try:
     import pandas as pd  # pytype: disable=import-error
-except ImportError:
-    pd = None
+except ImportError:  # pragma: no cover
+    pd = None  # pragma: no cover
 
 try:
     import sklearn  # pytype: disable=import-error
     import sklearn.model_selection
     import sklearn.pipeline
-except ImportError:
-    sklearn = None
+except ImportError:  # pragma: no cover
+    sklearn = None  # pragma: no cover
 
 from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import base_tuner


### PR DESCRIPTION
#862
- exclude the ImportError lines from coverage report
- improve test coverage for augment.py and efficientnet.py
- improve test coverage for resnet.py and xception.py
