### PR TITLE
fix: :rotating_light: Fix linter issues

### DIFF
--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -133,9 +133,11 @@ class Display(stateful.Stateful):
 
     def get_state(self):
         return {
-            "search_start": self.search_start.isoformat()
-            if self.search_start is not None
-            else self.search_start,
+            "search_start": (
+                self.search_start.isoformat()
+                if self.search_start is not None
+                else self.search_start
+            ),
             "trial_start": {
                 key: value.isoformat()
                 for key, value in self.trial_start.items()

--- a/keras_tuner/protos/v3/keras_tuner_pb2.py
+++ b/keras_tuner/protos/v3/keras_tuner_pb2.py
@@ -76,7 +76,7 @@ Value = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _VALUE,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Value)
     },
 )
@@ -87,7 +87,7 @@ Float = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _FLOAT,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Float)
     },
 )
@@ -98,7 +98,7 @@ Int = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _INT,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Int)
     },
 )
@@ -109,7 +109,7 @@ Choice = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _CHOICE,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Choice)
     },
 )
@@ -120,7 +120,7 @@ Boolean = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _BOOLEAN,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Boolean)
     },
 )
@@ -131,7 +131,7 @@ Fixed = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _FIXED,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Fixed)
     },
 )
@@ -146,7 +146,7 @@ HyperParameters = _reflection.GeneratedProtocolMessageType(
             (_message.Message,),
             {
                 "DESCRIPTOR": _HYPERPARAMETERS_SPACE,
-                "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                "__module__": "keras_tuner.protos.keras_tuner_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.HyperParameters.Space)
             },
         ),
@@ -159,17 +159,17 @@ HyperParameters = _reflection.GeneratedProtocolMessageType(
                     (_message.Message,),
                     {
                         "DESCRIPTOR": _HYPERPARAMETERS_VALUES_VALUESENTRY,
-                        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                        "__module__": "keras_tuner.protos.keras_tuner_pb2",
                         # @@protoc_insertion_point(class_scope:keras_tuner.HyperParameters.Values.ValuesEntry)
                     },
                 ),
                 "DESCRIPTOR": _HYPERPARAMETERS_VALUES,
-                "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                "__module__": "keras_tuner.protos.keras_tuner_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.HyperParameters.Values)
             },
         ),
         "DESCRIPTOR": _HYPERPARAMETERS,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.HyperParameters)
     },
 )
@@ -183,7 +183,7 @@ MetricObservation = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _METRICOBSERVATION,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.MetricObservation)
     },
 )
@@ -194,7 +194,7 @@ MetricHistory = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _METRICHISTORY,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.MetricHistory)
     },
 )
@@ -209,12 +209,12 @@ MetricsTracker = _reflection.GeneratedProtocolMessageType(
             (_message.Message,),
             {
                 "DESCRIPTOR": _METRICSTRACKER_METRICSENTRY,
-                "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                "__module__": "keras_tuner.protos.keras_tuner_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.MetricsTracker.MetricsEntry)
             },
         ),
         "DESCRIPTOR": _METRICSTRACKER,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.MetricsTracker)
     },
 )
@@ -230,12 +230,12 @@ Trial = _reflection.GeneratedProtocolMessageType(
             (_message.Message,),
             {
                 "DESCRIPTOR": _TRIAL_SCORE,
-                "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                "__module__": "keras_tuner.protos.keras_tuner_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.Trial.Score)
             },
         ),
         "DESCRIPTOR": _TRIAL,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Trial)
     },
 )
@@ -251,12 +251,12 @@ Condition = _reflection.GeneratedProtocolMessageType(
             (_message.Message,),
             {
                 "DESCRIPTOR": _CONDITION_PARENT,
-                "__module__": "keras_tuner.protos.keras_tuner_pb2"
+                "__module__": "keras_tuner.protos.keras_tuner_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.Condition.Parent)
             },
         ),
         "DESCRIPTOR": _CONDITION,
-        "__module__": "keras_tuner.protos.keras_tuner_pb2"
+        "__module__": "keras_tuner.protos.keras_tuner_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.Condition)
     },
 )

--- a/keras_tuner/protos/v3/service_pb2.py
+++ b/keras_tuner/protos/v3/service_pb2.py
@@ -61,7 +61,7 @@ GetSpaceRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETSPACEREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetSpaceRequest)
     },
 )
@@ -72,7 +72,7 @@ GetSpaceResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETSPACERESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetSpaceResponse)
     },
 )
@@ -83,7 +83,7 @@ UpdateSpaceRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _UPDATESPACEREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.UpdateSpaceRequest)
     },
 )
@@ -94,7 +94,7 @@ UpdateSpaceResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _UPDATESPACERESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.UpdateSpaceResponse)
     },
 )
@@ -105,7 +105,7 @@ CreateTrialRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _CREATETRIALREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.CreateTrialRequest)
     },
 )
@@ -116,7 +116,7 @@ CreateTrialResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _CREATETRIALRESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.CreateTrialResponse)
     },
 )
@@ -131,12 +131,12 @@ UpdateTrialRequest = _reflection.GeneratedProtocolMessageType(
             (_message.Message,),
             {
                 "DESCRIPTOR": _UPDATETRIALREQUEST_METRICSENTRY,
-                "__module__": "keras_tuner.protos.service_pb2"
+                "__module__": "keras_tuner.protos.service_pb2",
                 # @@protoc_insertion_point(class_scope:keras_tuner.UpdateTrialRequest.MetricsEntry)
             },
         ),
         "DESCRIPTOR": _UPDATETRIALREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.UpdateTrialRequest)
     },
 )
@@ -148,7 +148,7 @@ UpdateTrialResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _UPDATETRIALRESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.UpdateTrialResponse)
     },
 )
@@ -159,7 +159,7 @@ EndTrialRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _ENDTRIALREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.EndTrialRequest)
     },
 )
@@ -170,7 +170,7 @@ EndTrialResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _ENDTRIALRESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.EndTrialResponse)
     },
 )
@@ -181,7 +181,7 @@ GetBestTrialsRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETBESTTRIALSREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetBestTrialsRequest)
     },
 )
@@ -192,7 +192,7 @@ GetBestTrialsResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETBESTTRIALSRESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetBestTrialsResponse)
     },
 )
@@ -203,7 +203,7 @@ GetTrialRequest = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETTRIALREQUEST,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetTrialRequest)
     },
 )
@@ -214,7 +214,7 @@ GetTrialResponse = _reflection.GeneratedProtocolMessageType(
     (_message.Message,),
     {
         "DESCRIPTOR": _GETTRIALRESPONSE,
-        "__module__": "keras_tuner.protos.service_pb2"
+        "__module__": "keras_tuner.protos.service_pb2",
         # @@protoc_insertion_point(class_scope:keras_tuner.GetTrialResponse)
     },
 )

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -281,7 +281,6 @@ class GridSearchOracle(oracle_module.Oracle):
             combination), it returns None. The return values only include the
             active ones.
         """
-
         hps = self.get_space()
         all_values = {}
         for hp in hps.space:

--- a/keras_tuner/tuners/hyperband.py
+++ b/keras_tuner/tuners/hyperband.py
@@ -403,7 +403,7 @@ class Hyperband(tuner_module.Tuner):
         allow_new_entries=True,
         max_retries_per_trial=0,
         max_consecutive_failed_trials=3,
-        **kwargs
+        **kwargs,
     ):
         oracle = HyperbandOracle(
             objective,


### PR DESCRIPTION
This pull request fixes a few minor linting issues:

1. Using parentheses for grouping the ternary (conditional) expression.
2. Add comma in dictionary
3.  Remove unnecessary line after comment