### PR TITLE
Update oracle_client.py to enable_http_proxy

### DIFF
--- a/keras_tuner/distribute/oracle_client.py
+++ b/keras_tuner/distribute/oracle_client.py
@@ -32,7 +32,7 @@ class OracleClient:
 
         ip_addr = os.environ["KERASTUNER_ORACLE_IP"]
         port = os.environ["KERASTUNER_ORACLE_PORT"]
-        channel = grpc.insecure_channel(f"{ip_addr}:{port}")
+        channel = grpc.insecure_channel(f"{ip_addr}:{port}", options=(('grpc.enable_http_proxy', 0),))
         self.stub = protos.get_service_grpc().OracleStub(channel)
         self.tuner_id = os.environ["KERASTUNER_TUNER_ID"]
 


### PR DESCRIPTION
Line 35 anyway makes an insecure channel and expects that users are on a safe network. But it still uses https urls and some corporate environments try to verify certificates (as in my case) and it breaks. So adding the second line instead of the first worked in my case and ends up using http links.
``` python
# original
channel = grpc.insecure_channel(f"{ip_addr}:{port}")
# update to this
channel = grpc.insecure_channel(f"{ip_addr}:{port}", options=(('grpc.enable_http_proxy', 0),))
```