### PR TITLE
Add timeout to contributor avatar fetch

### DIFF
--- a/shell/contributors.py
+++ b/shell/contributors.py
@@ -7,6 +7,8 @@ from io import BytesIO
 import requests
 from PIL import Image
 
+REQUEST_TIMEOUT_SECONDS = 10
+
 
 def main(directory):
     contributors = []
@@ -38,7 +40,9 @@ def main(directory):
 
     for index, contributor in enumerate(contributors):
         file_name = os.path.join(directory, str(index) + ".jpeg")
-        response = requests.get(contributor["avatar_url"])
+        response = requests.get(
+            contributor["avatar_url"], timeout=REQUEST_TIMEOUT_SECONDS
+        )
         file = open(file_name, "wb")
         file.write(response.content)
         file.close()

--- a/shell/contributors.py
+++ b/shell/contributors.py
@@ -43,6 +43,7 @@ def main(directory):
         response = requests.get(
             contributor["avatar_url"], timeout=REQUEST_TIMEOUT_SECONDS
         )
+        response.raise_for_status()
         file = open(file_name, "wb")
         file.write(response.content)
         file.close()


### PR DESCRIPTION
## Summary
- add an explicit timeout when the contributor SVG helper downloads GitHub avatars

## Why
The helper currently waits indefinitely if an avatar request stalls. A small timeout makes the maintenance script fail fast instead of hanging forever on a single contributor image.

## Testing
- python3 -m py_compile shell/contributors.py