### PR TITLE
Add dependabot to monitor GitHub Actions and Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,9 +15,9 @@ jobs:
     name: Test the code with tf.keras
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Get pip cache dir
@@ -48,9 +48,9 @@ jobs:
         backend: [tensorflow, jax, torch]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Get pip cache dir
@@ -81,9 +81,9 @@ jobs:
     name: Check the code format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Get pip cache dir
@@ -106,9 +106,9 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'created'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Get pip cache dir
@@ -131,9 +131,9 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'created'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
     - name: Get pip cache dir

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,9 +13,9 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Get pip cache dir


### PR DESCRIPTION
Hey, it's Pedro (see https://github.com/keras-team/keras-tuner/pull/930 and https://github.com/keras-team/keras-tuner/pull/980) and I'm back with another security suggestion.

This PR is similar to the ones I sent to [Keras](https://github.com/keras-team/keras/pull/18834) and [KerasCV](https://github.com/keras-team/keras-cv/pull/2259). However, since all your Python dependencies are unbounded, I've configured Dependabot to only monitor the GitHub Actions used in KerasTuner's workflows.

I've also configured Dependabot to send a single monthly PR (every 1st of the month) updating all Actions with new versions. For an example of what that looks like, see the PR in my fork: https://github.com/pnacht/keras-tuner/pull/1.

I have taken the liberty of merging that Dependabot PR into this one so you don't receive a similar one right after merging this one.

(Following https://github.com/keras-team/keras/issues/18833#issuecomment-1828743533, I haven't sent an issue for this. Let me know if KerasTuner prefers always having an accompanying issue to discuss my contributions).