### PR TITLE
Migrate hyperband_test.py to Python 3.13

### DIFF
--- a/keras_tuner/tuners/hyperband_test.py
+++ b/keras_tuner/tuners/hyperband_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import gc
 import numpy as np
 import pytest
 
@@ -282,6 +283,9 @@ def test_hyperband_load_weights(tmp_path):
             new_model_weights, best_model_round_0_weights
         )
     )
+    del new_model
+    del best_model_round_0
+    gc.collect()
 
 
 def test_factor_less_than_2_error():


### PR DESCRIPTION
In Python 3.13 the test `test_hyperband_load_weights` raises an error on the garbage collectionstage: deleting the model in the predictable order to resolve the error.

Fixes the error:
```
Objects/listobject.c:307: _PyObject_GC_TRACK: Assertion "!_PyObject_GC_IS_TRACKED(((PyObject*)(op)))" failed: object already tracked by the garbage collector
```