### PR TITLE
Update the stop logic for Hyperband

### DIFF
--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -207,12 +207,11 @@ class HyperbandOracle(oracle_module.Oracle):
         # Max sweeps has been reached, no more brackets should be created.
         if (
             self._current_bracket == 0
-            and self._current_iteration + 1 >= self.hyperband_iterations
+            and self._current_iteration + 1 == self.hyperband_iterations
         ):
             # Stop creating new brackets, but wait to complete other brackets.
             if self.ongoing_trials:
                 return {"status": "IDLE"}
-            self._increment_bracket_num()
             return {"status": "STOPPED"}
         # Create a new bracket.
         else:
@@ -233,8 +232,6 @@ class HyperbandOracle(oracle_module.Oracle):
         if self._current_bracket < 0:
             self._current_bracket = self._get_num_brackets() - 1
             self._current_iteration += 1
-            if self._current_iteration > self.hyperband_iterations:
-                self._current_bracket = 0
 
     def _remove_completed_brackets(self):
         # Filter out completed brackets.

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -214,7 +214,7 @@ def test_hyperband_save_and_restore(tmp_path):
 
     num_trials = len(tuner.oracle.trials)
     assert num_trials > 0
-    assert tuner.oracle._current_iteration == 1
+    assert tuner.oracle._current_iteration == 0
 
     tuner.save()
     tuner.trials = {}
@@ -222,7 +222,7 @@ def test_hyperband_save_and_restore(tmp_path):
     tuner.reload()
 
     assert len(tuner.oracle.trials) == num_trials
-    assert tuner.oracle._current_iteration == 1
+    assert tuner.oracle._current_iteration == 0
 
 
 def test_hyperband_load_weights(tmp_path):


### PR DESCRIPTION
This PR is also part of improving test coverage #862.
This PR is reverting #304.

After the `Oracle` is decorated with `@synchronized`, there is no more
concurrency issues for `populate_space()`. We can updated the stop logic for
Hyperband to a simpler logic.  Whenever the end state is reached (line 208-211),
we just do not change the state any more by not calling
`self._increment_bracket_num()`.