### PR TITLE
separate extras for tensorflow-cpu

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,6 +27,6 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('setup.py') }}
       - name: Install dependencies
         run: |
-          pip install -e ".[tests]" --progress-bar off --upgrade
+          pip install -e ".[tensorflow-cpu,tests]" --progress-bar off --upgrade
       - name: Run the guides
         run: bash shell/run_guides.sh

--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,17 @@ setup(
     version=__version__,
     install_requires=[
         "packaging",
-        "tensorflow>=2.0",
         "requests",
         "kt-legacy",
         "protobuf<=3.20.3",
     ],
     extras_require={
+        "tensorflow": [
+            "tensorflow>=2.0",
+        ],
+        "tensorflow-cpu": [
+            "tensorflow-cpu>=2.0",
+        ],
         "tests": [
             "black",
             "flake8",


### PR DESCRIPTION
- allow to install `keras-tuner[tensorflow-cpu]`

Maybe a viable alternative to #775?