### PR TITLE
Added the parameter for max collisions in the Hyperband tuner.

### DIFF
--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -163,6 +163,11 @@ class Oracle(stateful.Stateful):
             number of consecutive failed `Trial`s. When this number is reached,
             the search will be stopped. A `Trial` is marked as failed when none
             of the retries succeeded.
+        max_collisions: Integer. Defaults to 20. Maximum number of identical
+            values that can be generated before we consider the space to be
+            exhausted. Increasing this value, increases the probability of
+            executing all possible combinations generated with the
+            `HyperParameters`, you would obtain the maximum number of trails.
     """
 
     def __init__(
@@ -175,6 +180,7 @@ class Oracle(stateful.Stateful):
         seed=None,
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
+        max_collisions=20,
     ):
         self.objective = obj_module.create_objective(objective)
         self.max_trials = max_trials
@@ -214,11 +220,11 @@ class Oracle(stateful.Stateful):
         self._seed_state = self.seed
         # Hashes of values in the trials, which only hashes the active values.
         self._tried_so_far = set()
-        # Dictionary mapping trial_id to the the hash of the values.
+        # Dictionary mapping trial_id to the hash of the values.
         self._id_to_hash = collections.defaultdict(lambda: None)
         # Maximum number of identical values that can be generated
         # before we consider the space to be exhausted.
-        self._max_collisions = 20
+        self._max_collisions = max_collisions
 
         # Set in `BaseTuner` via `set_project_dir`.
         self.directory = None

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -99,6 +99,11 @@ class HyperbandOracle(oracle_module.Oracle):
             number of consecutive failed `Trial`s. When this number is reached,
             the search will be stopped. A `Trial` is marked as failed when none
             of the retries succeeded.
+        max_collisions: Integer. Defaults to 20. Maximum number of identical
+            values that can be generated before we consider the space to be
+            exhausted. Increasing this value, increases the probability of
+            executing all possible combinations generated with the
+            `HyperParameters`, you would obtain the maximum number of trails.
     """
 
     def __init__(
@@ -113,6 +118,7 @@ class HyperbandOracle(oracle_module.Oracle):
         tune_new_entries=True,
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
+        max_collisions=20,
     ):
         super().__init__(
             objective=objective,
@@ -122,6 +128,7 @@ class HyperbandOracle(oracle_module.Oracle):
             seed=seed,
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
+            max_collisions=max_collisions,
         )
         if factor < 2:
             raise ValueError("factor needs to be a int larger than 1.")
@@ -384,6 +391,11 @@ class Hyperband(tuner_module.Tuner):
             number of consecutive failed `Trial`s. When this number is reached,
             the search will be stopped. A `Trial` is marked as failed when none
             of the retries succeeded.
+        max_collisions: Integer. Defaults to 20. Maximum number of identical
+            values that can be generated before we consider the space to be
+            exhausted. Increasing this value, increases the probability of
+            executing all possible combinations generated with the
+            `HyperParameters`, you would obtain the maximum number of trails.
         **kwargs: Keyword arguments relevant to all `Tuner` subclasses.
             Please see the docstring for `Tuner`.
     """
@@ -401,6 +413,7 @@ class Hyperband(tuner_module.Tuner):
         allow_new_entries=True,
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
+        max_collisions=20,
         **kwargs
     ):
         oracle = HyperbandOracle(
@@ -414,6 +427,7 @@ class Hyperband(tuner_module.Tuner):
             allow_new_entries=allow_new_entries,
             max_retries_per_trial=max_retries_per_trial,
             max_consecutive_failed_trials=max_consecutive_failed_trials,
+            max_collisions=max_collisions,
         )
         super().__init__(oracle=oracle, hypermodel=hypermodel, **kwargs)
 

--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -43,6 +43,26 @@ def build_model(hp):
     return model
 
 
+def build_model_hyperparameters(hp):
+    # It generates 16 combinations, 8 (learning_rate) * 2 (nesterov) = 16
+    model = tf.keras.Sequential()
+    model.add(tf.keras.layers.Dense(1, activation="relu"))
+    model.add(tf.keras.layers.Dense(1, activation="sigmoid"))
+    hp_learning_rate = hp.Choice(
+        "learning_rate",
+        values=[1e-01, 1e-02, 1e-03, 1e-04, 1e-05, 1e-06, 1e-07, 1e-08],
+    )
+    hp_nesterov = hp.Boolean("nesterov")
+    model.compile(
+        tf.keras.optimizers.SGD(
+            hp_learning_rate,
+            hp_nesterov,
+        ),
+        "mse",
+    )
+    return model
+
+
 def test_hyperband_oracle_bracket_configs(tmp_path):
     oracle = hyperband_module.HyperbandOracle(
         objective=keras_tuner.Objective("score", "max"),
@@ -321,3 +341,63 @@ def test_exhausted_values_during_init_bracket(tmp_path):
 
     trial_1 = oracle.create_trial("a")
     assert trial_1.status == "STOPPED"
+
+
+def test_hyperband_max_collisions(tmp_path):
+    x, y = np.ones((2, 5)), np.ones((2, 1))
+
+    # Checks when teh max collisions is equal to 1, get 5 trials.
+    tuner = hyperband_module.Hyperband(
+        objective="val_loss",
+        hypermodel=build_model_hyperparameters,
+        max_epochs=20,
+        factor=20,
+        seed=42,
+        max_collisions=1,
+        directory=tmp_path,
+    )
+    tuner.search(x, y, validation_data=(x, y))
+    total_trials = len(tuner.get_best_models(999999))
+    assert total_trials == 5
+
+    # Checks when teh max collisions is equal to 3, get 11 trials.
+    tuner = hyperband_module.Hyperband(
+        objective="val_loss",
+        hypermodel=build_model_hyperparameters,
+        max_epochs=20,
+        factor=20,
+        seed=42,
+        max_collisions=3,
+        directory=tmp_path,
+    )
+    tuner.search(x, y, validation_data=(x, y))
+    total_trials = len(tuner.get_best_models(999999))
+    assert total_trials == 11
+
+    # Checks when teh max collisions is equal to 4, get 14 trials.
+    tuner = hyperband_module.Hyperband(
+        objective="val_loss",
+        hypermodel=build_model_hyperparameters,
+        max_epochs=20,
+        factor=20,
+        seed=42,
+        max_collisions=4,
+        directory=tmp_path,
+    )
+    tuner.search(x, y, validation_data=(x, y))
+    total_trials = len(tuner.get_best_models(999999))
+    assert total_trials == 14
+
+    # Checks when teh max collisions is equal to 19, get 16 trials.
+    tuner = hyperband_module.Hyperband(
+        objective="val_loss",
+        hypermodel=build_model_hyperparameters,
+        max_epochs=20,
+        factor=20,
+        seed=42,
+        max_collisions=19,
+        directory=tmp_path,
+    )
+    tuner.search(x, y, validation_data=(x, y))
+    total_trials = len(tuner.get_best_models(999999))
+    assert total_trials == 16


### PR DESCRIPTION
Regarding the issue [#901 – Our right to determine the maximum number of collisions](https://github.com/keras-team/keras-tuner/issues/901), this is my proposal to solve and improve the use of tuners, specifically for the `Hyperband`.

It adds the parameter `max_collisions`, to adjust the number of trials completed given the combination of all the `HyperParameters`.

---

Technical justification:

Using the `Hyperband`, it calls the method `_random_values()`, which fills the hyperparameter space with random values. It affects directly on the number of trials executed.

Class inheritance and methods:
Hyperband → HyperbandOracle → populate_space() → _random_trial() → Oracle → _random_values() ⇒ self._duplicate(hps.values)

It generates random values for each `HyperParameter`, if this combination exists it plus one to the collisions variable, when it reaches out the limit, then it stops the function `_random_trial()` returning the value `{"status": "STOPPED"}` and finishing the `tuner_hyperband.search()` function.

---

In case, that this change is good for all of you and will be approved, I recommend adding this change for the other tuners in this pull request:

```text
keras_tuner/tuners/bayesian.py
class BayesianOptimizationOracle(oracle_module.Oracle)
class BayesianOptimization(tuner_module.Tuner)

keras_tuner/tuners/gridsearch.py
class GridSearchOracle(oracle_module.Oracle)
class GridSearch(tuner_module.Tuner)

keras_tuner/tuners/randomsearch.py
class RandomSearchOracle(oracle_module.Oracle)
class RandomSearch(tuner_module.Tuner)
```

---

Problems found changing the max collisions to high values.

If it sets the `max_collisions=99999999999`, then in the last trial will run at least 99999999999 times because if all combinations were done, then it runs one more time, but it will not find any new combination for the same reason.

In the class `HyperbandOracle` which is in the `keras_tuner/tuners/hyperband.py`. I think that is good to add some condition, for example, if the trials get the max number of combinations, then not generate values. I did not implement because I am uncertain if it affects some behaviors of the keras-tuner package.

```python
    def _random_trial(self, trial_id, bracket):
        bracket_num = bracket["bracket_num"]
        rounds = bracket["rounds"]

        # If max number of combinations is equal of trials, then skip the generation of the values
        values = None
        if max_combinations == trials_executed:
            values = self._random_values()

        if values:
            values["tuner/epochs"] = self._get_epochs(bracket_num, 0)
            values["tuner/initial_epoch"] = 0
            values["tuner/bracket"] = self._current_bracket
            values["tuner/round"] = 0
            rounds[0].append({"past_id": None, "id": trial_id})
            return {"status": "RUNNING", "values": values}
        elif self.ongoing_trials:
            # Can't create new random values, but successive halvings may still
            # be needed.
            return {"status": "IDLE"}
        else:
            # Collision and no ongoing trials should trigger an exit.
            return {"status": "STOPPED"}
```