### PR TITLE
Set a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send a [private vulnerability report](https://github.com/keras-team/keras-tuner/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+please give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #979.

This PR publishes a simple security policy for KerasTuner. It is effectively identical to the ones used by [Keras](https://github.com/keras-team/keras/blob/master/SECURITY.md) and [KerasCV](https://github.com/keras-team/keras-cv/blob/master/SECURITY.md).

If you merge this PR as is, make sure to also enable the GitHub private reporting feature in the repo [Settings > Code security & analysis](https://github.com/keras-team/keras-tuner/settings/security_analysis) page.

If KerasTuner is still closely tied to TensorFlow, let me know if you'd rather adopt the [tf-keras policy](https://github.com/keras-team/tf-keras/blob/6d9cd30/CONTRIBUTING.md#security-vulnerability-reports).