### PR TITLE
Make `col_width` customizable in Display class

### DIFF
--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -116,10 +116,10 @@ def synchronized(func, *args, **kwargs):
 
 # TODO: Add more extensive display.
 class Display(stateful.Stateful):
-    def __init__(self, oracle, verbose=1):
+    def __init__(self, oracle, verbose=1, col_width=18):
         self.verbose = verbose
         self.oracle = oracle
-        self.col_width = 18
+        self.col_width = col_width
 
         # Start time for the overall search
         self.search_start = None

--- a/keras_tuner/engine/oracle.py
+++ b/keras_tuner/engine/oracle.py
@@ -384,6 +384,14 @@ class Oracle(stateful.Stateful):
             value = 1
         self._display.verbose = value
 
+    @property
+    def col_width(self):
+        return self._display.col_width
+
+    @col_width.setter
+    def col_width(self, value):
+        self._display.col_width = value
+
     def _populate_space(self, trial_id):
         warnings.warn(
             "The `_populate_space` method is deprecated, "

--- a/keras_tuner/engine/oracle_test.py
+++ b/keras_tuner/engine/oracle_test.py
@@ -450,3 +450,9 @@ def test_display_format_duration_large_d():
     oracle.verbose = "auto"
     assert oracle_module.Display(oracle).format_duration(d) == "7d 00h 00m 00s"
     assert oracle.verbose == 1
+
+
+def test_display_col_width() -> None:
+    oracle = gridsearch.GridSearchOracle()
+    oracle.col_width = 10
+    assert oracle_module.Display(oracle).col_width == 10


### PR DESCRIPTION
This pull request adds the ability to customize the `col_width` parameter in the `Display` class of the `oracle.py` file. The `col_width` parameter determines the width of the columns when printing larger proposed model names.

The following commits are included in this pull request:

- `test: Add test for display col_width parameter`: This commit adds a test case to ensure that the `col_width` parameter is working correctly.

- `feat: Add property and setter for col_width`: This commit adds a property and setter method for the `col_width` parameter in the `Oracle` class.

- `chore: Update Display class in oracle.py with col_width parameter`: This commit updates the `Display` class in the `oracle.py` file to include the `col_width` parameter.

Fixes #1024