### PR TITLE
security: fix path traversal in BaseTuner directory/project_name/tuner_id

### DIFF
--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -115,6 +115,7 @@ class BaseTuner(stateful.Stateful):
         # Ops and metadata
         self.directory = directory or "."
         self.project_name = project_name or "untitled_project"
+        self._validate_project_path(self.directory, self.project_name)
         self.oracle._set_project_dir(self.directory, self.project_name)
 
         if overwrite and backend.io.exists(self.project_dir):
@@ -122,6 +123,7 @@ class BaseTuner(stateful.Stateful):
 
         # To support tuning distribution.
         self.tuner_id = os.environ.get("KERASTUNER_TUNER_ID", "tuner0")
+        self._validate_tuner_id(self.tuner_id)
 
         # Reloading state.
         if not overwrite and backend.io.exists(self._get_tuner_fname()):
@@ -470,6 +472,38 @@ class BaseTuner(stateful.Stateful):
         dirname = os.path.join(str(self.project_dir), f"trial_{str(trial_id)}")
         utils.create_directory(dirname)
         return dirname
+
+    @staticmethod
+    def _validate_project_path(directory, project_name):
+        """Validates that directory and project_name do not contain path traversal.
+
+        Raises:
+            ValueError: If path traversal sequences or absolute paths are detected.
+        """
+        for name, segment in (("directory", str(directory)), ("project_name", str(project_name))):
+            if ".." in segment:
+                raise ValueError(
+                    f"Path traversal is not allowed in {name}. Received: {segment!r}"
+                )
+            # Reject absolute paths in project_name to prevent writing outside CWD
+            if name == "project_name" and os.path.isabs(segment):
+                raise ValueError(
+                    f"Absolute paths are not allowed in {name}. Received: {segment!r}"
+                )
+
+    @staticmethod
+    def _validate_tuner_id(tuner_id):
+        """Validates that tuner_id does not contain path traversal sequences.
+
+        Raises:
+            ValueError: If path traversal sequences or path separators are detected.
+        """
+        tuner_id_str = str(tuner_id)
+        if ".." in tuner_id_str or "/" in tuner_id_str or "\\" in tuner_id_str:
+            raise ValueError(
+                f"tuner_id cannot contain path separators or traversal sequences. "
+                f"Received: {tuner_id_str!r}"
+            )
 
     def _get_tuner_fname(self):
         return os.path.join(str(self.project_dir), f"{str(self.tuner_id)}.json")

--- a/keras_tuner/engine/base_tuner.py
+++ b/keras_tuner/engine/base_tuner.py
@@ -15,6 +15,7 @@
 
 
 import copy
+import ntpath
 import os
 import traceback
 import warnings
@@ -485,8 +486,14 @@ class BaseTuner(stateful.Stateful):
                 raise ValueError(
                     f"Path traversal is not allowed in {name}. Received: {segment!r}"
                 )
-            # Reject absolute paths in project_name to prevent writing outside CWD
-            if name == "project_name" and os.path.isabs(segment):
+            if (
+                name == "project_name"
+                and (
+                    os.path.isabs(segment)
+                    or ntpath.isabs(segment)
+                    or ntpath.splitdrive(segment)[0]
+                )
+            ):
                 raise ValueError(
                     f"Absolute paths are not allowed in {name}. Received: {segment!r}"
                 )

--- a/keras_tuner/engine/base_tuner_test.py
+++ b/keras_tuner/engine/base_tuner_test.py
@@ -325,6 +325,24 @@ def test_project_name_absolute_path_raises_value_error(tmp_path):
         )
 
 
+@pytest.mark.parametrize(
+    "project_name", ["C:\\Windows", "C:Windows", "\\Windows"]
+)
+def test_project_name_windows_absolute_path_raises_value_error(
+    tmp_path, project_name
+):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    with pytest.raises(ValueError, match="Absolute paths"):
+        gridsearch.GridSearch(
+            directory=tmp_path,
+            project_name=project_name,
+            hypermodel=build_model,
+            max_trials=1,
+        )
+
+
 def test_tuner_id_forward_slash_raises_value_error(tmp_path):
     def build_model(hp):
         hp.Boolean("a")

--- a/keras_tuner/engine/base_tuner_test.py
+++ b/keras_tuner/engine/base_tuner_test.py
@@ -248,3 +248,99 @@ def test_chief_should_wait_for_clients(tmp_path):
         _the_func, num_workers=2, wait_for_chief=True
     )
     oracle_client.TIMEOUT = timeout
+
+
+
+def test_directory_path_traversal_raises_value_error(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    with pytest.raises(ValueError, match="Path traversal"):
+        gridsearch.GridSearch(
+            directory="../evil",
+            hypermodel=build_model,
+            max_trials=1,
+        )
+
+
+def test_project_name_path_traversal_raises_value_error(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    with pytest.raises(ValueError, match="Path traversal"):
+        gridsearch.GridSearch(
+            directory=tmp_path,
+            project_name="../../evil",
+            hypermodel=build_model,
+            max_trials=1,
+        )
+
+
+def test_tuner_id_path_traversal_raises_value_error(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    import os
+    original_tuner_id = os.environ.get("KERASTUNER_TUNER_ID")
+    try:
+        os.environ["KERASTUNER_TUNER_ID"] = "../../../evil"
+        with pytest.raises(ValueError, match="tuner_id"):
+            gridsearch.GridSearch(
+                directory=tmp_path,
+                hypermodel=build_model,
+                max_trials=1,
+            )
+    finally:
+        if original_tuner_id is not None:
+            os.environ["KERASTUNER_TUNER_ID"] = original_tuner_id
+        else:
+            os.environ.pop("KERASTUNER_TUNER_ID", None)
+
+
+def test_valid_directory_and_project_name_succeeds(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    # These should not raise
+    tuner = gridsearch.GridSearch(
+        directory=tmp_path,
+        project_name="my_project",
+        hypermodel=build_model,
+        max_trials=1,
+    )
+    assert tuner.directory == str(tmp_path)
+    assert tuner.project_name == "my_project"
+
+
+def test_project_name_absolute_path_raises_value_error(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    with pytest.raises(ValueError, match="Absolute paths"):
+        gridsearch.GridSearch(
+            directory=tmp_path,
+            project_name="/etc",
+            hypermodel=build_model,
+            max_trials=1,
+        )
+
+
+def test_tuner_id_forward_slash_raises_value_error(tmp_path):
+    def build_model(hp):
+        hp.Boolean("a")
+
+    import os
+    original_tuner_id = os.environ.get("KERASTUNER_TUNER_ID")
+    try:
+        os.environ["KERASTUNER_TUNER_ID"] = "evil/tuner"
+        with pytest.raises(ValueError, match="tuner_id"):
+            gridsearch.GridSearch(
+                directory=tmp_path,
+                hypermodel=build_model,
+                max_trials=1,
+            )
+    finally:
+        if original_tuner_id is not None:
+            os.environ["KERASTUNER_TUNER_ID"] = original_tuner_id
+        else:
+            os.environ.pop("KERASTUNER_TUNER_ID", None)


### PR DESCRIPTION
## Summary
Fixes a path traversal vulnerability in `BaseTuner` where user-supplied `directory`, `project_name`, and `tuner_id` parameters were joined into filesystem paths without validation.

## Impact
An attacker controlling these parameters could escape the intended project directory. When combined with `overwrite=True`, this leads to **arbitrary directory deletion** (CWE-22 / CWE-552).

## Changes
- Adds `_validate_project_path()` to reject `..` in `directory` and `project_name`
- Adds `_validate_tuner_id()` to reject `..` and path separators in `tuner_id`
- Tests cover all three vectors

## Vulnerability Details
### Before
```python
self.directory = directory or '.'
self.project_name = project_name or 'untitled_project'
# Attacker: directory='../evil', project_name='../../etc'
# Results in path: ../evil/../../etc -> escapes CWD
# With overwrite=True: shutil.rmtree('/etc')
```

### After
```python
self._validate_project_path(self.directory, self.project_name)
# Raises ValueError immediately on traversal sequences
```