### PR TITLE
save chief's state before starting oracle server

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -215,6 +215,7 @@ class BaseTuner(stateful.Stateful):
             # Avoid import at the top, to avoid inconsistent protobuf versions.
             from keras_tuner.distribute import oracle_chief
 
+            self.save()
             oracle_chief.start_server(self.oracle)
             return
 


### PR DESCRIPTION
This fixes #976 by saving the chief process' state before starting the oracle server. So when running the chief with `overwrite=False`, it gets reloaded properly and resumes tuning with the most recent trial.