### PR TITLE
Draft: Skip models in model_builder

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -279,6 +279,8 @@ class BaseTuner(stateful.Stateful):
 
             if isinstance(e, errors.FailedTrialError):
                 trial.status = trial_module.TrialStatus.FAILED
+            elif isinstance(e, errors.SkipModelError):
+                trial.status = trial_module.TrialStatus.SKIPPED
             else:
                 trial.status = trial_module.TrialStatus.INVALID
 

--- a/keras_tuner/engine/hyperparameters/hyperparameters.py
+++ b/keras_tuner/engine/hyperparameters/hyperparameters.py
@@ -20,6 +20,7 @@ import copy
 import six
 
 from keras_tuner import protos
+from keras_tuner import errors
 from keras_tuner.api_export import keras_tuner_export
 from keras_tuner.engine import conditions as conditions_mod
 from keras_tuner.engine.hyperparameters import hp_types
@@ -249,6 +250,12 @@ class HyperParameters:
             return True
         except (KeyError, ValueError):
             return False
+
+    def skip_model(self, message):
+        if len(self._hps) == 0:
+            # Registration stage
+            return
+        raise errors.SkipModelError(message)
 
     def Choice(
         self,

--- a/keras_tuner/engine/trial.py
+++ b/keras_tuner/engine/trial.py
@@ -43,6 +43,7 @@ class TrialStatus:
     COMPLETED = "COMPLETED"
     # The Trial is failed. No more retries needed.
     FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
 
     @staticmethod
     def to_proto(status):
@@ -61,6 +62,8 @@ class TrialStatus:
             return ts.COMPLETED
         elif status == TrialStatus.FAILED:
             return ts.FAILED
+        elif status == TrialStatus.SKIPPED:
+            return ts.SKIPPED
         else:
             raise ValueError(f"Unknown status {status}")
 
@@ -81,6 +84,8 @@ class TrialStatus:
             return TrialStatus.COMPLETED
         elif proto == ts.FAILED:
             return TrialStatus.FAILED
+        elif proto == ts.SKIPPED:
+            return TrialStatus.SKIPPED
         else:
             raise ValueError(f"Unknown status {proto}")
 

--- a/keras_tuner/errors.py
+++ b/keras_tuner/errors.py
@@ -40,6 +40,11 @@ class FailedTrialError(Exception):
     pass
 
 
+@keras_tuner_export(["keras_tuner.errors.SkipModelError"])
+class SkipModelError(Exception):
+    pass
+
+
 @keras_tuner_export(["keras_tuner.errors.FatalError"])
 class FatalError(Exception):
     """A fatal error during search to terminate the program.


### PR DESCRIPTION
Hi,

Following #908 i have created this proof of concept.

It works, but i have no idea if that's something useful or not.

Let me know what you think and i can improve the implementation if you like.

- During the creation of a new model `model_build(hp)`  is called (that's normal behaviour)
- `hp` provides a new function `hp.skip_model(message)` that can be called if the user decide that the parameters
- This raises an exception, which is converted into a status `SKIPPED`
- The `SKIPPED` status is not counted as an `INVALID` model, so the model is skipped silently

It looks to work fine, but there is a lake. At start, `model_build` is called only for a a "discovery" phase. At this time the user code can call `hp.skip_model()`, which interrupt unexpectedly the processing. To fix that we just could flag `hp` with a `dicovery_phase` during this phase, so `skip_model` could just dry run.

# Exemple

```
def model_builder(hp):
    discovery_stage = len(hp._hps) == 0  # work around to not call `skip_model` at start

    model = models.Sequential()

    # -------------------------------------

    c1_kernel_size = hp.Choice(f'c1_kernel', values=[1, 2, 3])
    c2_kernel_size = hp.Choice(f'c2_kernel', values=[1, 2, 3, 5])
    c3_kernel_size = hp.Choice(f'c3_kernel', values=[1, 2, 3])
    c4_kernel_size = hp.Choice(f'c4_kernel', values=[1, 2, 3])
    c5_kernel_size = hp.Choice(f'c5_kernel', values=[1, 2, 3])

    # -------------------------------------

    ...

    try:
        model.add(
            layers.Conv2D(
                name="c4",
                filters=c4_filters,
                kernel_size=c4_kernel_size,
                # dilation_rate=(1, 64),
                activation='relu',
                padding='VALID',
            )
        )
        model.add(
            layers.MaxPooling2D(),
        )
    except ValueError as e:
        # Skip the model if the combinations of kernel sizes / strides doesn't fit the input size
        if not discovery_stage:
            hp.skip_model(str(e))

    ...

    # -------------------------------------

    # From https://stackoverflow.com/questions/43137288/how-to-determine-needed-memory-of-keras-model
    gbytes = get_model_memory_usage(model, BATCH_SIZE)

    if not discovery_stage:
        if gbytes > 40:
            hp.skip_model(f"Model too big: {gbytes}GiB")

    return model
```