### PR TITLE
GridSearchOracle: persist _ordered_ids and _populate_next across reloads (#1055)

### DIFF
--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -323,10 +323,6 @@ class GridSearchOracle(oracle_module.Oracle):
         self._populate_next.append(trial.trial_id)
 
     def get_state(self):
-        # Persist the GridSearch-specific bookkeeping in addition to the base
-        # Oracle state so that a fresh process resuming a search (e.g.
-        # `GridSearch(..., overwrite=False)` after a kernel restart) keeps
-        # working without `KeyError` from `_ordered_ids.next()` (#1055).
         state = super().get_state()
         state["ordered_ids"] = list(self._ordered_ids._memory)
         state["populate_next"] = list(self._populate_next)
@@ -334,9 +330,6 @@ class GridSearchOracle(oracle_module.Oracle):
 
     def set_state(self, state):
         super().set_state(state)
-        # Older state files (saved by versions <= 1.4.8) did not include the
-        # new keys. Lazily rebuild `_ordered_ids` from `start_order` so we
-        # remain compatible with checkpoints written before this fix.
         self._ordered_ids = LinkedList()
         ordered_ids = state.get("ordered_ids")
         if ordered_ids is None:
@@ -347,8 +340,6 @@ class GridSearchOracle(oracle_module.Oracle):
             prev_id = trial_id
         populate_next = state.get("populate_next")
         if populate_next is None:
-            # Match the workaround in #1055: seed with the most recent
-            # completed trial so end_trial-driven progression resumes.
             populate_next = [self.end_order[-1]] if self.end_order else []
         self._populate_next = list(populate_next)
 

--- a/keras_tuner/tuners/gridsearch.py
+++ b/keras_tuner/tuners/gridsearch.py
@@ -322,6 +322,36 @@ class GridSearchOracle(oracle_module.Oracle):
         # For not blocking _populate_space, we push it regardless of the status.
         self._populate_next.append(trial.trial_id)
 
+    def get_state(self):
+        # Persist the GridSearch-specific bookkeeping in addition to the base
+        # Oracle state so that a fresh process resuming a search (e.g.
+        # `GridSearch(..., overwrite=False)` after a kernel restart) keeps
+        # working without `KeyError` from `_ordered_ids.next()` (#1055).
+        state = super().get_state()
+        state["ordered_ids"] = list(self._ordered_ids._memory)
+        state["populate_next"] = list(self._populate_next)
+        return state
+
+    def set_state(self, state):
+        super().set_state(state)
+        # Older state files (saved by versions <= 1.4.8) did not include the
+        # new keys. Lazily rebuild `_ordered_ids` from `start_order` so we
+        # remain compatible with checkpoints written before this fix.
+        self._ordered_ids = LinkedList()
+        ordered_ids = state.get("ordered_ids")
+        if ordered_ids is None:
+            ordered_ids = list(self.start_order)
+        prev_id = None
+        for trial_id in ordered_ids:
+            self._ordered_ids.insert(trial_id, prev_id)
+            prev_id = trial_id
+        populate_next = state.get("populate_next")
+        if populate_next is None:
+            # Match the workaround in #1055: seed with the most recent
+            # completed trial so end_trial-driven progression resumes.
+            populate_next = [self.end_order[-1]] if self.end_order else []
+        self._populate_next = list(populate_next)
+
 
 @keras_tuner_export(["keras_tuner.GridSearch", "keras_tuner.tuners.GridSearch"])
 class GridSearch(tuner_module.Tuner):

--- a/keras_tuner/tuners/gridsearch_test.py
+++ b/keras_tuner/tuners/gridsearch_test.py
@@ -225,3 +225,88 @@ def test_linked_list():
     assert linked_list.next("1") == "3"
     assert linked_list.next("3") == "4"
     assert linked_list.next("4") is None
+
+
+def test_grid_search_oracle_state_round_trip_resumes_search(tmp_path):
+    """Regression test for #1055: GridSearchOracle.get_state / set_state must
+    persist `_ordered_ids` and `_populate_next` so a fresh-process resume
+    (``GridSearch(..., overwrite=False)`` after a kernel restart) doesn't
+    KeyError on the first completed trial."""
+    from keras_tuner.engine import hyperparameters as hp_module
+    from keras_tuner.tuners.gridsearch import GridSearchOracle
+
+    hps = hp_module.HyperParameters()
+    hps.Boolean("b1")
+    hps.Boolean("b2")
+
+    def make_oracle():
+        return GridSearchOracle(
+            objective="val_loss",
+            max_trials=10,
+            hyperparameters=hps,
+        )
+
+    # Drive the search through a couple of completed trials so the LinkedList
+    # and the populate-next queue actually have non-empty state.
+    oracle = make_oracle()
+    trial_1 = oracle.create_trial(tuner_id="1")
+    trial_2 = oracle.create_trial(tuner_id="2")
+    trial_1.status = trial_module.TrialStatus.COMPLETED
+    trial_2.status = trial_module.TrialStatus.COMPLETED
+    oracle.end_trial(trial_1)
+    oracle.end_trial(trial_2)
+    assert len(oracle._ordered_ids._memory) >= 2
+
+    # Round-trip through get_state / set_state on a brand-new oracle (mimics
+    # process restart + reload-from-disk).
+    state = oracle.get_state()
+    fresh_oracle = make_oracle()
+    fresh_oracle.trials = oracle.trials
+    fresh_oracle.set_state(state)
+
+    # Resumed oracle's LinkedList must contain the same trial ids.
+    assert fresh_oracle._ordered_ids._memory == oracle._ordered_ids._memory
+    assert fresh_oracle._populate_next == oracle._populate_next
+
+    # And the next create_trial must NOT raise KeyError from _ordered_ids.next.
+    trial_3 = fresh_oracle.create_trial(tuner_id="3")
+    assert trial_3.status in (
+        trial_module.TrialStatus.RUNNING,
+        trial_module.TrialStatus.IDLE,
+        trial_module.TrialStatus.STOPPED,
+    )
+
+
+def test_grid_search_oracle_set_state_recovers_from_legacy_state(tmp_path):
+    """A state dict written by an older keras-tuner that did not persist the
+    GridSearch bookkeeping must still rehydrate without KeyError — the new
+    set_state lazily rebuilds `_ordered_ids` from `start_order`."""
+    from keras_tuner.engine import hyperparameters as hp_module
+    from keras_tuner.tuners.gridsearch import GridSearchOracle
+
+    hps = hp_module.HyperParameters()
+    hps.Boolean("b1")
+
+    oracle = GridSearchOracle(
+        objective="val_loss",
+        max_trials=5,
+        hyperparameters=hps,
+    )
+    trial_1 = oracle.create_trial(tuner_id="1")
+    trial_1.status = trial_module.TrialStatus.COMPLETED
+    oracle.end_trial(trial_1)
+
+    # Build a "legacy" state by dropping the new keys, then round-trip.
+    state = oracle.get_state()
+    state.pop("ordered_ids", None)
+    state.pop("populate_next", None)
+
+    fresh_oracle = GridSearchOracle(
+        objective="val_loss",
+        max_trials=5,
+        hyperparameters=hps,
+    )
+    fresh_oracle.trials = oracle.trials
+    fresh_oracle.set_state(state)
+    # Rebuilt from start_order rather than directly from the missing key.
+    assert fresh_oracle._ordered_ids._memory == list(oracle.start_order)

--- a/keras_tuner/tuners/gridsearch_test.py
+++ b/keras_tuner/tuners/gridsearch_test.py
@@ -279,7 +279,7 @@ def test_grid_search_oracle_state_round_trip_resumes_search(tmp_path):
 
 def test_grid_search_oracle_set_state_recovers_from_legacy_state(tmp_path):
     """A state dict written by an older keras-tuner that did not persist the
-    GridSearch bookkeeping must still rehydrate without KeyError — the new
+    GridSearch bookkeeping must still rehydrate without KeyError, the new
     set_state lazily rebuilds `_ordered_ids` from `start_order`."""
     from keras_tuner.engine import hyperparameters as hp_module
     from keras_tuner.tuners.gridsearch import GridSearchOracle

--- a/keras_tuner/tuners/gridsearch_test.py
+++ b/keras_tuner/tuners/gridsearch_test.py
@@ -246,8 +246,6 @@ def test_grid_search_oracle_state_round_trip_resumes_search(tmp_path):
             hyperparameters=hps,
         )
 
-    # Drive the search through a couple of completed trials so the LinkedList
-    # and the populate-next queue actually have non-empty state.
     oracle = make_oracle()
     trial_1 = oracle.create_trial(tuner_id="1")
     trial_2 = oracle.create_trial(tuner_id="2")
@@ -257,18 +255,14 @@ def test_grid_search_oracle_state_round_trip_resumes_search(tmp_path):
     oracle.end_trial(trial_2)
     assert len(oracle._ordered_ids._memory) >= 2
 
-    # Round-trip through get_state / set_state on a brand-new oracle (mimics
-    # process restart + reload-from-disk).
     state = oracle.get_state()
     fresh_oracle = make_oracle()
     fresh_oracle.trials = oracle.trials
     fresh_oracle.set_state(state)
 
-    # Resumed oracle's LinkedList must contain the same trial ids.
     assert fresh_oracle._ordered_ids._memory == oracle._ordered_ids._memory
     assert fresh_oracle._populate_next == oracle._populate_next
 
-    # And the next create_trial must NOT raise KeyError from _ordered_ids.next.
     trial_3 = fresh_oracle.create_trial(tuner_id="3")
     assert trial_3.status in (
         trial_module.TrialStatus.RUNNING,
@@ -278,9 +272,6 @@ def test_grid_search_oracle_state_round_trip_resumes_search(tmp_path):
 
 
 def test_grid_search_oracle_set_state_recovers_from_legacy_state(tmp_path):
-    """A state dict written by an older keras-tuner that did not persist the
-    GridSearch bookkeeping must still rehydrate without KeyError, the new
-    set_state lazily rebuilds `_ordered_ids` from `start_order`."""
     from keras_tuner.engine import hyperparameters as hp_module
     from keras_tuner.tuners.gridsearch import GridSearchOracle
 
@@ -296,7 +287,6 @@ def test_grid_search_oracle_set_state_recovers_from_legacy_state(tmp_path):
     trial_1.status = trial_module.TrialStatus.COMPLETED
     oracle.end_trial(trial_1)
 
-    # Build a "legacy" state by dropping the new keys, then round-trip.
     state = oracle.get_state()
     state.pop("ordered_ids", None)
     state.pop("populate_next", None)
@@ -308,5 +298,4 @@ def test_grid_search_oracle_set_state_recovers_from_legacy_state(tmp_path):
     )
     fresh_oracle.trials = oracle.trials
     fresh_oracle.set_state(state)
-    # Rebuilt from start_order rather than directly from the missing key.
     assert fresh_oracle._ordered_ids._memory == list(oracle.start_order)


### PR DESCRIPTION
Closes #1055.

`GridSearchOracle.__init__` builds two in-memory bookkeeping fields not present in `Oracle`:

- `_ordered_ids`: a `LinkedList` of trial ids in hp-combo order
- `_populate_next`: a queue of trial ids ready to produce their next combination

Neither is in `Oracle.get_state` / `set_state` and `GridSearchOracle` doesn't override them, so after a process restart with `overwrite=False` they reload empty. `start_order` rehydrates fine, the first `end_trial` pushes a trial id onto `_populate_next`, and the next `populate_space` calls `_ordered_ids.next(old_trial_id)` against an empty `_data_to_index` → `KeyError: '<trial_id>'` at `gridsearch.py:80,197`.

Override `get_state` / `set_state` on `GridSearchOracle` to persist both fields and rebuild the `LinkedList` from them on reload. Older state files (saved before this change) lazily rebuild from `start_order` so existing checkpoints keep working.

Regression tests in `gridsearch_test.py` cover:
- the state round-trip (write → fresh oracle → resume, no `KeyError`)
- legacy state files that lack the new keys still rehydrate via `start_order`